### PR TITLE
Fixes the Encoding error in Windows system

### DIFF
--- a/gravis/_internal/plotting/data_structures.py
+++ b/gravis/_internal/plotting/data_structures.py
@@ -119,7 +119,7 @@ class Figure:
             _operating_system.is_file(filepath, raise_exception=True)
 
         # Transformation
-        with open(filepath, 'w') as file_handle:
+        with open(filepath, 'w', encoding="utf-8") as file_handle:
             html_text = self.to_html()
             file_handle.write(html_text)
 


### PR DESCRIPTION
# Transformation
        with open(filepath, 'w', encoding="utf-8") as file_handle:
            html_text = self.to_html()
added 
encoding = "utf-8"
at line 122.

This fixes error in encoding because Windows uses ISO as default encoding, leading to error UnicodeEncodeError

UnicodeEncodeError: 'charmap' codec can't encode characters \uxxxx at position (something)

data_structures.py 

PLEASE NOTE THIS MIGHT BE A FIX OF WINDOWS SYSTEM WITH ISO ENCODING Only. This option should not create any problems as default encoding is utf in Linux and almost everywhere else.

Please reach me, Dr Santhosh Rajamani at minerva.santh@gmail.com if any other information is needed about this error.