### PR TITLE
Add dark mode support via `use_dark_mode` argument

### DIFF
--- a/gravis/__init__.py
+++ b/gravis/__init__.py
@@ -11,9 +11,11 @@ __all__ = [
     'd3',
     'vis',
     'three',
+    'legends',
 ]
 
 __version__ = '0.1.0'
 
 from ._internal.conversion import convert
 from ._internal.plotting import d3, three, vis
+from ._internal.features import legends

--- a/gravis/_internal/features/__init__.py
+++ b/gravis/_internal/features/__init__.py
@@ -1,0 +1,5 @@
+from .legends import LegendBuilder
+
+__all__ = [
+    "LegendBuilder",
+]

--- a/gravis/_internal/features/legends.py
+++ b/gravis/_internal/features/legends.py
@@ -329,7 +329,7 @@ class LegendBuilder:
             f'border:1px solid {palette["border"]}; border-radius:12px; '
             f'box-shadow:0 2px 8px rgba(0,0,0,0.15); padding:16px 20px; '
             f'width:fit-content; max-width:260px; opacity:{legend.opacity}; '
-            f'backdrop-filter:blur(6px);">'
+            f'backdrop-filter:blur(16px);">'
         ]
 
         html_parts.append(

--- a/gravis/_internal/features/legends.py
+++ b/gravis/_internal/features/legends.py
@@ -288,7 +288,7 @@ class LegendBuilder:
     # HTML GENERATION
     # ------------------------------------------------------------------
     @staticmethod
-    def build_html(graph_data: Dict[str, Any], dark_mode: bool = False) -> str:
+    def build_html(graph_data: Dict[str, Any], dark_mode: bool = False, scale_node: float = 1.0, scale_edge: float = 1.0) -> str:
         """
         Build a modern, theme-aware HTML legend from graph data.
         
@@ -380,9 +380,9 @@ class LegendBuilder:
                 html_parts.append(
                     f'<li style="display:flex; align-items:center; '
                     f'margin:{LegendBuilder.ITEM_MARGIN}px 0;">'
-                    f'<span style="display:inline-block; width:{size}px; height:{size}px; '
+                    f'<span style="display:inline-block; width:{size*scale_node}px; height:{size*scale_node}px; '
                     f'border-radius:{shape_css}; background:{color}; '
-                    f'border:{border_width}px solid {border_color}; '
+                    f'border:{border_width*scale_node}px solid {border_color}; '
                     f'margin-right:10px; flex-shrink:0;" '
                     f'aria-hidden="true"></span>'
                     f'<span>{safe_label}</span></li>'
@@ -426,7 +426,7 @@ class LegendBuilder:
                     f'aria-hidden="true">'
                     f'<line x1="0" y1="{edge_width}" '
                     f'x2="{LegendBuilder.SVG_LINE_LENGTH}" y2="{edge_width}" '
-                    f'stroke="{stroke_color}" stroke-width="{edge_width/10}" '
+                    f'stroke="{stroke_color}" stroke-width="{edge_width*scale_edge}" '
                     f'stroke-dasharray="{dash_pattern}" stroke-linecap="round" />'
                     f'</svg>'
                     f'<span>{safe_label}</span></li>'

--- a/gravis/_internal/features/legends.py
+++ b/gravis/_internal/features/legends.py
@@ -1,0 +1,437 @@
+"""Legend features for graph visualization (integrated with NetworkX node_link_data)."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Literal, Dict, Any
+from enum import Enum
+from collections import defaultdict
+import html as html_escape
+import re
+
+
+# ----------------------------------------------------------------------
+# ENUMS
+# ----------------------------------------------------------------------
+
+class LegendPosition(Enum):
+    """Positions for legend placement."""
+    TOP_LEFT = "top-left"
+    TOP_RIGHT = "top-right"
+    BOTTOM_LEFT = "bottom-left"
+    BOTTOM_RIGHT = "bottom-right"
+    LEFT = "left"
+    RIGHT = "right"
+
+
+# ----------------------------------------------------------------------
+# NODE & EDGE ENTRY MODELS
+# ----------------------------------------------------------------------
+
+@dataclass
+class NodeLegendEntry:
+    """Configuration for a single node legend entry."""
+    label: str
+    color: str
+    shape: Literal["circle", "square", "diamond", "triangle"] = "circle"
+    size: int = 10
+    border_color: Optional[str] = None
+    border_width: int = 0
+
+    def to_dict(self):
+        return {
+            "label": self.label,
+            "color": self.color,
+            "shape": self.shape,
+            "size": self.size,
+            "border_color": self.border_color,
+            "border_width": self.border_width
+        }
+
+
+@dataclass
+class EdgeLegendEntry:
+    """Configuration for a single edge legend entry."""
+    label: str
+    color: str
+    width: int = 2
+    style: Literal["solid", "dashed", "dotted"] = "solid"
+    arrow: bool = True
+
+    def to_dict(self):
+        return {
+            "label": self.label,
+            "color": self.color,
+            "width": self.width,
+            "style": self.style,
+            "arrow": self.arrow
+        }
+
+
+# ----------------------------------------------------------------------
+# LEGEND CONFIGURATION
+# ----------------------------------------------------------------------
+
+@dataclass
+class LegendConfig:
+    """Complete legend configuration."""
+    enabled: bool = True
+    position: LegendPosition = LegendPosition.TOP_RIGHT
+    draggable: bool = True
+    collapsible: bool = True
+    background_color: str = "#ffffff"
+    border_color: str = "#cccccc"
+    opacity: float = 0.9
+
+    node_entries: List[NodeLegendEntry] = field(default_factory=list)
+    edge_entries: List[EdgeLegendEntry] = field(default_factory=list)
+
+    def add_node_entry(self, label: str, color: str, **kwargs):
+        entry = NodeLegendEntry(label=label, color=color, **kwargs)
+        self.node_entries.append(entry)
+        return entry
+
+    def add_edge_entry(self, label: str, color: str, **kwargs):
+        entry = EdgeLegendEntry(label=label, color=color, **kwargs)
+        self.edge_entries.append(entry)
+        return entry
+
+    def to_dict(self):
+        return {
+            "enabled": self.enabled,
+            "position": self.position.value,
+            "draggable": self.draggable,
+            "collapsible": self.collapsible,
+            "background_color": self.background_color,
+            "border_color": self.border_color,
+            "opacity": self.opacity,
+            "node_entries": [e.to_dict() for e in self.node_entries],
+            "edge_entries": [e.to_dict() for e in self.edge_entries]
+        }
+
+
+# ----------------------------------------------------------------------
+# LEGEND BUILDER
+# ----------------------------------------------------------------------
+
+class LegendBuilder:
+    """Automatically build legends from graph data."""
+    
+    # Constants for HTML generation
+    NODE_SIZE_PADDING = 6
+    EDGE_HEIGHT_PADDING = 6
+    SVG_LINE_LENGTH = 50
+    ITEM_MARGIN = 6
+    MAX_EDGE_HEIGHT = 20
+        
+    @staticmethod
+    def from_graph_data(graph_data: Dict[str, Any], auto_detect: bool = True) -> LegendConfig:
+        legend = LegendConfig()
+
+        if auto_detect:
+            # Auto-detect node categories
+            node_categories = LegendBuilder._detect_node_categories(graph_data)
+            for category, props in node_categories.items():
+                legend.add_node_entry(
+                    label=category,
+                    color=props.get('color', '#666666'),
+                    shape=props.get('shape', 'circle'),
+                    size=props.get('size', 10)
+                )
+
+            # Auto-detect edge categories
+            edge_categories = LegendBuilder._detect_edge_categories(graph_data)
+            for category, props in edge_categories.items():
+                legend.add_edge_entry(
+                    label=category,
+                    color=props.get('color', '#999999'),
+                    width=props.get('width', 2),
+                    style=props.get('style', 'solid')
+                )
+
+        # Merge explicit legend data if present
+        metadata = graph_data.get('metadata', {})
+        if 'node_legend' in metadata:
+            legend = LegendBuilder._merge_explicit_legend(legend, metadata['node_legend'], 'node')
+        if 'edge_legend' in metadata:
+            legend = LegendBuilder._merge_explicit_legend(legend, metadata['edge_legend'], 'edge')
+
+        return legend
+
+    # ------------------------------------------------------------------
+    # INTERNAL DETECTION HELPERS
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _merge_explicit_legend(legend: LegendConfig, explicit_data: Dict, legend_type: str) -> LegendConfig:
+        if legend_type == 'node':
+            for entry in explicit_data:
+                legend.add_node_entry(
+                    label=entry.get('label', ''),
+                    color=entry.get('color', '#666666'),
+                    shape=entry.get('shape', 'circle'),
+                    size=entry.get('size', 10),
+                    border_color=entry.get('border_color'),
+                    border_width=entry.get('border_width', 0)
+                )
+        elif legend_type == 'edge':
+            for entry in explicit_data:
+                legend.add_edge_entry(
+                    label=entry.get('label', ''),
+                    color=entry.get('color', '#999999'),
+                    width=entry.get('width', 2),
+                    style=entry.get('style', 'solid'),
+                    arrow=entry.get('arrow', True)
+                )
+        return legend
+
+    @staticmethod
+    def _detect_node_categories(graph_data: Dict[str, Any]) -> Dict[str, Dict]:
+        """Detect unique node categories and properties, even if no color is provided."""
+        categories = defaultdict(lambda: {'colors': set(), 'shapes': set(), 'sizes': set()})
+        nodes = graph_data.get('nodes', [])
+
+        for node in nodes:
+            metadata = node.get('metadata', node)
+            category = metadata.get('legend_category', metadata.get('type', 'default'))
+
+            # Always create the category
+            categories[category]  # ensures it exists
+
+            color = metadata.get('color')
+            if color and color.strip():
+                categories[category]['colors'].add(color)
+            if 'shape' in metadata:
+                categories[category]['shapes'].add(metadata['shape'])
+            if 'size' in metadata:
+                categories[category]['sizes'].add(metadata['size'])
+
+        result = {}
+        for cat, props in categories.items():
+            result[cat] = {
+                'color': list(props['colors'])[0] if props['colors'] else None,
+                'shape': list(props['shapes'])[0] if props['shapes'] else 'circle',
+                'size': int(sum(props['sizes']) / len(props['sizes'])) if props['sizes'] else 10
+            }
+        return result
+
+    @staticmethod
+    def _detect_edge_categories(graph_data: Dict[str, Any]) -> Dict[str, Dict]:
+        """Detect unique edge categories and properties, even if no color is provided."""
+        categories = defaultdict(lambda: {'colors': set(), 'widths': set(), 'styles': set()})
+        edges = graph_data.get('edges', [])
+
+        for edge in edges:
+            metadata = edge.get('metadata', edge)
+            category = metadata.get('legend_category', metadata.get('type', 'default'))
+
+            # Always create the category
+            categories[category]
+
+            color = metadata.get('color')
+            if color and color.strip():
+                categories[category]['colors'].add(color)
+            if 'weight' in metadata or 'width' in metadata:
+                categories[category]['widths'].add(metadata.get('weight', metadata.get('width')))
+            if 'style' in metadata:
+                categories[category]['styles'].add(metadata['style'])
+
+        result = {}
+        for cat, props in categories.items():
+            result[cat] = {
+                'color': list(props['colors'])[0] if props['colors'] else None,
+                'width': int(sum(props['widths']) / len(props['widths'])) if props['widths'] else 2,
+                'style': list(props['styles'])[0] if props['styles'] else 'solid'
+            }
+        return result
+
+    # ------------------------------------------------------------------
+    # VALIDATION HELPERS
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _is_valid_color(color: str) -> bool:
+        """Check if color is a valid CSS color value."""
+        if not color or not isinstance(color, str) or not color.strip():
+            return False
+        color = color.strip()
+        # Match hex colors, rgb/rgba, hsl/hsla, or named colors
+        patterns = [
+            r'^#[0-9a-fA-F]{3,8}$',  # Hex colors
+            r'^rgba?\([^)]+\)$',      # RGB/RGBA
+            r'^hsla?\([^)]+\)$',      # HSL/HSLA
+            r'^[a-z]+$'               # Named colors (basic check)
+        ]
+        return any(re.match(pattern, color, re.IGNORECASE) for pattern in patterns)
+    
+    @staticmethod
+    def _sanitize_dimension(value: Any, default: int = 10) -> int:
+        """Ensure dimension values are positive integers."""
+        try:
+            val = int(value)
+            return max(1, val)
+        except (ValueError, TypeError):
+            return default
+    
+    @staticmethod
+    def _get_dash_pattern(style: str) -> str:
+        """Get SVG stroke-dasharray pattern for edge style."""
+        patterns = {
+            "solid": "none",
+            "dashed": "4,3",
+            "dotted": "1,3"
+        }
+        return patterns.get(style.lower() if style else "", "none")
+    
+    @staticmethod
+    def _get_shape_radius(shape: str) -> str:
+        """Get CSS border-radius for node shape."""
+        return "50%" if shape and shape.lower() == "circle" else "4px"
+
+    # ------------------------------------------------------------------
+    # HTML GENERATION
+    # ------------------------------------------------------------------
+    @staticmethod
+    def build_html(graph_data: Dict[str, Any], dark_mode: bool = False) -> str:
+        """
+        Build a modern, theme-aware HTML legend from graph data.
+        
+        Args:
+            graph_data: Dictionary containing graph configuration and data
+            dark_mode: Whether to use dark theme colors
+            
+        Returns:
+            HTML string for the legend with proper escaping and validation
+        """
+        legend = LegendBuilder.from_graph_data(graph_data)
+
+        # === Palette ===
+        if dark_mode:
+            palette = dict(
+                background="#1f1f25",
+                text="#f0f0f5",
+                border="#3a3a40",
+                heading="#7ddba3",
+                node_default="#7ddba3",
+                edge_default="#b5b8c5",
+            )
+        else:
+            palette = dict(
+                background="#ffffff",
+                text="#111111",
+                border="#cccccc",
+                heading="#222222",
+                node_default="#000000",
+                edge_default="#000000",
+            )
+
+        # === Container ===
+        html_parts = [
+            f'<div class="legend-container" role="figure" aria-label="Graph legend" style="'
+            f'font-family: Inter, Arial, sans-serif; font-size: 14px; '
+            f'color:{palette["text"]}; background:{palette["background"]}; '
+            f'border:1px solid {palette["border"]}; border-radius:12px; '
+            f'box-shadow:0 2px 8px rgba(0,0,0,0.15); padding:16px 20px; '
+            f'width:fit-content; max-width:260px; opacity:{legend.opacity}; '
+            f'backdrop-filter:blur(6px);">'
+        ]
+
+        html_parts.append(
+            f'<h3 style="margin:0 0 12px 0; font-size:16px; color:{palette["heading"]}; '
+            f'font-weight:600;">Legend</h3>'
+        )
+
+        # === Node section ===
+        if legend.node_entries:
+            html_parts.append('<div class="node-legend" style="margin-bottom:14px;">')
+            html_parts.append(
+                '<h4 style="margin:4px 0 6px 0; font-size:13px; font-weight:600;">Nodes</h4>'
+            )
+            html_parts.append('<ul style="list-style:none; padding:0; margin:0;">')
+
+            for entry in legend.node_entries:
+                # Validate and use default if missing/invalid
+                color = (
+                    entry.color 
+                    if LegendBuilder._is_valid_color(entry.color) 
+                    else palette["node_default"]
+                )
+                
+                # Validate border color
+                border_color = (
+                    entry.border_color 
+                    if LegendBuilder._is_valid_color(entry.border_color)
+                    else palette["border"]
+                )
+                
+                # Sanitize dimensions
+                size = LegendBuilder._sanitize_dimension(
+                    entry.size, 
+                    default=10
+                ) + LegendBuilder.NODE_SIZE_PADDING
+                
+                border_width = LegendBuilder._sanitize_dimension(
+                    entry.border_width,
+                    default=0
+                )
+                
+                # Get shape styling
+                shape_css = LegendBuilder._get_shape_radius(entry.shape)
+                
+                # Escape user-provided label
+                safe_label = html_escape.escape(entry.label)
+
+                html_parts.append(
+                    f'<li style="display:flex; align-items:center; '
+                    f'margin:{LegendBuilder.ITEM_MARGIN}px 0;">'
+                    f'<span style="display:inline-block; width:{size}px; height:{size}px; '
+                    f'border-radius:{shape_css}; background:{color}; '
+                    f'border:{border_width}px solid {border_color}; '
+                    f'margin-right:10px; flex-shrink:0;" '
+                    f'aria-hidden="true"></span>'
+                    f'<span>{safe_label}</span></li>'
+                )
+            html_parts.append('</ul></div>')
+
+        # === Edge section ===
+        if legend.edge_entries:
+            html_parts.append('<div class="edge-legend">')
+            html_parts.append(
+                '<h4 style="margin:4px 0 6px 0; font-size:13px; font-weight:600;">Edges</h4>'
+            )
+            html_parts.append('<ul style="list-style:none; padding:0; margin:0;">')
+
+            for entry in legend.edge_entries:
+                # Validate color
+                stroke_color = (
+                    entry.color 
+                    if LegendBuilder._is_valid_color(entry.color)
+                    else palette["edge_default"]
+                )
+                
+                # Sanitize width
+                edge_width = LegendBuilder._sanitize_dimension(
+                    entry.width,
+                    default=2
+                )
+                
+                # Get dash pattern
+                dash_pattern = LegendBuilder._get_dash_pattern(entry.style)
+                
+                # Escape user-provided label
+                safe_label = html_escape.escape(entry.label)
+
+                html_parts.append(
+                    f'<li style="display:flex; align-items:center; '
+                    f'margin:{LegendBuilder.ITEM_MARGIN}px 0;">'
+                    f'<svg width="{LegendBuilder.SVG_LINE_LENGTH}" height="{edge_width * 2}" '
+                    f'viewBox="0 0 {LegendBuilder.SVG_LINE_LENGTH} {edge_width * 2}" '
+                    f'style="margin-right:10px; display:block; flex-shrink:0;" '
+                    f'aria-hidden="true">'
+                    f'<line x1="0" y1="{edge_width}" '
+                    f'x2="{LegendBuilder.SVG_LINE_LENGTH}" y2="{edge_width}" '
+                    f'stroke="{stroke_color}" stroke-width="{edge_width/10}" '
+                    f'stroke-dasharray="{dash_pattern}" stroke-linecap="round" />'
+                    f'</svg>'
+                    f'<span>{safe_label}</span></li>'
+                )
+            html_parts.append('</ul></div>')
+
+        html_parts.append('</div>')
+        return "\n".join(html_parts)

--- a/gravis/_internal/plotting/d3.py
+++ b/gravis/_internal/plotting/d3.py
@@ -34,7 +34,8 @@ def d3(data,
        collision_force_strength=0.7,
        use_x_positioning_force=False, x_positioning_force_strength=0.2,
        use_y_positioning_force=False, y_positioning_force_strength=0.2,
-       use_centering_force=True):
+       use_centering_force=True,
+       use_dark_mode=False):
     """Create an interactive graph visualization with HTML/CSS/JS based on d3.v7.js.
 
     Parameters
@@ -200,6 +201,8 @@ def d3(data,
         This force attracts each node towards the center of the coordinate system at (0, 0)
         to keep the graph in the display area. It may lead to unexpected repulsion effects
         if all nodes are fixed and then a single one is released by dragging it.
+    use_dark_mode : bool
+        If True, the interface is rendered with a dark theme instead of the default light theme.
 
     Returns
     -------
@@ -218,6 +221,7 @@ def d3(data,
     _ca(show_details_toggle_button, 'show_details_toggle_button', bool)
     _ca(show_menu, 'show_menu', bool)
     _ca(show_menu_toggle_button, 'show_menu_toggle_button', bool)
+    _ca(use_dark_mode, 'use_dark_mode', bool)
     _ca(show_node, 'show_node', bool)
     _ca(node_size_factor, 'node_size_factor', (int, float))
     _ca(node_size_data_source, 'node_size_data_source', str)
@@ -270,6 +274,7 @@ def d3(data,
     _ca(use_y_positioning_force, 'use_y_positioning_force', bool)
     _ca(y_positioning_force_strength, 'y_positioning_force_strength', (int, float))
     _ca(use_centering_force, 'use_centering_force', bool)
+    _ca(use_dark_mode, 'use_dark_mode', bool)
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -284,6 +289,7 @@ def d3(data,
         'SHOW_DETAILS_TOGGLE_BUTTON': _ts.to_json(show_details_toggle_button),
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
+        'USE_DARK_MODE': _ts.to_json(use_dark_mode),
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/gravis/_internal/plotting/d3.py
+++ b/gravis/_internal/plotting/d3.py
@@ -35,7 +35,7 @@ def d3(data,
        use_x_positioning_force=False, x_positioning_force_strength=0.2,
        use_y_positioning_force=False, y_positioning_force_strength=0.2,
        use_centering_force=True,
-       use_dark_mode=False):
+       use_dark_mode=False, legend_code=""):
     """Create an interactive graph visualization with HTML/CSS/JS based on d3.v7.js.
 
     Parameters
@@ -203,6 +203,8 @@ def d3(data,
         if all nodes are fixed and then a single one is released by dragging it.
     use_dark_mode : bool
         If True, the interface is rendered with a dark theme instead of the default light theme.
+    legend_code : str
+        Custom HTML code for the legend section of the visualization.
 
     Returns
     -------
@@ -221,7 +223,6 @@ def d3(data,
     _ca(show_details_toggle_button, 'show_details_toggle_button', bool)
     _ca(show_menu, 'show_menu', bool)
     _ca(show_menu_toggle_button, 'show_menu_toggle_button', bool)
-    _ca(use_dark_mode, 'use_dark_mode', bool)
     _ca(show_node, 'show_node', bool)
     _ca(node_size_factor, 'node_size_factor', (int, float))
     _ca(node_size_data_source, 'node_size_data_source', str)
@@ -275,6 +276,7 @@ def d3(data,
     _ca(y_positioning_force_strength, 'y_positioning_force_strength', (int, float))
     _ca(use_centering_force, 'use_centering_force', bool)
     _ca(use_dark_mode, 'use_dark_mode', bool)
+    _ca(legend_code, 'legend_code', str)
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -290,6 +292,7 @@ def d3(data,
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
         'USE_DARK_MODE': _ts.to_json(use_dark_mode),
+        'LEGEND-CODE': legend_code,
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/gravis/_internal/plotting/template_system.py
+++ b/gravis/_internal/plotting/template_system.py
@@ -1,22 +1,22 @@
 """Template system for using HTML template files and inserting data into them."""
 
 import json as _json
-
-import pkg_resources as _pkg_resources
+from importlib import resources
 
 
 def load(resource_path):
     """Load a file in the same directory as the template system module."""
-    resource_package = __name__
-    binary_data = _pkg_resources.resource_string(resource_package, resource_path)
-    string = binary_data.decode('utf-8')
-    return string
+    # The package is the current module's package
+    resource_package = __package__
+    # Use importlib.resources to open the file as text
+    with resources.files(resource_package).joinpath(resource_path).open('r', encoding='utf-8') as f:
+        return f.read()
 
 
 def insert(template, data):
     """Insert data into a template."""
     for key, val in data.items():
-        tag = '§' + key + '§'
+        tag = f'§{key}§'
         template = template.replace(tag, val)
     return template
 

--- a/gravis/_internal/plotting/templates/d3.html
+++ b/gravis/_internal/plotting/templates/d3.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1056,6 +1115,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1291,21 +1351,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1316,10 +1393,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2231,17 +2308,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2458,15 +2529,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -3534,6 +3600,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/d3.html
+++ b/gravis/_internal/plotting/templates/d3.html
@@ -1,558 +1,644 @@
 §PREFIX§
-  <style>
-    /* Main divisions */
-    #§RANDOM_ID§-main-div {
-      line-height: normal;
-      box-sizing: content-box;
-      padding: 3px;
-      background-color: var(--§RANDOM_ID§-background-color);
-      color: var(--§RANDOM_ID§-text-color);
-      --§RANDOM_ID§-background-color: #ffffff;
-      --§RANDOM_ID§-text-color: #222222;
-      --§RANDOM_ID§-text-color-subtle: #666666;
-      --§RANDOM_ID§-accent-color: #006429;
-      --§RANDOM_ID§-surface-color: #f5f5f5;
-      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
-      --§RANDOM_ID§-surface-color-strong: #dddddd;
-      --§RANDOM_ID§-surface-color-overlay: #ffffff;
-      --§RANDOM_ID§-border-color: #cccccc;
-      --§RANDOM_ID§-border-color-strong: #bbbbbb;
-      --§RANDOM_ID§-border-color-hover: #999999;
-      --§RANDOM_ID§-tooltip-background: #ffffff;
-      --§RANDOM_ID§-tooltip-text: #111111;
-      --§RANDOM_ID§-details-separator: #333333;
-      --§RANDOM_ID§-progress-border: #000000;
-      --§RANDOM_ID§-progress-fill: #000000;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
-    }
-    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
-      --§RANDOM_ID§-background-color: #1f1f25;
-      --§RANDOM_ID§-text-color: #f0f0f5;
-      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
-      --§RANDOM_ID§-accent-color: #7ddba3;
-      --§RANDOM_ID§-surface-color: #2d303c;
-      --§RANDOM_ID§-surface-color-muted: #343746;
-      --§RANDOM_ID§-surface-color-strong: #3d4050;
-      --§RANDOM_ID§-surface-color-overlay: #282a36;
-      --§RANDOM_ID§-border-color: #43465a;
-      --§RANDOM_ID§-border-color-strong: #50546a;
-      --§RANDOM_ID§-border-color-hover: #5e637c;
-      --§RANDOM_ID§-tooltip-background: #2f3241;
-      --§RANDOM_ID§-tooltip-text: #f0f2ff;
-      --§RANDOM_ID§-details-separator: #5e637c;
-      --§RANDOM_ID§-progress-border: #f0f2ff;
-      --§RANDOM_ID§-progress-fill: #7ddba3;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
-    }
-    #§RANDOM_ID§-left-div {
-      float: left;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-div {
-      float: left;
-      height: 100%;
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-inner-div {
-      padding-left: 5px;
-      padding-right: 2px;
-      overflow-x: hidden;
-      overflow-y: auto;
-      height: 100%;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+<style>
+  /* Main divisions */
+  #§RANDOM_ID§-main-div {
+    line-height: normal;
+    box-sizing: content-box;
+    padding: 3px;
+    background-color: var(--§RANDOM_ID§-background-color);
+    color: var(--§RANDOM_ID§-text-color);
+    --§RANDOM_ID§-background-color: #ffffff;
+    --§RANDOM_ID§-text-color: #222222;
+    --§RANDOM_ID§-text-color-subtle: #666666;
+    --§RANDOM_ID§-accent-color: #006429;
+    --§RANDOM_ID§-surface-color: #f5f5f5;
+    --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+    --§RANDOM_ID§-surface-color-strong: #dddddd;
+    --§RANDOM_ID§-surface-color-overlay: #ffffff;
+    --§RANDOM_ID§-border-color: #cccccc;
+    --§RANDOM_ID§-border-color-strong: #bbbbbb;
+    --§RANDOM_ID§-border-color-hover: #999999;
+    --§RANDOM_ID§-tooltip-background: #ffffff;
+    --§RANDOM_ID§-tooltip-text: #111111;
+    --§RANDOM_ID§-details-separator: #333333;
+    --§RANDOM_ID§-progress-border: #000000;
+    --§RANDOM_ID§-progress-fill: #000000;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+  }
 
-    /* Graph and details (contained in left-inner-div) */
-    #§RANDOM_ID§-graph-div {
-      overflow: hidden;
-      resize: vertical;
-      position: relative;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-div {
-      overflow: auto;
-      resize: vertical;
-      margin-top: 5px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-head {
-      user-select: none;
-      padding-left: 4px !important;
-      padding-top: 4px !important;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color-subtle);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-details-body {
-      padding: 10px;
-      padding-top: 6px;
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+  #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+    --§RANDOM_ID§-background-color: #1f1f25;
+    --§RANDOM_ID§-text-color: #f0f0f5;
+    --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+    --§RANDOM_ID§-accent-color: #7ddba3;
+    --§RANDOM_ID§-surface-color: #2d303c;
+    --§RANDOM_ID§-surface-color-muted: #343746;
+    --§RANDOM_ID§-surface-color-strong: #3d4050;
+    --§RANDOM_ID§-surface-color-overlay: #282a36;
+    --§RANDOM_ID§-border-color: #43465a;
+    --§RANDOM_ID§-border-color-strong: #50546a;
+    --§RANDOM_ID§-border-color-hover: #5e637c;
+    --§RANDOM_ID§-tooltip-background: #2f3241;
+    --§RANDOM_ID§-tooltip-text: #f0f2ff;
+    --§RANDOM_ID§-details-separator: #5e637c;
+    --§RANDOM_ID§-progress-border: #f0f2ff;
+    --§RANDOM_ID§-progress-fill: #7ddba3;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
+  }
 
-    /* Control menu (contained in right-inner-div) */
-    .§RANDOM_ID§-menu-item-head {
-      font-size: 11px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      cursor: pointer;
-      padding-left: 5px;
-      padding-right: 0px;
-      padding-top: 5px;
-      padding-bottom: 5px;
-      margin-bottom: 5px;
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
-      background-color: var(--§RANDOM_ID§-surface-color);
-      border-color: var(--§RANDOM_ID§-border-color-hover);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
-    }
-    .§RANDOM_ID§-menu-item-body {
-      margin-left: 5px;
-      margin-bottom: 10px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-head {
-      font-size: 9px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-weight: 600;
-      color: var(--§RANDOM_ID§-accent-color);
-      cursor: default;
-      margin-bottom: 2px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-body {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      margin-left: 7px;
-      margin-bottom: 5px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-labeled-input {
-      all: initial;
-      display: flex;
-      align-items: center;
-      margin-top: 1px;
-      margin-bottom: 1px;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-label {
-      all: initial;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      cursor: pointer;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-slider {
-      width: 100%;
-      margin-bottom: 2px;
-    }
-    .§RANDOM_ID§-slider::-moz-focus-outer {
-      border: 0;
-    }
-    .§RANDOM_ID§-slider-text-left {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      color: var(--§RANDOM_ID§-text-color);
-      float: left;
-      margin-top: 2px;
-    }
-    .§RANDOM_ID§-slider-text-right {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      float: right;
-    }
-    .§RANDOM_ID§-checkbox {
-      margin-left: 0px !important;
-      margin-right: 4px !important;
-      margin-top: 2px !important;
-      margin-bottom: 2px !important;
-      padding: 0px !important;
-    }
+  #§RANDOM_ID§-left-div {
+    float: left;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-div {
+    float: left;
+    height: 100%;
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-inner-div {
+    padding-left: 5px;
+    padding-right: 2px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100%;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Graph and details (contained in left-inner-div) */
+  #§RANDOM_ID§-graph-div {
+    overflow: hidden;
+    resize: vertical;
+    position: relative;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-div {
+    overflow: auto;
+    resize: vertical;
+    margin-top: 5px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-head {
+    user-select: none;
+    padding-left: 4px !important;
+    padding-top: 4px !important;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color-subtle);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-details-body {
+    padding: 10px;
+    padding-top: 6px;
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Control menu (contained in right-inner-div) */
+  .§RANDOM_ID§-menu-item-head {
+    font-size: 11px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    cursor: pointer;
+    padding-left: 5px;
+    padding-right: 0px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-bottom: 5px;
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+    background-color: var(--§RANDOM_ID§-surface-color);
+    border-color: var(--§RANDOM_ID§-border-color-hover);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
+  }
+
+  .§RANDOM_ID§-menu-item-body {
+    margin-left: 5px;
+    margin-bottom: 10px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-head {
+    font-size: 9px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-weight: 600;
+    color: var(--§RANDOM_ID§-accent-color);
+    cursor: default;
+    margin-bottom: 2px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-body {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    margin-left: 7px;
+    margin-bottom: 5px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-labeled-input {
+    all: initial;
+    display: flex;
+    align-items: center;
+    margin-top: 1px;
+    margin-bottom: 1px;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-label {
+    all: initial;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    cursor: pointer;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-slider {
+    width: 100%;
+    margin-bottom: 2px;
+  }
+
+  .§RANDOM_ID§-slider::-moz-focus-outer {
+    border: 0;
+  }
+
+  .§RANDOM_ID§-slider-text-left {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    color: var(--§RANDOM_ID§-text-color);
+    float: left;
+    margin-top: 2px;
+  }
+
+  .§RANDOM_ID§-slider-text-right {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    float: right;
+  }
+
+  .§RANDOM_ID§-checkbox {
+    margin-left: 0px !important;
+    margin-right: 4px !important;
+    margin-top: 2px !important;
+    margin-bottom: 2px !important;
+    padding: 0px !important;
+  }
+
+  .§RANDOM_ID§-select {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color);
+    width: 100%;
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 5px;
+    padding-right: 10px;
+    margin-right: 5px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: var(--§RANDOM_ID§-select-arrow);
+    background-repeat: no-repeat;
+    background-position: right 4px top 50%;
+    background-size: 6px;
+  }
+
+  @-moz-document url-prefix() {
+
+    /* Dirty hack to remove dotted border on focus */
     .§RANDOM_ID§-select {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color);
-      width: 100%;
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 5px;
-      padding-right: 10px;
-      margin-right: 5px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+      color: transparent !important;
+      text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
+    }
+  }
 
-      -moz-appearance: none;
-      -webkit-appearance: none;
-      appearance: none;
-      background-image: var(--§RANDOM_ID§-select-arrow);
-      background-repeat: no-repeat;
-      background-position: right 4px top 50%;
-      background-size: 6px;
-    }
-    @-moz-document url-prefix() {
-      /* Dirty hack to remove dotted border on focus */
-      .§RANDOM_ID§-select {
-        color: transparent !important;
-        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
-      }
-    }
-    .§RANDOM_ID§-select:after {
-      cursor: pointer;
-    }
-    .§RANDOM_ID§-button {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-muted);
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 10px;
-      padding-right: 10px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
-    }
-    .§RANDOM_ID§-button:hover {
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
-      background-color: var(--§RANDOM_ID§-surface-color);
-    }
-    .§RANDOM_ID§-button:active {
-      background-color: var(--§RANDOM_ID§-surface-color-strong);
-    }
-    .§RANDOM_ID§-button::-moz-focus-inner {
-      border: 0;
-    }
-    /* Hidden menu items */
-    #§RANDOM_ID§-graph-select-div {
-      display: none;
-    }
-    #§RANDOM_ID§-node-size-norm-div {
-      display: none;
-    }
-    #§RANDOM_ID§-edge-size-norm-div {
-      display: none;
-    }
+  .§RANDOM_ID§-select:after {
+    cursor: pointer;
+  }
 
-    /* Graph */
-    #§RANDOM_ID§-tooltip-div {
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42001;
-      opacity: 0;
-      visibility: hidden;
-      position: absolute !important;
-      max-width: 40%;
-      padding: 5px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: var(--§RANDOM_ID§-tooltip-text);
-      background-color: var(--§RANDOM_ID§-tooltip-background);
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button, #§RANDOM_ID§-details-toggle-button, #§RANDOM_ID§-progress-container {
-      font-size: 14px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42000;
-      cursor: pointer;
-      position: absolute;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      border-radius: 4px;
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button {
-      top: 0;
-      right: 0;
-      padding-left: 6px;
-      padding-right: 6px;
-      padding-top: 12px;
-      padding-bottom: 12px;
-      border-top: 0px;
-      border-right: 0px;
-      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
-      border-left: 1px solid var(--§RANDOM_ID§-border-color);
-    }
-    #§RANDOM_ID§-details-toggle-button {
-      bottom: 0;
-      left: 0;
-      padding-left: 19px;
-      padding-right: 19px;
-      padding-top: 0.5px;
-      padding-bottom: 2px;
-      border-top: 1px solid var(--§RANDOM_ID§-border-color);
-      border-right: 1px solid var(--§RANDOM_ID§-border-color);
-      border-bottom: 0px;
-      border-left: 0px;
-    }
-    #§RANDOM_ID§-progress-container {
-      font-size: 10px;
-      text-align: center;
-      top: 46%;
-      left: 15%;
-      width: 70%;
-      padding: 8px;
-      border: none;
-      box-shadow: none;
-    }
+  .§RANDOM_ID§-button {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-muted);
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  }
 
-    .§RANDOM_ID§-progress-bar-outer {
-      border: 1px solid var(--§RANDOM_ID§-progress-border);
-      border-radius: 4px;
-      margin-top: 1ex;
-      padding: 1px;
-    }
-    .§RANDOM_ID§-progress-bar-inner {
-      background-color: var(--§RANDOM_ID§-progress-fill);
-      width: 0%;
-      height: 8px;
-      border-radius: 3px;
-    }
+  .§RANDOM_ID§-button:hover {
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+    background-color: var(--§RANDOM_ID§-surface-color);
+  }
 
-    /* Details */
-    #§RANDOM_ID§-details-user-provided {
-      margin-top: 3px;
-      padding-top: 3.5px;
-      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
-      line-height: normal;
-      box-sizing: content-box;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    #§RANDOM_ID§-details-user-provided ul {
-      list-style-position: inside;
-      padding-left: 6px;
-    }
-  </style>
+  .§RANDOM_ID§-button:active {
+    background-color: var(--§RANDOM_ID§-surface-color-strong);
+  }
 
-  <div id="§RANDOM_ID§-main-div">
-    <div id="§RANDOM_ID§-tooltip-div"></div>
+  .§RANDOM_ID§-button::-moz-focus-inner {
+    border: 0;
+  }
 
-    <div id="§RANDOM_ID§-left-div">
-      <div id="§RANDOM_ID§-left-inner-div">
-        <div id="§RANDOM_ID§-graph-div"></div>
-        <div id="§RANDOM_ID§-details-div">
-          <div id="§RANDOM_ID§-details-head">
-            Details for selected element
-          </div>
-          <div id="§RANDOM_ID§-details-body">
-          </div>
+  /* Hidden menu items */
+  #§RANDOM_ID§-graph-select-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-node-size-norm-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-edge-size-norm-div {
+    display: none;
+  }
+
+  /* Graph */
+  #§RANDOM_ID§-tooltip-div {
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42001;
+    opacity: 0;
+    visibility: hidden;
+    position: absolute !important;
+    max-width: 40%;
+    padding: 5px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--§RANDOM_ID§-tooltip-text);
+    background-color: var(--§RANDOM_ID§-tooltip-background);
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button,
+  #§RANDOM_ID§-details-toggle-button,
+  #§RANDOM_ID§-progress-container {
+    font-size: 14px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42000;
+    cursor: pointer;
+    position: absolute;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    border-radius: 4px;
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button {
+    top: 0;
+    right: 0;
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-top: 0px;
+    border-right: 0px;
+    border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+    border-left: 1px solid var(--§RANDOM_ID§-border-color);
+  }
+
+  #§RANDOM_ID§-details-toggle-button {
+    bottom: 0;
+    left: 0;
+    padding-left: 19px;
+    padding-right: 19px;
+    padding-top: 0.5px;
+    padding-bottom: 2px;
+    border-top: 1px solid var(--§RANDOM_ID§-border-color);
+    border-right: 1px solid var(--§RANDOM_ID§-border-color);
+    border-bottom: 0px;
+    border-left: 0px;
+  }
+
+  #§RANDOM_ID§-progress-container {
+    font-size: 10px;
+    text-align: center;
+    top: 46%;
+    left: 15%;
+    width: 70%;
+    padding: 8px;
+    border: none;
+    box-shadow: none;
+  }
+
+  .§RANDOM_ID§-progress-bar-outer {
+    border: 1px solid var(--§RANDOM_ID§-progress-border);
+    border-radius: 4px;
+    margin-top: 1ex;
+    padding: 1px;
+  }
+
+  .§RANDOM_ID§-progress-bar-inner {
+    background-color: var(--§RANDOM_ID§-progress-fill);
+    width: 0%;
+    height: 8px;
+    border-radius: 3px;
+  }
+
+  /* Details */
+  #§RANDOM_ID§-details-user-provided {
+    margin-top: 3px;
+    padding-top: 3.5px;
+    border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
+    line-height: normal;
+    box-sizing: content-box;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  #§RANDOM_ID§-details-user-provided ul {
+    list-style-position: inside;
+    padding-left: 6px;
+  }
+
+  /* Legend */
+
+  #legend {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+  }
+</style>
+
+<div id="§RANDOM_ID§-main-div">
+  <div id="legend">§LEGEND-CODE§</div>
+  <div id="§RANDOM_ID§-tooltip-div"></div>
+
+  <div id="§RANDOM_ID§-left-div">
+    <div id="§RANDOM_ID§-left-inner-div">
+      <div id="§RANDOM_ID§-graph-div"></div>
+      <div id="§RANDOM_ID§-details-div">
+        <div id="§RANDOM_ID§-details-head">
+          Details for selected element
+        </div>
+        <div id="§RANDOM_ID§-details-body">
         </div>
       </div>
     </div>
+  </div>
 
-    <div id="§RANDOM_ID§-right-div">
-      <div id="§RANDOM_ID§-right-inner-div">
-        <!-- Menu: General -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-general-head">
-          General
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-general-body">
-          <!-- Sub-menu: State -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              App state
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-reset"
-                      type="button">Reset</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Display mode (fullscreen or not) -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Display mode
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-fullscreen-button"
-                      type="button">Enter full screen</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Export -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Export
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-svg"
-                      type="button">SVG</button>
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-png"
-                      type="button">PNG</button>
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-jpg"
-                      type="button">JPG</button>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Data -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-data-head">
-          Data selection
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-data-body">
-          <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
-          <div id="§RANDOM_ID§-graph-select-div">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Graph
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-graph-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node label text -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Node label text
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-label-data-source-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Edge label text -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Edge label text
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-edge-label-data-source-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node size -->
+  <div id="§RANDOM_ID§-right-div">
+    <div id="§RANDOM_ID§-right-inner-div">
+      <!-- Menu: General -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-general-head">
+        General
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-general-body">
+        <!-- Sub-menu: State -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Node size
+            App state
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-reset" type="button">Reset</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Display mode (fullscreen or not) -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Display mode
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-fullscreen-button" type="button">Enter full
+              screen</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Export -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Export
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-svg" type="button">SVG</button>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-png" type="button">PNG</button>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-jpg" type="button">JPG</button>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Data -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-data-head">
+        Data selection
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-data-body">
+        <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
+        <div id="§RANDOM_ID§-graph-select-div">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Graph
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-graph-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node label text -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Node label text
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-label-data-source-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Edge label text -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Edge label text
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-edge-label-data-source-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Node size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-node-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-min-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-max-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Edge size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Edge size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-edge-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-edge-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-min-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-max-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Nodes -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-head">
+        Nodes
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-checkbox">Show nodes</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
             <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-size-data-source-select"></select>
-            </div>
-            <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-node-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
-            </div>
-            <div id="§RANDOM_ID§-node-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-min-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-max-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
-              </div>
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
             </div>
           </div>
-          <!-- Sub-menu: Edge size -->
+        </div>
+        <!-- Sub-menu: Position -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Edge size
+            Position
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
-            <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-edge-size-data-source-select"></select>
-            </div>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-node-release-button" type="button">Release fixed
+              nodes</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Drag behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Drag behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
             <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-edge-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
-            </div>
-            <div id="§RANDOM_ID§-edge-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-min-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-max-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-drag-fix-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
             </div>
           </div>
         </div>
-        <!-- Menu: Nodes -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-head">
-          Nodes
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-hover-neighborhood-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-hover-neighborhood-checkbox">Show
+                neighborhood</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
+            </div>
+          </div>
         </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-body">
+      </div>
+      <!-- Menu: Node images -->
+      <div id="§RANDOM_ID§-node-image-meta-control">
+        <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-image-head">
+          Node images
+        </div>
+        <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-image-body">
           <!-- Sub-menu: Visibility -->
           <div>
             <div class="§RANDOM_ID§-menu-subitem-head">
@@ -560,11 +646,8 @@
             </div>
             <div class="§RANDOM_ID§-menu-subitem-body">
               <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-checkbox">Show nodes</label>
+                <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-image-checkbox" type="checkbox">
+                <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
               </div>
             </div>
           </div>
@@ -574,3697 +657,3526 @@
               Size
             </div>
             <div class="§RANDOM_ID§-menu-subitem-body">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Position -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Position
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-node-release-button"
-                      type="button">Release fixed nodes</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Drag behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Drag behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-drag-fix-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-hover-neighborhood-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-hover-neighborhood-checkbox">Show neighborhood</label>
-              </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if provided)</label>
-              </div>
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-image-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-image-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
             </div>
           </div>
         </div>
-        <!-- Menu: Node images -->
-        <div id="§RANDOM_ID§-node-image-meta-control">
-          <div class="§RANDOM_ID§-menu-item-head"
-               id="§RANDOM_ID§-node-image-head">
-            Node images
+      </div>
+      <!-- Menu: Node labels -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-label-head">
+        Node labels
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-label-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
           </div>
-          <div class="§RANDOM_ID§-menu-item-body"
-               id="§RANDOM_ID§-node-image-body">
-            <!-- Sub-menu: Visibility -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Visibility
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-border-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-label-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-label-size-factor-slider" type="range" min="0.01"
+              max="5.0" step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Rotation -->
+        <div id="§RANDOM_ID§-node-label-rotation">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Rotation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Angle</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-label-rotation-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-label-rotation-slider" type="range" min="0.0"
+              max="359.0" step="1.0">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Edges -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-edge-head">
+        Edges
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-edge-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-checkbox">Show edges</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-factor-slider" type="range" min="0.01" max="5.0"
+              step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Form -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Form
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-curvature-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-curvature-slider" type="range" min="-1.2" max="1.2"
+              step="0.02">
+          </div>
+        </div>
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Edge labels -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-edge-label-head">
+        Edge labels
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-edge-label-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-label-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-label-checkbox">Show edge labels</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-label-border-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-label-border-checkbox">Show borders</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-label-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-label-size-factor-slider" type="range" min="0.01"
+              max="5.0" step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Rotation -->
+        <div id="§RANDOM_ID§-edge-label-rotation">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Rotation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Angle</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-label-rotation-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-label-rotation-slider" type="range" min="0.0"
+              max="359.0" step="1.0">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Layout algorithm -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-layout-algorithm-head">
+        Layout algorithm
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-layout-algorithm-body">
+
+        <!-- Sub-menu: Simulation -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Simulation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-simulation-active-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Many-body force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Many-body force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-checkbox">On</label>
+            </div>
+            <div id="§RANDOM_ID§-many-body-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-strength-slider" type="range"
+                  min="-2000.0" max="200.0" step="0.01" style="direction:rtl;">
               </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Theta</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-theta-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-theta-slider" type="range" min="0.01"
+                  max="2.0" step="0.001">
+              </div>
+              <div style="margin-top: 6px;">
                 <div class="§RANDOM_ID§-labeled-input">
-                  <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-node-image-checkbox"
-                         type="checkbox">
-                  <label class="§RANDOM_ID§-label"
-                         for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
+                  <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-min-distance-checkbox"
+                    type="checkbox">
+                  <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-min-distance-checkbox">Use minimum
+                    distance</label>
+                </div>
+                <div id="§RANDOM_ID§-many-body-force-min-distance-div">
+                  <span class="§RANDOM_ID§-slider-text-left">Min</span>
+                  <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-min-distance-text"></span>
+                  <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-min-distance-slider" type="range"
+                    min="0.01" max="10000.0" step="0.01">
                 </div>
               </div>
-            </div>
-            <!-- Sub-menu: Size -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Size
-              </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-image-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-image-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
+              <div style="margin-top: 6px;">
+                <div class="§RANDOM_ID§-labeled-input">
+                  <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-max-distance-checkbox"
+                    type="checkbox">
+                  <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-max-distance-checkbox">Use maximum
+                    distance</label>
+                </div>
+                <div id="§RANDOM_ID§-many-body-force-max-distance-div">
+                  <span class="§RANDOM_ID§-slider-text-left">Max</span>
+                  <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-max-distance-text"></span>
+                  <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-max-distance-slider" type="range"
+                    min="0.01" max="10000.0" step="0.01">
+                </div>
               </div>
             </div>
           </div>
         </div>
-        <!-- Menu: Node labels -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-label-head">
-          Node labels
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-label-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
+        <!-- Sub-menu: Links force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Links force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-links-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-links-force-checkbox">On</label>
+              </label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
+            <div id="§RANDOM_ID§-links-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Distance</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-links-force-distance-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-links-force-distance-slider" type="range" min="0.01"
+                  max="1000.0" step="0.01">
               </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-border-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-node-label-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-node-label-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Rotation -->
-          <div id="§RANDOM_ID§-node-label-rotation">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Rotation
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Angle</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-node-label-rotation-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-node-label-rotation-slider"
-                     type="range" min="0.0" max="359.0" step="1.0">
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Edges -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-edge-head">
-          Edges
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-edge-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-checkbox">Show edges</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Form -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Form
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-curvature-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-curvature-slider"
-                     type="range" min="-1.2" max="1.2" step="0.02">
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if provided)</label>
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-links-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-links-force-strength-slider" type="range" min="0.01"
+                  max="1.0" step="0.001">
               </div>
             </div>
           </div>
         </div>
-        <!-- Menu: Edge labels -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-edge-label-head">
-          Edge labels
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-edge-label-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-label-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-label-checkbox">Show edge labels</label>
-              </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-label-border-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-label-border-checkbox">Show borders</label>
-              </div>
-            </div>
+        <!-- Sub-menu: Collision force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Collision force
           </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-collision-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-collision-force-checkbox">On</label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-label-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-label-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Rotation -->
-          <div id="§RANDOM_ID§-edge-label-rotation">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Rotation
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Angle</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-label-rotation-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-label-rotation-slider"
-                     type="range" min="0.0" max="359.0" step="1.0">
+            <div id="§RANDOM_ID§-collision-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Radius</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-collision-force-radius-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-collision-force-radius-slider" type="range" min="0"
+                  max="100.0" step="0.01">
+              </div>
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-collision-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-collision-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
+              </div>
             </div>
           </div>
         </div>
-        <!-- Menu: Layout algorithm -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-layout-algorithm-head">
-          Layout algorithm
+        <!-- Sub-menu: x-positioning force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            x-positioning force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-x-positioning-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-x-positioning-force-checkbox">On</label>
+            </div>
+            <div id="§RANDOM_ID§-x-positioning-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-x-positioning-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-x-positioning-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-layout-algorithm-body">
-
-          <!-- Sub-menu: Simulation -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Simulation
+        <!-- Sub-menu: y-positioning force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            y-positioning force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-y-positioning-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-y-positioning-force-checkbox">On</label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-simulation-active-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
+            <div id="§RANDOM_ID§-y-positioning-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-y-positioning-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-y-positioning-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
               </div>
             </div>
           </div>
-          <!-- Sub-menu: Many-body force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Many-body force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-many-body-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-many-body-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-many-body-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-many-body-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-many-body-force-strength-slider"
-                         type="range" min="-2000.0" max="200.0" step="0.01"
-                         style="direction:rtl;">
-                </div>
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Theta</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-many-body-force-theta-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-many-body-force-theta-slider"
-                         type="range" min="0.01" max="2.0" step="0.001">
-                </div>
-                <div style="margin-top: 6px;">
-                  <div class="§RANDOM_ID§-labeled-input">
-                    <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-many-body-force-min-distance-checkbox"
-                         type="checkbox">
-                    <label class="§RANDOM_ID§-label"
-                           for="§RANDOM_ID§-many-body-force-min-distance-checkbox">Use minimum distance</label>
-                  </div>
-                  <div id="§RANDOM_ID§-many-body-force-min-distance-div">
-                    <span class="§RANDOM_ID§-slider-text-left">Min</span>
-                    <span class="§RANDOM_ID§-slider-text-right"
-                          id="§RANDOM_ID§-many-body-force-min-distance-text"></span>
-                    <input class="§RANDOM_ID§-slider"
-                           id="§RANDOM_ID§-many-body-force-min-distance-slider"
-                           type="range" min="0.01" max="10000.0" step="0.01">
-                  </div>
-                </div>
-                <div style="margin-top: 6px;">
-                  <div class="§RANDOM_ID§-labeled-input">
-                    <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-many-body-force-max-distance-checkbox"
-                         type="checkbox">
-                    <label class="§RANDOM_ID§-label"
-                           for="§RANDOM_ID§-many-body-force-max-distance-checkbox">Use maximum distance</label>
-                  </div>
-                  <div id="§RANDOM_ID§-many-body-force-max-distance-div">
-                    <span class="§RANDOM_ID§-slider-text-left">Max</span>
-                    <span class="§RANDOM_ID§-slider-text-right"
-                          id="§RANDOM_ID§-many-body-force-max-distance-text"></span>
-                    <input class="§RANDOM_ID§-slider"
-                           id="§RANDOM_ID§-many-body-force-max-distance-slider"
-                           type="range" min="0.01" max="10000.0" step="0.01">
-                  </div>
-                </div>
-              </div>
-            </div>
+        </div>
+        <!-- Sub-menu: Centering force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Centering force
           </div>
-          <!-- Sub-menu: Links force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Links force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-links-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-links-force-checkbox">On</label>
-                </label>
-              </div>
-              <div id="§RANDOM_ID§-links-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Distance</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-links-force-distance-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-links-force-distance-slider"
-                         type="range" min="0.01" max="1000.0" step="0.01">
-                </div>
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-links-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-links-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Collision force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Collision force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-collision-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-collision-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-collision-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Radius</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-collision-force-radius-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-collision-force-radius-slider"
-                         type="range" min="0" max="100.0" step="0.01">
-                </div>
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-collision-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-collision-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: x-positioning force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              x-positioning force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-x-positioning-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-x-positioning-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-x-positioning-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-x-positioning-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-x-positioning-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: y-positioning force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              y-positioning force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-y-positioning-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-y-positioning-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-y-positioning-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-y-positioning-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-y-positioning-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Centering force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Centering force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-centering-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-centering-force-checkbox">On</label>
-              </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-centering-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-centering-force-checkbox">On</label>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+</div>
 
-  <script charset="utf-8" type="text/javascript">
-    if(typeof(require) === "undefined"){
+<script charset="utf-8" type="text/javascript">
+  if (typeof (require) === "undefined") {
       §LOAD_REQUIRE§
-    }
+  }
     §DEFINE_D3§
 
-    require(["gravis-d3-v7"], function(d3){
-      // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
-      "use strict";
-      
-      const state = {
-        manager:{
-          // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
+  require(["gravis-d3-v7"], function (d3) {
+    // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
+    "use strict";
 
-          // 1) Fetch state.rawData
-          fetchRawDataFromTemplating(){
-            state.rawData = §DATA§;
-            // Data selection and normalization
-            state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
-            state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
-            state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
-            state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
-            state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
-            state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
-            state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
-            state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
-            state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
-            state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
-            // Containers
-            state.graphContainerHeight = §GRAPH_HEIGHT§;
-            state.detailsContainerHeight = §DETAILS_HEIGHT§;
-            state.showDetails = §SHOW_DETAILS§,
-            state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
-            state.showMenu = §SHOW_MENU§,
-            state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
-            state.useDarkMode = §USE_DARK_MODE§,
-            // Nodes
-            state.showNodes = §SHOW_NODE§;
-            state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
-            state.nodeDragFix = §NODE_DRAG_FIX§;
-            state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
-            state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
-            state.showNodeImages = §SHOW_NODE_IMAGE§;
-            state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
-            state.showNodeLabels = §SHOW_NODE_LABEL§;
-            state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
-            state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
-            state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
-            state.nodeLabelFont = §NODE_LABEL_FONT§;
-            // Edges
-            state.showEdges = §SHOW_EDGE§;
-            state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
-            state.edgeCurvature = §EDGE_CURVATURE§;
-            state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
-            state.showEdgeLabels = §SHOW_EDGE_LABEL§;
-            state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
-            state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
-            state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
-            state.edgeLabelFont = §EDGE_LABEL_FONT§;
-            // Layout algorithm
-            state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
-            state.useManyBodyForce = §USE_MANY_BODY_FORCE§;
-            state.manyBodyForceStrength = §MANY_BODY_FORCE_STRENGTH§;
-            state.manyBodyForceTheta = §MANY_BODY_FORCE_THETA§;
-            state.useManyBodyForceMinDistance = §USE_MANY_BODY_FORCE_MIN_DISTANCE§;
-            state.manyBodyForceMinDistance = §MANY_BODY_FORCE_MIN_DISTANCE§;
-            state.useManyBodyForceMaxDistance = §USE_MANY_BODY_FORCE_MAX_DISTANCE§;
-            state.manyBodyForceMaxDistance = §MANY_BODY_FORCE_MAX_DISTANCE§;
-            state.useLinksForce = §USE_LINKS_FORCE§;
-            state.linksForceDistance = §LINKS_FORCE_DISTANCE§;
-            state.linksForceStrength = §LINKS_FORCE_STRENGTH§;
-            state.useCollisionForce = §USE_COLLISION_FORCE§;
-            state.collisionForceRadius = §COLLISION_FORCE_RADIUS§;
-            state.collisionForceStrength = §COLLISION_FORCE_STRENGTH§;
-            state.useXPositioningForce = §USE_X_POSITIONING_FORCE§;
-            state.xPositioningForceStrength = §X_POSITIONING_FORCE_STRENGTH§;
-            state.useYPositioningForce = §USE_Y_POSITIONING_FORCE§;
-            state.yPositioningForceStrength = §Y_POSITIONING_FORCE_STRENGTH§;
-            state.useCenteringForce = §USE_CENTERING_FORCE§;
-            // Other
-            state.initZoomFactor = §ZOOM_FACTOR§;
-            state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
-          },
+    const state = {
+      manager: {
+        // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
 
-          // 2) Derive state.parsedData from state.givenData
-          rawDataParser:{
-            getBool(obj, prop, def){
-              try{
-                const value = obj[prop];
-                if(value == "true" || value == "True"){
-                  value = true;
-                } else if(value == "false" || value == "False"){
-                  value = false;
-                }
-                if(value !== true && value !== false){
-                  throw "Invalid value. Not a bool.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def
-            },
-
-            getString(obj, prop, def) {
-              try{
-                const value = String(obj[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def;
-            },
-
-            getArrayLengthOrZero(array){
-              try{
-                const value = parseInt(array.length);
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-            
-            getObjectLengthOrZero(obj){
-              try{
-                const value = Object.keys(obj).length;
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-
-            createUniqueEdgeId(sourceId, targetId, knownEdgeIds){
-              let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
-                newEdgeId = newEdgeIdBase,
-                multiEdgeCounter = 1;
-              for(let i=2; knownEdgeIds.has(newEdgeId); i++){
-                newEdgeId = newEdgeIdBase + "_" + String(i);
-                multiEdgeCounter += 1;
-              }
-              knownEdgeIds.add(newEdgeId);
-              return {"id": newEdgeId, "count": multiEdgeCounter}
-            },
-          },
-
-          rawMetadataParser:{
-            getString(obj, prop, def){
-              try{
-                const value = String(obj.metadata[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getColor(obj, prop, def){
-              function isBodyidColor(strColor) {
-                const sty = new Option().style;
-                sty.color = strColor;
-                return sty.color !== "";
-              }
-              try{
-                const value = obj.metadata[prop];
-                if(!isBodyidColor(value)){
-                  throw "Invalid value. Not a color."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null){
-                  throw "Invalid value. Not a finite number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumberOrNull(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value)){  // Note: isFinite(null) gives true
-                  throw "Invalid value. Not a finite number or null."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFinitePositiveNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null || value < 0.0){
-                  throw "Invalid value. Not a finite positive number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            collectOtherMetadata(sourceObject, targetObject, definedMetadata){
-              if(typeof(sourceObject) !== "undefined" && typeof(sourceObject.metadata) !== "undefined"){
-                const properties = Object.keys(sourceObject.metadata);
-                for(let i=0; i<properties.length; i++){
-                  const property = properties[i];
-                  if(!definedMetadata.has(property)){
-                    targetObject[property] = sourceObject.metadata[property];
-                  }
-                }
-              }
-            },
-          },
-
-          propertyClassifier:{
-            numeric: null,
-            nonNumeric: null,
-            init(){
-              this.numeric = new Set(),
-              this.nonNumeric = new Set();
-            },
-            isNumeric(d){
-              return d === null || typeof(d) === "undefined" || String(parseFloat(d)) === String(d);
-            },
-            inspect(object, property){
-              const value = object[property];
-              if(!this.nonNumeric.has(property)){
-                if(this.isNumeric(value)){
-                  this.numeric.add(property);
-                } else{
-                  this.nonNumeric.add(property);
-                  this.numeric.delete(property);
-                }
-              }
-            }
-          },
-
-          replaceStringVariables(givenString, givenItem, variables){
-            let newString = givenString;
-            for(let i=0; i<variables.length; i++){
-              let variable = variables[i],
-                variableText = "$" + variable;
-              if(variable === "x"){
-                variable = "fx";
-              } else if (variable === "y"){
-                variable = "fy";
-              }
-              let insertedText = String(givenItem[variable]);
-              if(insertedText === "undefined"){
-                insertedText = "";
-              }
-              newString = newString.replace(variableText, insertedText);
-            }
-            return newString;
-          },
-
-          parseGeneral(givenData, parsedData){
-            const generalDefaults = state.useDarkMode ? {
-              background_color: "#1f1f25",
-              arrow_color: "#7ddba3",
-              node_color: "#7ddba3",
-              node_border_color: "#f0f0f5",
-              node_label_color: "#f0f0f5",
-              edge_color: "#b5b8c5",
-              edge_label_color: "#f0f0f5",
-            } : {
-              background_color: "white",
-              arrow_color: "black",
-              node_color: "black",
-              node_border_color: "black",
-              node_label_color: "black",
-              edge_color: "black",
-              edge_label_color: "black",
-            };
-            parsedData.general = {
-              // General
-              directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
-              label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
-              arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
-              // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
-              node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
-              node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
-              node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
-              node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
-              node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
-              node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
-              node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
-              node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
-              node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
-              node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
-              contains_node_hover: false,
-              contains_node_click: false,
-              contains_node_image: false,
-              // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
-              edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
-              edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
-              edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
-              edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
-              edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
-              contains_edge_hover: false,
-              contains_edge_click: false,
-            };
-            if(!parsedData.general.directed){
-              parsedData.general.arrow_size = 0.0;
-            }
-          },
-
-          parseNodes(givenData, parsedData){
-            const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
-              nodeIdToObjectMap = new Map(),
-              nodeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "shape", "border_color", "border_size",
-                 "label_color", "label_size", "hover", "click", "image", "x", "y"]),
-              nodeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "shape", "border_color", "border_size",
-                "label_color", "label_size", "image", "x", "y"];
-            state.manager.propertyClassifier.init();
-            try {
-              Object.entries(givenData.nodes);
-            }
-            catch(e){
-               givenData.nodes = {};
-            }
-            for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
-              const parsedNode = {};
-              // data: id, label
-              parsedNode.id = String(givenNodeId);
-              parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
-              // defined metadata
-              parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
-              parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
-              parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
-              parsedNode.shape = state.manager.rawMetadataParser.getString(givenNode, "shape", parsedData.general.node_shape);
-              parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
-              parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
-              parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
-              parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
-              const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
-              if(image !== ""){
-                parsedNode.image = image;
-                parsedData.general.contains_node_image = true;
-              }
-              if(hover !== ""){
-                parsedNode.hover = hover;
-                parsedData.general.contains_node_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
-              if(click !== ""){
-                parsedNode.click = click;
-                parsedData.general.contains_node_click = true;
-              }
-              const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
-              const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
-              if(x !== null){
-                parsedNode.fx = x;
-              }
-              if(y !== null){
-                parsedNode.fy = y;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
-              // feature classification
-              const parsedNodeProperties = Object.keys(parsedNode);
-              for(let i=0; i<parsedNodeProperties.length; i++){
-                const property = parsedNodeProperties[i],
-                  value = parsedNode[property];
-                state.manager.propertyClassifier.inspect(parsedNode, property);
-              }
-              // variable replacements
-              if(parsedNode.hover){
-                parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
-              }
-              if(parsedNode.click){
-                parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
-              }
-              // store the parsed node
-              parsedData.nodes.push(parsedNode);
-              // data structure for inserting node object references into edge data
-              nodeIdToObjectMap.set(parsedNode.id, parsedNode);
-            }
-            // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            for(let i=0; i<numNodes; i++){
-              const parsedNode = parsedData.nodes[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedNode[property]);
-                parsedNode[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.node_properties = {
-              "node_size_data_sources": numericProperties,
-              "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report empty graph
-            if(!(numNodes > 0)){
-              console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
-            }
-            return nodeIdToObjectMap;
-          },
-
-          parseEdges(givenData, parsedData, nodeIdToObjectMap){
-            let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
-            const knownEdgeIds = new Set(),
-              ignoredEdges = [],
-              edgeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
-              edgeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "label_color", "label_size"];
-            state.manager.propertyClassifier.init();
-            for(let i=0; i<numEdges; i++){
-              const givenEdge = givenData.edges[i],
-                parsedEdge = {},
-                sourceId = String(givenEdge.source),
-                targetId = String(givenEdge.target);
-              // data: source, target, id, multi_edge_counter, label
-              try{
-                const sourceObj = nodeIdToObjectMap.get(sourceId);
-                const targetObj = nodeIdToObjectMap.get(targetId);
-                if(typeof(sourceObj) === "undefined" || typeof(targetObj) === "undefined"){
-                  throw "Invalid node reference.";
-                }
-                parsedEdge.source = sourceObj;
-                parsedEdge.target = targetObj;
-              } catch(e){
-                const ignoredEdge = {
-                  index: i,
-                  source: sourceId,
-                  target: targetId,
-                }
-                ignoredEdges.push(ignoredEdge);
-                continue;
-              }
-              const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
-              parsedEdge.id = result.id;
-              parsedEdge.multi_edge_counter = result.count;
-              parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
-              // defined metadata
-              parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
-              parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
-              parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
-              parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
-              parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
-              if(hover !== ""){
-                parsedEdge.hover = hover;
-                parsedData.general.contains_edge_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
-              if(click !== ""){
-                parsedEdge.click = click;
-                parsedData.general.contains_edge_click = true;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
-              // feature classification
-              const parsedEdgeProperties = Object.keys(parsedEdge);
-              for(let i=0; i<parsedEdgeProperties.length; i++){
-                const property = parsedEdgeProperties[i],
-                  value = parsedEdge[property];
-                state.manager.propertyClassifier.inspect(parsedEdge, property);
-              }
-              // variable replacements
-              if(parsedEdge.hover){
-                parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
-              }
-              if(parsedEdge.click){
-                parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
-              }
-              // store it
-              parsedData.edges.push(parsedEdge);
-            }
-            // Ensure numeric properties are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges)
-            for(let i=0; i<numEdges; i++){
-              const parsedEdge = parsedData.edges[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedEdge[property]);
-                parsedEdge[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.edge_properties = {
-              "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
-              "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
-                item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report invalid edges
-            if(ignoredEdges.length > 0){
-              let message = undefined;
-              if(ignoredEdges.length == 1){
-                message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
-                  "refers to a node that is not part of the node list:\n";
-              } else{
-                message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
-                  "refer to a node that is not part of the node list:\n";
-              }
-              for(let i=0; i<ignoredEdges.length; i++){
-                const ignoredEdge = ignoredEdges[i];
-                message += '- Edge with index ' + ignoredEdge.index;
-                message += ', source "' + ignoredEdge.source;
-                message += '", target "' + ignoredEdge.target + '"\n';
-                if(i==9){
-                  message += '...';
-                  break;
-                }
-              }
-              console.log(message);
-            }
-          },
-
-          parseChosenData(chosenGraphNumber){
-            let givenData = state.rawData[chosenGraphNumber],
-              parsedData = {
-                general: {},
-                nodes: [],
-                edges: [],
-                adjacency: null,
-                incidence: null,
-              };
-            if(!givenData || givenData === null){
-              givenData = [];
-            }
-            // a) General
-            state.manager.parseGeneral(givenData, parsedData);
-            // b) Nodes
-            const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
-            // c) Edges
-            state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
-            // Update state
-            state.parsedData = parsedData;
-            state.currentGraphParts = {};
-            // Update UI: show or hide containers
-            ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
-            ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
-          },
-
-          // 3) Derive state.shownData from state.parsedData
-          createNodeToAdjacentNodesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(sourceNode, targetNode){
-                let adjacentNodes = this.map.get(sourceNode);
-                if(adjacentNodes){
-                  adjacentNodes.add(targetNode);
-                } else{
-                  adjacentNodes = new Set([targetNode]);
-                  this.map.set(sourceNode, adjacentNodes);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          createNodeToIncidentEdgesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(node, edge){
-                let incidentEdges = this.map.get(node);
-                if(incidentEdges){
-                  incidentEdges.add(edge);
-                } else{
-                  incidentEdges = new Set([edge]);
-                  this.map.set(node, incidentEdges);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          prepareShownData(){
-            const numNodes = state.parsedData.nodes.length,
-              numEdges = state.parsedData.edges.length;
-            state.shownData = {
-              "general": null,
-              "nodes": new Array(numNodes),
-              "edges": new Array(numEdges),
-            }
-            const nodeIdToObjectMap = new Map(),
-              nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            // a) General
-            state.shownData.general = {
-              "background_color": state.parsedData.general.background_color,
-              "arrow_size": state.parsedData.general.arrow_size,
-              "arrow_color": state.parsedData.general.arrow_color,
-              "directed": state.parsedData.general.directed,
-              "node_image_fetching_failed": false,
-            };
-            // b) Nodes
-            for(let i=0; i<numNodes; i++){
-              state.shownData.nodes[i] = {};
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.id = parsedNode.id;
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-              shownNode.color = parsedNode.color;
-              shownNode.opacity = parsedNode.opacity;
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              shownNode.shape = parsedNode.shape;
-              shownNode.border_color = parsedNode.border_color;
-              shownNode.border_size = parsedNode.border_size;
-              shownNode.label_color = parsedNode.label_color;
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-              if(typeof(parsedNode.image) !== "undefined"){
-                shownNode.image = parsedNode.image;
-              }
-              if(typeof(parsedNode.hover) !== "undefined"){
-                shownNode.hover = parsedNode.hover;
-              }
-              if(typeof(parsedNode.click) !== "undefined"){
-                shownNode.click = parsedNode.click;
-              }
-              if(typeof(parsedNode.fx) !== "undefined"){
-                shownNode.fx = parsedNode.fx;
-              }
-              if(typeof(parsedNode.fy) !== "undefined"){
-                shownNode.fy = parsedNode.fy;
-              }
-              nodeIdToObjectMap.set(shownNode.id, shownNode);
-              // Derived properties for performance improvement in updateNodePositions
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-              state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
-              state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
-            }
-            // c) Edges
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
-              nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
-              nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
-            for(let i=0; i<numEdges; i++){
-              state.shownData.edges[i] = {};
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
-              shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
-              shownEdge.id = parsedEdge.id;
-              shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
-              shownEdge.color = parsedEdge.color;
-              shownEdge.opacity = parsedEdge.opacity;
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-              shownEdge.label_color = parsedEdge.label_color;
-              shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
-              shownEdge.multi_edge_counter = parsedEdge.multi_edge_counter;
-              if(typeof(parsedEdge.hover) !== "undefined"){
-                shownEdge.hover = parsedEdge.hover;
-              }
-              if(typeof(parsedEdge.click) !== "undefined"){
-                shownEdge.click = parsedEdge.click;
-              }
-              // Derived properties for performance improvement in updateEdgePositions
-              shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-              // Data structure for highlighting adjacent nodes and incident edges to this node
-              nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
-              nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
-              nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
-              nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
-            }
-            state.shownData.adjacency = nodeToAdjacentNodesMap;
-            state.shownData.incidence = nodeToIncidentEdgesMap;
-          },
-
-          calcSingleNodeSize(parsedNode, nodeSizeNormalizer){
-            let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
-            if(!isFinite(nodeSize)){
-              nodeSize = state.parsedData.general.node_size;
-            }
-            return nodeSize * state.nodeSizeFactor;
-          },
-
-          calcSingleNodeLabelText(parsedNode){
-            return String(parsedNode[state.nodeLabelTextDataSource]);
-          },
-
-          calcSingleNodeLabelSize(parsedNode){
-            return parsedNode.label_size * state.nodeLabelSizeFactor;
-          },
-
-          calcSingleNodeLabelPlacement(node){
-            let baseSize = node.size_half;
-            if(state.showNodeImages && typeof(node.image) !== "undefined"){
-              baseSize = (node.size_half > node.image_size_half) ? node.size_half : node.image_size_half;
-            }
-            return baseSize + node.label_size * 0.77 + 2.0;
-          },
-
-          calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer){
-            let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
-            if(!isFinite(edgeSize)){
-              edgeSize = state.parsedData.general.edge_size;
-            }
-            return edgeSize * state.edgeSizeFactor;
-          },
-
-          calcSingleEdgeCurvatureFactor(parsedEdge){
-            return state.edgeCurvature * parsedEdge.multi_edge_counter;
-          },
-
-          calcSingleEdgeLabelText(parsedEdge){
-            return String(parsedEdge[state.edgeLabelTextDataSource]);
-          },
-
-          calcSingleEdgeLabelSize(parsedEdge){
-            return parsedEdge.label_size * state.edgeLabelSizeFactor;
-          },
-
-          calcSingleNodeSizeDerivatives(shownNode){
-            // Note: Many values are calculated here once to improve the performance of node position updates
-            shownNode.size_half = shownNode.size / 2.0;
-            shownNode.size_for_hexagon_r = shownNode.size / 1.8;
-            shownNode.size_for_hexagon_rh = shownNode.size_for_hexagon_r / 2.0;
-            shownNode.size_for_hexagon_rs = shownNode.size_for_hexagon_r * 0.886;
-            shownNode.image_size = shownNode.size / 1.42 * state.nodeImageSizeFactor;
-            shownNode.image_size_half = shownNode.image_size / 2.0;
-            shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
-          },
-
-          calcSingleNodeLabelSizeDerivatives(shownNode){
-            shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
-          },
-
-          calcSingleNodeBorderSizeDerivatives(shownNode){
-            shownNode.border_size_half = shownNode.border_size / 2.0;
-          },
-
-          createNodeSizeNormalizer(){
-            let normalizer;
-            if(state.useNodeSizeNormalization){
-              const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
-                dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
-                targetMin = state.nodeSizeNormalizationMin,
-                targetMax = state.nodeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor) || factor === null){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          createEdgeSizeNormalizer(){
-            let normalizer;
-            if(state.useEdgeSizeNormalization){
-              const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
-                dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
-                targetMin = state.edgeSizeNormalizationMin,
-                targetMax = state.edgeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor)){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          updateNodeSizes(){
-            // Data
-            const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeSizes();
-          },
-
-          updateNodeLabelTexts(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-            }
-            // UI
-            ui.composites.graph.createNodeLabels();
-          },
-
-          updateNodeLabelSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-              state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.createNodeLabels();
-          },
-
-          updateNodeLabelRotations(){
-            // Performance improvement: Completely remove rotation transform if angle is 0.0
-            if(state.nodeLabelRotation === 0.0){
-              if(state.showNodeLabelBorders){
-                state.currentGraphParts.nodeLabelBackground
-                  .attr("transform", null);
-              }
-              state.currentGraphParts.nodeLabel
-                .attr("transform", null);
-            }
-            // Note: Update on every node move is required, transform uses absolute (x, y) position
-            ui.composites.graph.updateNodeLabelPositions();
-          },
-
-          updateNodeImageSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeImageSizes();
-            ui.composites.graph.updateNodeImagePositions();
-            ui.composites.graph.updateNodeLabelPlacements();
-          },
-
-          updateEdgeSizes(){
-            // Data
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-            }
-            // UI
-            ui.composites.graph.updateEdgeSizes();
-          },
-
-          updateEdgeCurvatures(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.updateEdgePositions();
-            ui.composites.graph.updateEdgeLabelPositions();
-          },
-
-          updateEdgeLabelTexts(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.createEdgeLabels();
-          },
-
-          updateEdgeLabelSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.createEdgeLabels();
-          },
-
-          updateEdgeLabelRotations(){
-            // Performance improvement: Completely remove rotation transform if angle is 0.0
-            if(state.edgeLabelRotation === 0.0){
-              if(state.showEdgeLabelBorders){
-                state.currentGraphParts.edgeLabelBackground
-                  .attr("transform", null);
-              }
-              state.currentGraphParts.edgeLabel
-                .attr("transform", null);
-            }
-            ui.composites.graph.updateEdgeLabelPositions();
-          },
-        }
-      }
-
-      const ui = {
-        symbols:{
-          // Choice of symbols is influenced by their appearance in different browsers
-          // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
-          // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
-          detailsShown: "▾",
-          detailsHidden: "▴",
-          menuShown: "▸",
-          menuHidden: "◂",
-          menuItemActive: "▸",
-          menuItemInactive: "▾",
-        },
-
-        elements:{
+        // 1) Fetch state.rawData
+        fetchRawDataFromTemplating() {
+          state.rawData = §DATA§;
+          // Data selection and normalization
+          state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
+          state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
+          state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
+          state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
+          state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
+          state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
+          state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
+          state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
+          state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
+          state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
           // Containers
-          mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
-          tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
-          leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
-          rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
-          graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
-          detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
-          detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
-          detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
-          // Data sources
-          dataHead: document.getElementById("§RANDOM_ID§-data-head"),
-          dataBody: document.getElementById("§RANDOM_ID§-data-body"),
-          graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
-          graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
-          nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
-          nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
-          nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
-          nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
-          nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
-          nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
-          nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
-          edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
-          edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
-          edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
-          edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
-          edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
-          edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
-          edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
-          // General
-          generalHead: document.getElementById("§RANDOM_ID§-general-head"),
-          generalBody: document.getElementById("§RANDOM_ID§-general-body"),
-          resetButton: document.getElementById("§RANDOM_ID§-reset"),
-          fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
-          svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
-          pngExportButton: document.getElementById("§RANDOM_ID§-png"),
-          jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+          state.graphContainerHeight = §GRAPH_HEIGHT§;
+          state.detailsContainerHeight = §DETAILS_HEIGHT§;
+          state.showDetails = §SHOW_DETAILS§,
+          state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
+          state.showMenu = §SHOW_MENU§,
+          state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+          state.useDarkMode = §USE_DARK_MODE§,
           // Nodes
-          nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
-          nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
-          nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
-          nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
-          nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
-          nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
-          nodeHoverNeighborhoodCheckbox: document.getElementById("§RANDOM_ID§-node-hover-neighborhood-checkbox"),
-          nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
-          nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
-          // Node images
-          nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
-          nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
-          nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
-          nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
-          nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
-          nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
-          // Node labels
-          nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
-          nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
-          nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
-          nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
-          nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
-          nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
-          nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
-          nodeLabelRotationText: document.getElementById("§RANDOM_ID§-node-label-rotation-text"),
-          nodeLabelRotationSlider: document.getElementById("§RANDOM_ID§-node-label-rotation-slider"),
+          state.showNodes = §SHOW_NODE§;
+          state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
+          state.nodeDragFix = §NODE_DRAG_FIX§;
+          state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
+          state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
+          state.showNodeImages = §SHOW_NODE_IMAGE§;
+          state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
+          state.showNodeLabels = §SHOW_NODE_LABEL§;
+          state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
+          state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
+          state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
+          state.nodeLabelFont = §NODE_LABEL_FONT§;
           // Edges
-          edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
-          edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
-          edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
-          edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
-          edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
-          edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
-          edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
-          edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
-          // Edge labels
-          edgeLabelHead: document.getElementById("§RANDOM_ID§-edge-label-head"),
-          edgeLabelBody: document.getElementById("§RANDOM_ID§-edge-label-body"),
-          edgeLabelCheckbox: document.getElementById("§RANDOM_ID§-edge-label-checkbox"),
-          edgeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-edge-label-border-checkbox"),
-          edgeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-label-data-source-select"),
-          edgeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-edge-label-size-factor-text"),
-          edgeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-label-size-factor-slider"),
-          edgeLabelRotationText: document.getElementById("§RANDOM_ID§-edge-label-rotation-text"),
-          edgeLabelRotationSlider: document.getElementById("§RANDOM_ID§-edge-label-rotation-slider"),
+          state.showEdges = §SHOW_EDGE§;
+          state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
+          state.edgeCurvature = §EDGE_CURVATURE§;
+          state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
+          state.showEdgeLabels = §SHOW_EDGE_LABEL§;
+          state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
+          state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
+          state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
+          state.edgeLabelFont = §EDGE_LABEL_FONT§;
           // Layout algorithm
-          layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
-          layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
-          simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
-          manyBodyForceCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-checkbox"),
-          manyBodyForceContainer: document.getElementById("§RANDOM_ID§-many-body-force-div"),
-          manyBodyForceStrengthText: document.getElementById("§RANDOM_ID§-many-body-force-strength-text"),
-          manyBodyForceStrengthSlider: document.getElementById("§RANDOM_ID§-many-body-force-strength-slider"),
-          manyBodyForceThetaText: document.getElementById("§RANDOM_ID§-many-body-force-theta-text"),
-          manyBodyForceThetaSlider: document.getElementById("§RANDOM_ID§-many-body-force-theta-slider"),
-          manyBodyForceMinDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-checkbox"),
-          manyBodyForceMinDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-div"),
-          manyBodyForceMinDistText: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-text"),
-          manyBodyForceMinDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-slider"),
-          manyBodyForceMaxDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-checkbox"),
-          manyBodyForceMaxDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-div"),
-          manyBodyForceMaxDistText: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-text"),
-          manyBodyForceMaxDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-slider"),
-          linksForceCheckbox: document.getElementById("§RANDOM_ID§-links-force-checkbox"),
-          linksForceContainer: document.getElementById("§RANDOM_ID§-links-force-div"),
-          linksForceDistanceText: document.getElementById("§RANDOM_ID§-links-force-distance-text"),
-          linksForceDistanceSlider: document.getElementById("§RANDOM_ID§-links-force-distance-slider"),
-          linksForceStrengthText: document.getElementById("§RANDOM_ID§-links-force-strength-text"),
-          linksForceStrengthSlider: document.getElementById("§RANDOM_ID§-links-force-strength-slider"),
-          collisionForceCheckbox: document.getElementById("§RANDOM_ID§-collision-force-checkbox"),
-          collisionForceContainer: document.getElementById("§RANDOM_ID§-collision-force-div"),
-          collisionForceRadiusText: document.getElementById("§RANDOM_ID§-collision-force-radius-text"),
-          collisionForceRadiusSlider: document.getElementById("§RANDOM_ID§-collision-force-radius-slider"),
-          collisionForceStrengthText: document.getElementById("§RANDOM_ID§-collision-force-strength-text"),
-          collisionForceStrengthSlider: document.getElementById("§RANDOM_ID§-collision-force-strength-slider"),
-          xPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-x-positioning-force-checkbox"),
-          xPositioningForceContainer: document.getElementById("§RANDOM_ID§-x-positioning-force-div"),
-          xPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-text"),
-          xPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-slider"),
-          yPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-y-positioning-force-checkbox"),
-          yPositioningForceContainer: document.getElementById("§RANDOM_ID§-y-positioning-force-div"),
-          yPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-text"),
-          yPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-slider"),
-          centeringForceCheckbox: document.getElementById("§RANDOM_ID§-centering-force-checkbox"),
+          state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
+          state.useManyBodyForce = §USE_MANY_BODY_FORCE§;
+          state.manyBodyForceStrength = §MANY_BODY_FORCE_STRENGTH§;
+          state.manyBodyForceTheta = §MANY_BODY_FORCE_THETA§;
+          state.useManyBodyForceMinDistance = §USE_MANY_BODY_FORCE_MIN_DISTANCE§;
+          state.manyBodyForceMinDistance = §MANY_BODY_FORCE_MIN_DISTANCE§;
+          state.useManyBodyForceMaxDistance = §USE_MANY_BODY_FORCE_MAX_DISTANCE§;
+          state.manyBodyForceMaxDistance = §MANY_BODY_FORCE_MAX_DISTANCE§;
+          state.useLinksForce = §USE_LINKS_FORCE§;
+          state.linksForceDistance = §LINKS_FORCE_DISTANCE§;
+          state.linksForceStrength = §LINKS_FORCE_STRENGTH§;
+          state.useCollisionForce = §USE_COLLISION_FORCE§;
+          state.collisionForceRadius = §COLLISION_FORCE_RADIUS§;
+          state.collisionForceStrength = §COLLISION_FORCE_STRENGTH§;
+          state.useXPositioningForce = §USE_X_POSITIONING_FORCE§;
+          state.xPositioningForceStrength = §X_POSITIONING_FORCE_STRENGTH§;
+          state.useYPositioningForce = §USE_Y_POSITIONING_FORCE§;
+          state.yPositioningForceStrength = §Y_POSITIONING_FORCE_STRENGTH§;
+          state.useCenteringForce = §USE_CENTERING_FORCE§;
+          // Other
+          state.initZoomFactor = §ZOOM_FACTOR§;
+          state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
         },
 
-        composites:{
-          responsiveContainer:{
-            init(){
-              // Delete all contained items (relevant only for reset, not first creation)
-              ui.deleteChildElements(ui.elements.graphContainer);
-              ui.deleteChildElements(ui.elements.detailsBody);
-              // Menu
-              if(state.showMenu){
-                ui.composites.menu.show();
-              } else{
-                ui.composites.menu.hide();
+        // 2) Derive state.parsedData from state.givenData
+        rawDataParser: {
+          getBool(obj, prop, def) {
+            try {
+              const value = obj[prop];
+              if (value == "true" || value == "True") {
+                value = true;
+              } else if (value == "false" || value == "False") {
+                value = false;
               }
-              // Details
-              if(state.showDetails){
-                ui.composites.details.show(true);
-              } else{
-                ui.composites.details.hide(true);
+              if (value !== true && value !== false) {
+                throw "Invalid value. Not a bool.";
               }
-              // Divs
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-              ui.composites.responsiveContainer.getInnerWidths();
-            },
-
-            getInnerWidths(){
-              state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
-              state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
-            },
-
-            getInnerHeights(){
-              state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
-              if(state.showDetails){
-                state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-              }
-            },
-
-            setInnerHeights(){
-              ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
-              ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
-            },
-
-            setOuterHeights(){
-              ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
-            },
-
-            getSizes(){
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-            },
-
-            setSizes(){
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-            },
-
-            adaptToResize(){
-              ui.composites.responsiveContainer.getSizes();
-              ui.composites.responsiveContainer.setSizes();
-            },
-
-            adaptToFullscreen(){
-              ui.composites.responsiveContainer.getSizes();
-              if(document.fullscreenElement){
-                // On entering fullscreen, remember the current container heights
-                state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
-                state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
-                // and then adapt them to maximum height possible in full screen mode
-                function calculateFullscreenMaxGraphHeight(){
-                  let outerHeight = null;
-                  try{
-                    const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
-                      graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                      paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
-                      borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
-                      borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
-                      paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
-                    outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
-                    if(!isFinite(outerHeight) || outerHeight === null){
-                      throw "Invalid number";
-                    }
-                  } catch(e){
-                    // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
-                    outerHeight = 1 + 3 + 3 + 1;
-                  }
-                  let graphHeight = screen.height - outerHeight;
-                  if(state.showDetails){
-                    graphHeight -= ui.composites.details.calculateHeightDifference();
-                  }
-                  return graphHeight;
-                }
-                state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
-              } else{
-                // On leaving fullscreen, set container heights back to remembered values
-                state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
-                state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
-              }
-              ui.composites.responsiveContainer.setSizes();
-            },
+              return value;
+            } catch (e) {
+              return def;
+            }
+            return def
           },
 
-          menu:{
-            show(){
-              ui.elements.leftContainer.style.width = "80%";
-              ui.elements.rightContainer.style.width = "20%";
-              ui.elements.rightContainer.style.display = "block";
-            },
-
-            hide(){
-              ui.elements.leftContainer.style.width = "100%";
-              ui.elements.rightContainer.style.width = "0%";
-              ui.elements.rightContainer.style.display = "none";
-            },
-
-            toggle(){
-              // Update menu button
-              const div = ui.elements.menuToggleDiv;
-              state.showMenu = !state.showMenu;
-              if(state.showMenu){
-                div.innerText = ui.symbols.menuShown;
-                ui.composites.menu.show();
-              } else {
-                div.innerHTML = ui.symbols.menuHidden;
-                ui.composites.menu.hide();
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
               }
+              return value;
+            } catch (e) {
+              return def;
+            }
+            return def;
+          },
 
+          getArrayLengthOrZero(array) {
+            try {
+              const value = parseInt(array.length);
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
+              }
+              return value;
+            } catch (e) {
+              return 0;
+            }
+          },
+
+          getObjectLengthOrZero(obj) {
+            try {
+              const value = Object.keys(obj).length;
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
+              }
+              return value;
+            } catch (e) {
+              return 0;
+            }
+          },
+
+          createUniqueEdgeId(sourceId, targetId, knownEdgeIds) {
+            let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
+              newEdgeId = newEdgeIdBase,
+              multiEdgeCounter = 1;
+            for (let i = 2; knownEdgeIds.has(newEdgeId); i++) {
+              newEdgeId = newEdgeIdBase + "_" + String(i);
+              multiEdgeCounter += 1;
+            }
+            knownEdgeIds.add(newEdgeId);
+            return { "id": newEdgeId, "count": multiEdgeCounter }
+          },
+        },
+
+        rawMetadataParser: {
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj.metadata[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getColor(obj, prop, def) {
+            function isBodyidColor(strColor) {
+              const sty = new Option().style;
+              sty.color = strColor;
+              return sty.color !== "";
+            }
+            try {
+              const value = obj.metadata[prop];
+              if (!isBodyidColor(value)) {
+                throw "Invalid value. Not a color."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null) {
+                throw "Invalid value. Not a finite number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumberOrNull(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value)) {  // Note: isFinite(null) gives true
+                throw "Invalid value. Not a finite number or null."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFinitePositiveNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null || value < 0.0) {
+                throw "Invalid value. Not a finite positive number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          collectOtherMetadata(sourceObject, targetObject, definedMetadata) {
+            if (typeof (sourceObject) !== "undefined" && typeof (sourceObject.metadata) !== "undefined") {
+              const properties = Object.keys(sourceObject.metadata);
+              for (let i = 0; i < properties.length; i++) {
+                const property = properties[i];
+                if (!definedMetadata.has(property)) {
+                  targetObject[property] = sourceObject.metadata[property];
+                }
+              }
+            }
+          },
+        },
+
+        propertyClassifier: {
+          numeric: null,
+          nonNumeric: null,
+          init() {
+            this.numeric = new Set(),
+              this.nonNumeric = new Set();
+          },
+          isNumeric(d) {
+            return d === null || typeof (d) === "undefined" || String(parseFloat(d)) === String(d);
+          },
+          inspect(object, property) {
+            const value = object[property];
+            if (!this.nonNumeric.has(property)) {
+              if (this.isNumeric(value)) {
+                this.numeric.add(property);
+              } else {
+                this.nonNumeric.add(property);
+                this.numeric.delete(property);
+              }
+            }
+          }
+        },
+
+        replaceStringVariables(givenString, givenItem, variables) {
+          let newString = givenString;
+          for (let i = 0; i < variables.length; i++) {
+            let variable = variables[i],
+              variableText = "$" + variable;
+            if (variable === "x") {
+              variable = "fx";
+            } else if (variable === "y") {
+              variable = "fy";
+            }
+            let insertedText = String(givenItem[variable]);
+            if (insertedText === "undefined") {
+              insertedText = "";
+            }
+            newString = newString.replace(variableText, insertedText);
+          }
+          return newString;
+        },
+
+        parseGeneral(givenData, parsedData) {
+          const generalDefaults = state.useDarkMode ? {
+            background_color: "#1f1f25",
+            arrow_color: "#7ddba3",
+            node_color: "#7ddba3",
+            node_border_color: "#f0f0f5",
+            node_label_color: "#f0f0f5",
+            edge_color: "#b5b8c5",
+            edge_label_color: "#f0f0f5",
+          } : {
+            background_color: "white",
+            arrow_color: "black",
+            node_color: "black",
+            node_border_color: "black",
+            node_label_color: "black",
+            edge_color: "black",
+            edge_label_color: "black",
+          };
+          parsedData.general = {
+            // General
+            directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
+            label: state.manager.rawDataParser.getString(givenData, "label", ""),
+            background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+            arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
+            arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
+            // Nodes
+            node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
+            node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
+            node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
+            node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
+            node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
+            node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
+            node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
+            node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
+            node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
+            node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
+            node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
+            node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
+            node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
+            contains_node_hover: false,
+            contains_node_click: false,
+            contains_node_image: false,
+            // Edges
+            edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
+            edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
+            edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
+            edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
+            edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
+            edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
+            edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
+            contains_edge_hover: false,
+            contains_edge_click: false,
+          };
+          if (!parsedData.general.directed) {
+            parsedData.general.arrow_size = 0.0;
+          }
+        },
+
+        parseNodes(givenData, parsedData) {
+          const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
+            nodeIdToObjectMap = new Map(),
+            nodeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "shape", "border_color", "border_size",
+                "label_color", "label_size", "hover", "click", "image", "x", "y"]),
+            nodeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "shape", "border_color", "border_size",
+              "label_color", "label_size", "image", "x", "y"];
+          state.manager.propertyClassifier.init();
+          try {
+            Object.entries(givenData.nodes);
+          }
+          catch (e) {
+            givenData.nodes = {};
+          }
+          for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
+            const parsedNode = {};
+            // data: id, label
+            parsedNode.id = String(givenNodeId);
+            parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
+            // defined metadata
+            parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
+            parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
+            parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
+            parsedNode.shape = state.manager.rawMetadataParser.getString(givenNode, "shape", parsedData.general.node_shape);
+            parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
+            parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
+            parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
+            parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
+            const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
+            if (image !== "") {
+              parsedNode.image = image;
+              parsedData.general.contains_node_image = true;
+            }
+            if (hover !== "") {
+              parsedNode.hover = hover;
+              parsedData.general.contains_node_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
+            if (click !== "") {
+              parsedNode.click = click;
+              parsedData.general.contains_node_click = true;
+            }
+            const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
+            const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
+            if (x !== null) {
+              parsedNode.fx = x;
+            }
+            if (y !== null) {
+              parsedNode.fy = y;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
+            // feature classification
+            const parsedNodeProperties = Object.keys(parsedNode);
+            for (let i = 0; i < parsedNodeProperties.length; i++) {
+              const property = parsedNodeProperties[i],
+                value = parsedNode[property];
+              state.manager.propertyClassifier.inspect(parsedNode, property);
+            }
+            // variable replacements
+            if (parsedNode.hover) {
+              parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
+            }
+            if (parsedNode.click) {
+              parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
+            }
+            // store the parsed node
+            parsedData.nodes.push(parsedNode);
+            // data structure for inserting node object references into edge data
+            nodeIdToObjectMap.set(parsedNode.id, parsedNode);
+          }
+          // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          for (let i = 0; i < numNodes; i++) {
+            const parsedNode = parsedData.nodes[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedNode[property]);
+              parsedNode[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
+                }
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.node_properties = {
+            "node_size_data_sources": numericProperties,
+            "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report empty graph
+          if (!(numNodes > 0)) {
+            console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
+          }
+          return nodeIdToObjectMap;
+        },
+
+        parseEdges(givenData, parsedData, nodeIdToObjectMap) {
+          let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
+          const knownEdgeIds = new Set(),
+            ignoredEdges = [],
+            edgeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
+            edgeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "label_color", "label_size"];
+          state.manager.propertyClassifier.init();
+          for (let i = 0; i < numEdges; i++) {
+            const givenEdge = givenData.edges[i],
+              parsedEdge = {},
+              sourceId = String(givenEdge.source),
+              targetId = String(givenEdge.target);
+            // data: source, target, id, multi_edge_counter, label
+            try {
+              const sourceObj = nodeIdToObjectMap.get(sourceId);
+              const targetObj = nodeIdToObjectMap.get(targetId);
+              if (typeof (sourceObj) === "undefined" || typeof (targetObj) === "undefined") {
+                throw "Invalid node reference.";
+              }
+              parsedEdge.source = sourceObj;
+              parsedEdge.target = targetObj;
+            } catch (e) {
+              const ignoredEdge = {
+                index: i,
+                source: sourceId,
+                target: targetId,
+              }
+              ignoredEdges.push(ignoredEdge);
+              continue;
+            }
+            const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
+            parsedEdge.id = result.id;
+            parsedEdge.multi_edge_counter = result.count;
+            parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
+            // defined metadata
+            parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
+            parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
+            parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
+            parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
+            parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
+            if (hover !== "") {
+              parsedEdge.hover = hover;
+              parsedData.general.contains_edge_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
+            if (click !== "") {
+              parsedEdge.click = click;
+              parsedData.general.contains_edge_click = true;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
+            // feature classification
+            const parsedEdgeProperties = Object.keys(parsedEdge);
+            for (let i = 0; i < parsedEdgeProperties.length; i++) {
+              const property = parsedEdgeProperties[i],
+                value = parsedEdge[property];
+              state.manager.propertyClassifier.inspect(parsedEdge, property);
+            }
+            // variable replacements
+            if (parsedEdge.hover) {
+              parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
+            }
+            if (parsedEdge.click) {
+              parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
+            }
+            // store it
+            parsedData.edges.push(parsedEdge);
+          }
+          // Ensure numeric properties are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges)
+          for (let i = 0; i < numEdges; i++) {
+            const parsedEdge = parsedData.edges[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedEdge[property]);
+              parsedEdge[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
+                }
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.edge_properties = {
+            "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
+            "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
+              item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report invalid edges
+          if (ignoredEdges.length > 0) {
+            let message = undefined;
+            if (ignoredEdges.length == 1) {
+              message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
+                "refers to a node that is not part of the node list:\n";
+            } else {
+              message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
+                "refer to a node that is not part of the node list:\n";
+            }
+            for (let i = 0; i < ignoredEdges.length; i++) {
+              const ignoredEdge = ignoredEdges[i];
+              message += '- Edge with index ' + ignoredEdge.index;
+              message += ', source "' + ignoredEdge.source;
+              message += '", target "' + ignoredEdge.target + '"\n';
+              if (i == 9) {
+                message += '...';
+                break;
+              }
+            }
+            console.log(message);
+          }
+        },
+
+        parseChosenData(chosenGraphNumber) {
+          let givenData = state.rawData[chosenGraphNumber],
+            parsedData = {
+              general: {},
+              nodes: [],
+              edges: [],
+              adjacency: null,
+              incidence: null,
+            };
+          if (!givenData || givenData === null) {
+            givenData = [];
+          }
+          // a) General
+          state.manager.parseGeneral(givenData, parsedData);
+          // b) Nodes
+          const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
+          // c) Edges
+          state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
+          // Update state
+          state.parsedData = parsedData;
+          state.currentGraphParts = {};
+          // Update UI: show or hide containers
+          ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
+          ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
+        },
+
+        // 3) Derive state.shownData from state.parsedData
+        createNodeToAdjacentNodesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(sourceNode, targetNode) {
+              let adjacentNodes = this.map.get(sourceNode);
+              if (adjacentNodes) {
+                adjacentNodes.add(targetNode);
+              } else {
+                adjacentNodes = new Set([targetNode]);
+                this.map.set(sourceNode, adjacentNodes);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        createNodeToIncidentEdgesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(node, edge) {
+              let incidentEdges = this.map.get(node);
+              if (incidentEdges) {
+                incidentEdges.add(edge);
+              } else {
+                incidentEdges = new Set([edge]);
+                this.map.set(node, incidentEdges);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        prepareShownData() {
+          const numNodes = state.parsedData.nodes.length,
+            numEdges = state.parsedData.edges.length;
+          state.shownData = {
+            "general": null,
+            "nodes": new Array(numNodes),
+            "edges": new Array(numEdges),
+          }
+          const nodeIdToObjectMap = new Map(),
+            nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          // a) General
+          state.shownData.general = {
+            "background_color": state.parsedData.general.background_color,
+            "arrow_size": state.parsedData.general.arrow_size,
+            "arrow_color": state.parsedData.general.arrow_color,
+            "directed": state.parsedData.general.directed,
+            "node_image_fetching_failed": false,
+          };
+          // b) Nodes
+          for (let i = 0; i < numNodes; i++) {
+            state.shownData.nodes[i] = {};
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.id = parsedNode.id;
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+            shownNode.color = parsedNode.color;
+            shownNode.opacity = parsedNode.opacity;
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            shownNode.shape = parsedNode.shape;
+            shownNode.border_color = parsedNode.border_color;
+            shownNode.border_size = parsedNode.border_size;
+            shownNode.label_color = parsedNode.label_color;
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+            if (typeof (parsedNode.image) !== "undefined") {
+              shownNode.image = parsedNode.image;
+            }
+            if (typeof (parsedNode.hover) !== "undefined") {
+              shownNode.hover = parsedNode.hover;
+            }
+            if (typeof (parsedNode.click) !== "undefined") {
+              shownNode.click = parsedNode.click;
+            }
+            if (typeof (parsedNode.fx) !== "undefined") {
+              shownNode.fx = parsedNode.fx;
+            }
+            if (typeof (parsedNode.fy) !== "undefined") {
+              shownNode.fy = parsedNode.fy;
+            }
+            nodeIdToObjectMap.set(shownNode.id, shownNode);
+            // Derived properties for performance improvement in updateNodePositions
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+            state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
+            state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
+          }
+          // c) Edges
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
+            nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
+            nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
+          for (let i = 0; i < numEdges; i++) {
+            state.shownData.edges[i] = {};
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
+            shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
+            shownEdge.id = parsedEdge.id;
+            shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
+            shownEdge.color = parsedEdge.color;
+            shownEdge.opacity = parsedEdge.opacity;
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+            shownEdge.label_color = parsedEdge.label_color;
+            shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
+            shownEdge.multi_edge_counter = parsedEdge.multi_edge_counter;
+            if (typeof (parsedEdge.hover) !== "undefined") {
+              shownEdge.hover = parsedEdge.hover;
+            }
+            if (typeof (parsedEdge.click) !== "undefined") {
+              shownEdge.click = parsedEdge.click;
+            }
+            // Derived properties for performance improvement in updateEdgePositions
+            shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+            // Data structure for highlighting adjacent nodes and incident edges to this node
+            nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
+            nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
+            nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
+            nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
+          }
+          state.shownData.adjacency = nodeToAdjacentNodesMap;
+          state.shownData.incidence = nodeToIncidentEdgesMap;
+        },
+
+        calcSingleNodeSize(parsedNode, nodeSizeNormalizer) {
+          let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
+          if (!isFinite(nodeSize)) {
+            nodeSize = state.parsedData.general.node_size;
+          }
+          return nodeSize * state.nodeSizeFactor;
+        },
+
+        calcSingleNodeLabelText(parsedNode) {
+          return String(parsedNode[state.nodeLabelTextDataSource]);
+        },
+
+        calcSingleNodeLabelSize(parsedNode) {
+          return parsedNode.label_size * state.nodeLabelSizeFactor;
+        },
+
+        calcSingleNodeLabelPlacement(node) {
+          let baseSize = node.size_half;
+          if (state.showNodeImages && typeof (node.image) !== "undefined") {
+            baseSize = (node.size_half > node.image_size_half) ? node.size_half : node.image_size_half;
+          }
+          return baseSize + node.label_size * 0.77 + 2.0;
+        },
+
+        calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer) {
+          let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
+          if (!isFinite(edgeSize)) {
+            edgeSize = state.parsedData.general.edge_size;
+          }
+          return edgeSize * state.edgeSizeFactor;
+        },
+
+        calcSingleEdgeCurvatureFactor(parsedEdge) {
+          return state.edgeCurvature * parsedEdge.multi_edge_counter;
+        },
+
+        calcSingleEdgeLabelText(parsedEdge) {
+          return String(parsedEdge[state.edgeLabelTextDataSource]);
+        },
+
+        calcSingleEdgeLabelSize(parsedEdge) {
+          return parsedEdge.label_size * state.edgeLabelSizeFactor;
+        },
+
+        calcSingleNodeSizeDerivatives(shownNode) {
+          // Note: Many values are calculated here once to improve the performance of node position updates
+          shownNode.size_half = shownNode.size / 2.0;
+          shownNode.size_for_hexagon_r = shownNode.size / 1.8;
+          shownNode.size_for_hexagon_rh = shownNode.size_for_hexagon_r / 2.0;
+          shownNode.size_for_hexagon_rs = shownNode.size_for_hexagon_r * 0.886;
+          shownNode.image_size = shownNode.size / 1.42 * state.nodeImageSizeFactor;
+          shownNode.image_size_half = shownNode.image_size / 2.0;
+          shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
+        },
+
+        calcSingleNodeLabelSizeDerivatives(shownNode) {
+          shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
+        },
+
+        calcSingleNodeBorderSizeDerivatives(shownNode) {
+          shownNode.border_size_half = shownNode.border_size / 2.0;
+        },
+
+        createNodeSizeNormalizer() {
+          let normalizer;
+          if (state.useNodeSizeNormalization) {
+            const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
+              dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
+              targetMin = state.nodeSizeNormalizationMin,
+              targetMax = state.nodeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor) || factor === null) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        createEdgeSizeNormalizer() {
+          let normalizer;
+          if (state.useEdgeSizeNormalization) {
+            const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
+              dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
+              targetMin = state.edgeSizeNormalizationMin,
+              targetMax = state.edgeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor)) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        updateNodeSizes() {
+          // Data
+          const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeSizes();
+        },
+
+        updateNodeLabelTexts() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+          }
+          // UI
+          ui.composites.graph.createNodeLabels();
+        },
+
+        updateNodeLabelSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+            state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.createNodeLabels();
+        },
+
+        updateNodeLabelRotations() {
+          // Performance improvement: Completely remove rotation transform if angle is 0.0
+          if (state.nodeLabelRotation === 0.0) {
+            if (state.showNodeLabelBorders) {
+              state.currentGraphParts.nodeLabelBackground
+                .attr("transform", null);
+            }
+            state.currentGraphParts.nodeLabel
+              .attr("transform", null);
+          }
+          // Note: Update on every node move is required, transform uses absolute (x, y) position
+          ui.composites.graph.updateNodeLabelPositions();
+        },
+
+        updateNodeImageSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeImageSizes();
+          ui.composites.graph.updateNodeImagePositions();
+          ui.composites.graph.updateNodeLabelPlacements();
+        },
+
+        updateEdgeSizes() {
+          // Data
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+          }
+          // UI
+          ui.composites.graph.updateEdgeSizes();
+        },
+
+        updateEdgeCurvatures() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.updateEdgePositions();
+          ui.composites.graph.updateEdgeLabelPositions();
+        },
+
+        updateEdgeLabelTexts() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.createEdgeLabels();
+        },
+
+        updateEdgeLabelSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.createEdgeLabels();
+        },
+
+        updateEdgeLabelRotations() {
+          // Performance improvement: Completely remove rotation transform if angle is 0.0
+          if (state.edgeLabelRotation === 0.0) {
+            if (state.showEdgeLabelBorders) {
+              state.currentGraphParts.edgeLabelBackground
+                .attr("transform", null);
+            }
+            state.currentGraphParts.edgeLabel
+              .attr("transform", null);
+          }
+          ui.composites.graph.updateEdgeLabelPositions();
+        },
+      }
+    }
+
+    const ui = {
+      symbols: {
+        // Choice of symbols is influenced by their appearance in different browsers
+        // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
+        // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
+        detailsShown: "▾",
+        detailsHidden: "▴",
+        menuShown: "▸",
+        menuHidden: "◂",
+        menuItemActive: "▸",
+        menuItemInactive: "▾",
+      },
+
+      elements: {
+        // Containers
+        mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
+        tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
+        leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
+        rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
+        graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
+        detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
+        detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
+        detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
+        // Data sources
+        dataHead: document.getElementById("§RANDOM_ID§-data-head"),
+        dataBody: document.getElementById("§RANDOM_ID§-data-body"),
+        graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
+        graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
+        nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
+        nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
+        nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
+        nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
+        nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
+        nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
+        nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
+        edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
+        edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
+        edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
+        edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
+        edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
+        edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
+        edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
+        // General
+        generalHead: document.getElementById("§RANDOM_ID§-general-head"),
+        generalBody: document.getElementById("§RANDOM_ID§-general-body"),
+        resetButton: document.getElementById("§RANDOM_ID§-reset"),
+        fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
+        svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
+        pngExportButton: document.getElementById("§RANDOM_ID§-png"),
+        jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+        // Nodes
+        nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
+        nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
+        nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
+        nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
+        nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
+        nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
+        nodeHoverNeighborhoodCheckbox: document.getElementById("§RANDOM_ID§-node-hover-neighborhood-checkbox"),
+        nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
+        nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
+        // Node images
+        nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
+        nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
+        nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
+        nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
+        nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
+        nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
+        // Node labels
+        nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
+        nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
+        nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
+        nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
+        nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
+        nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
+        nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
+        nodeLabelRotationText: document.getElementById("§RANDOM_ID§-node-label-rotation-text"),
+        nodeLabelRotationSlider: document.getElementById("§RANDOM_ID§-node-label-rotation-slider"),
+        // Edges
+        edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
+        edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
+        edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
+        edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
+        edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
+        edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
+        edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
+        edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
+        // Edge labels
+        edgeLabelHead: document.getElementById("§RANDOM_ID§-edge-label-head"),
+        edgeLabelBody: document.getElementById("§RANDOM_ID§-edge-label-body"),
+        edgeLabelCheckbox: document.getElementById("§RANDOM_ID§-edge-label-checkbox"),
+        edgeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-edge-label-border-checkbox"),
+        edgeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-label-data-source-select"),
+        edgeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-edge-label-size-factor-text"),
+        edgeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-label-size-factor-slider"),
+        edgeLabelRotationText: document.getElementById("§RANDOM_ID§-edge-label-rotation-text"),
+        edgeLabelRotationSlider: document.getElementById("§RANDOM_ID§-edge-label-rotation-slider"),
+        // Layout algorithm
+        layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
+        layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
+        simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
+        manyBodyForceCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-checkbox"),
+        manyBodyForceContainer: document.getElementById("§RANDOM_ID§-many-body-force-div"),
+        manyBodyForceStrengthText: document.getElementById("§RANDOM_ID§-many-body-force-strength-text"),
+        manyBodyForceStrengthSlider: document.getElementById("§RANDOM_ID§-many-body-force-strength-slider"),
+        manyBodyForceThetaText: document.getElementById("§RANDOM_ID§-many-body-force-theta-text"),
+        manyBodyForceThetaSlider: document.getElementById("§RANDOM_ID§-many-body-force-theta-slider"),
+        manyBodyForceMinDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-checkbox"),
+        manyBodyForceMinDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-div"),
+        manyBodyForceMinDistText: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-text"),
+        manyBodyForceMinDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-slider"),
+        manyBodyForceMaxDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-checkbox"),
+        manyBodyForceMaxDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-div"),
+        manyBodyForceMaxDistText: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-text"),
+        manyBodyForceMaxDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-slider"),
+        linksForceCheckbox: document.getElementById("§RANDOM_ID§-links-force-checkbox"),
+        linksForceContainer: document.getElementById("§RANDOM_ID§-links-force-div"),
+        linksForceDistanceText: document.getElementById("§RANDOM_ID§-links-force-distance-text"),
+        linksForceDistanceSlider: document.getElementById("§RANDOM_ID§-links-force-distance-slider"),
+        linksForceStrengthText: document.getElementById("§RANDOM_ID§-links-force-strength-text"),
+        linksForceStrengthSlider: document.getElementById("§RANDOM_ID§-links-force-strength-slider"),
+        collisionForceCheckbox: document.getElementById("§RANDOM_ID§-collision-force-checkbox"),
+        collisionForceContainer: document.getElementById("§RANDOM_ID§-collision-force-div"),
+        collisionForceRadiusText: document.getElementById("§RANDOM_ID§-collision-force-radius-text"),
+        collisionForceRadiusSlider: document.getElementById("§RANDOM_ID§-collision-force-radius-slider"),
+        collisionForceStrengthText: document.getElementById("§RANDOM_ID§-collision-force-strength-text"),
+        collisionForceStrengthSlider: document.getElementById("§RANDOM_ID§-collision-force-strength-slider"),
+        xPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-x-positioning-force-checkbox"),
+        xPositioningForceContainer: document.getElementById("§RANDOM_ID§-x-positioning-force-div"),
+        xPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-text"),
+        xPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-slider"),
+        yPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-y-positioning-force-checkbox"),
+        yPositioningForceContainer: document.getElementById("§RANDOM_ID§-y-positioning-force-div"),
+        yPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-text"),
+        yPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-slider"),
+        centeringForceCheckbox: document.getElementById("§RANDOM_ID§-centering-force-checkbox"),
+      },
+
+      composites: {
+        responsiveContainer: {
+          init() {
+            // Delete all contained items (relevant only for reset, not first creation)
+            ui.deleteChildElements(ui.elements.graphContainer);
+            ui.deleteChildElements(ui.elements.detailsBody);
+            // Menu
+            if (state.showMenu) {
+              ui.composites.menu.show();
+            } else {
+              ui.composites.menu.hide();
+            }
+            // Details
+            if (state.showDetails) {
+              ui.composites.details.show(true);
+            } else {
+              ui.composites.details.hide(true);
+            }
+            // Divs
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.responsiveContainer.getInnerWidths();
+          },
+
+          getInnerWidths() {
+            state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
+            state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
+          },
+
+          getInnerHeights() {
+            state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
+            if (state.showDetails) {
+              state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+            }
+          },
+
+          setInnerHeights() {
+            ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
+            ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
+          },
+
+          setOuterHeights() {
+            ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
+          },
+
+          getSizes() {
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+          },
+
+          setSizes() {
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+          },
+
+          adaptToResize() {
+            ui.composites.responsiveContainer.getSizes();
+            ui.composites.responsiveContainer.setSizes();
+          },
+
+          adaptToFullscreen() {
+            ui.composites.responsiveContainer.getSizes();
+            if (document.fullscreenElement) {
+              // On entering fullscreen, remember the current container heights
+              state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
+              state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
+              // and then adapt them to maximum height possible in full screen mode
+              function calculateFullscreenMaxGraphHeight() {
+                let outerHeight = null;
+                try {
+                  const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
+                    graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                    paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
+                    borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
+                    borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
+                    paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
+                  outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
+                  if (!isFinite(outerHeight) || outerHeight === null) {
+                    throw "Invalid number";
+                  }
+                } catch (e) {
+                  // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
+                  outerHeight = 1 + 3 + 3 + 1;
+                }
+                let graphHeight = screen.height - outerHeight;
+                if (state.showDetails) {
+                  graphHeight -= ui.composites.details.calculateHeightDifference();
+                }
+                return graphHeight;
+              }
+              state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
+            } else {
+              // On leaving fullscreen, set container heights back to remembered values
+              state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
+              state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
+            }
+            ui.composites.responsiveContainer.setSizes();
+          },
+        },
+
+        menu: {
+          show() {
+            ui.elements.leftContainer.style.width = "80%";
+            ui.elements.rightContainer.style.width = "20%";
+            ui.elements.rightContainer.style.display = "block";
+          },
+
+          hide() {
+            ui.elements.leftContainer.style.width = "100%";
+            ui.elements.rightContainer.style.width = "0%";
+            ui.elements.rightContainer.style.display = "none";
+          },
+
+          toggle() {
+            // Update menu button
+            const div = ui.elements.menuToggleDiv;
+            state.showMenu = !state.showMenu;
+            if (state.showMenu) {
+              div.innerText = ui.symbols.menuShown;
+              ui.composites.menu.show();
+            } else {
+              div.innerHTML = ui.symbols.menuHidden;
+              ui.composites.menu.hide();
+            }
+
+            // Update rest of UI
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.graph.updateGraphDrawingArea();
+          },
+
+          setItem(keyElement, valElement, toActive) {
+            const currentText = keyElement.innerHTML;
+            let sliceStart = 0;
+            if (currentText.startsWith(ui.symbols.menuItemActive)) {
+              sliceStart = ui.symbols.menuItemActive.length;
+            } else if (currentText.startsWith(ui.symbols.menuItemInactive)) {
+              sliceStart = ui.symbols.menuItemInactive.length;
+            }
+            if (toActive) {
+              keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
+              keyElement.classList.add("§RANDOM_ID§-active");
+              valElement.style.display = "block";
+            } else {
+              keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
+              keyElement.classList.remove("§RANDOM_ID§-active");
+              valElement.style.display = "none";
+            }
+          },
+
+          toggleItem(keyElement, valElement) {
+            const toActive = !(valElement.style.display !== "none");
+            ui.composites.menu.setItem(keyElement, valElement, toActive);
+          },
+        },
+
+        details: {
+          calculateHeightDifference() {
+            let outerHeight = null;
+            try {
+              const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
+                border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
+                margin = parseFloat(detailsContainerComputedStyle.marginTop),
+                border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
+              outerHeight = border1 + margin + border2;
+              if (!isFinite(outerHeight) || outerHeight === null) {
+                throw "Invalid number";
+              }
+            } catch (e) {
+              // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
+              outerHeight = 7.0;
+            }
+            return state.detailsContainerHeight + outerHeight
+          },
+
+          show(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "block";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight -= heightDiff;
+              if (state.graphContainerHeight < 70) {
+                state.graphContainerHeight = 70;
+              }
               // Update rest of UI
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
+              ui.composites.responsiveContainer.setSizes();
               ui.composites.graph.updateGraphDrawingArea();
-            },
-
-            setItem(keyElement, valElement, toActive){
-              const currentText = keyElement.innerHTML;
-              let sliceStart = 0;
-              if(currentText.startsWith(ui.symbols.menuItemActive)){
-                sliceStart = ui.symbols.menuItemActive.length;
-              } else if (currentText.startsWith(ui.symbols.menuItemInactive)){
-                sliceStart = ui.symbols.menuItemInactive.length;
-              }
-              if(toActive){
-                keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.classList.add("§RANDOM_ID§-active");
-                valElement.style.display = "block";
-              } else {
-                keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.classList.remove("§RANDOM_ID§-active");
-                valElement.style.display = "none";
-              }
-            },
-
-            toggleItem(keyElement, valElement){
-              const toActive = !(valElement.style.display !== "none");
-              ui.composites.menu.setItem(keyElement, valElement, toActive);
-            },
+            }
           },
 
-          details:{
-            calculateHeightDifference(){
-              let outerHeight = null;
-              try{
-                const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                  detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
-                  border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
-                  margin = parseFloat(detailsContainerComputedStyle.marginTop),
-                  border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
-                outerHeight = border1 + margin + border2;
-                if(!isFinite(outerHeight) || outerHeight === null){
-                  throw "Invalid number";
-                }
-              } catch(e){
-                // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
-                outerHeight = 7.0;
-              }
-              return state.detailsContainerHeight + outerHeight
-            },
-
-            show(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "block";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight -= heightDiff;
-                if(state.graphContainerHeight < 70){
-                  state.graphContainerHeight = 70;
-                }
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            hide(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "none";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight += heightDiff;
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            toggle(){
-              // Update details button
-              const toggleDiv = ui.elements.detailsToggleDiv;
-              state.showDetails = !state.showDetails;
-              if(state.showDetails){
-                toggleDiv.innerText = ui.symbols.detailsShown;
-                ui.composites.details.show();
-              } else {
-                toggleDiv.innerHTML = ui.symbols.detailsHidden;
-                ui.composites.details.hide();
-              }
-            },
+          hide(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "none";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight += heightDiff;
+              // Update rest of UI
+              ui.composites.responsiveContainer.setSizes();
+              ui.composites.graph.updateGraphDrawingArea();
+            }
           },
 
-          download:{
-            png(filename){
-              ui.composites.download._rasterImage(filename, "png");
-            },
+          toggle() {
+            // Update details button
+            const toggleDiv = ui.elements.detailsToggleDiv;
+            state.showDetails = !state.showDetails;
+            if (state.showDetails) {
+              toggleDiv.innerText = ui.symbols.detailsShown;
+              ui.composites.details.show();
+            } else {
+              toggleDiv.innerHTML = ui.symbols.detailsHidden;
+              ui.composites.details.hide();
+            }
+          },
+        },
 
-            jpg(filename){
-              ui.composites.download._rasterImage(filename, "jpeg");
-            },
+        download: {
+          png(filename) {
+            ui.composites.download._rasterImage(filename, "png");
+          },
 
-            svg(filename){
-              if(state.shownData.general.node_image_fetching_failed){
-                ui.composites.download._warnAboutMissingImage();
+          jpg(filename) {
+            ui.composites.download._rasterImage(filename, "jpeg");
+          },
+
+          svg(filename) {
+            if (state.shownData.general.node_image_fetching_failed) {
+              ui.composites.download._warnAboutMissingImage();
+            }
+            const svgText = ui.composites.download._getSvgText();
+            // Blob to overcome size limitations for data URLs (e.g. 4MB in Chrome)
+            const mimeType = "image/svg+xml",
+              blob = new Blob([svgText], { type: mimeType });
+            ui.composites.download._blobToFileDownload(blob, filename);
+          },
+
+          _getSvgText() {
+            const svgElement = ui.elements.graphContainer.getElementsByTagName("svg")[0];
+            let svgText = svgElement.outerHTML;
+            if (!svgText.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)) {
+              svgText = svgText.replace(/^<svg/, '<svg xmlns="http://www.w3.org/2000/svg"');
+            }
+            if (!svgText.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
+              svgText = svgText.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"');
+            }
+            svgText = '<?xml version="1.0" standalone="no"?>\r\n' + svgText;
+            return svgText;
+          },
+
+          _getSvgDataUrl() {
+            const svgText = ui.composites.download._getSvgText();
+            return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgText);
+          },
+
+          _rasterImage(filename, format, resolutionFactor = 5.0) {
+            if (state.shownData.general.node_image_fetching_failed) {
+              ui.composites.download._warnAboutMissingImage();
+            }
+            const svg = ui.elements.graphContainer.getElementsByTagName("svg")[0],
+              width = svg.getAttribute("width"),
+              height = svg.getAttribute("height"),
+              image = new Image;
+            image.src = ui.composites.download._getSvgDataUrl();
+            image.onload = function () {
+              const canvas = document.createElement("canvas");
+              canvas.setAttribute("width", width * resolutionFactor);
+              canvas.setAttribute("height", height * resolutionFactor);
+              const context = canvas.getContext("2d");
+              context.drawImage(image, 0, 0, width * resolutionFactor, height * resolutionFactor);
+              const mimeType = "image/" + format;
+              function finishedBlobCallback(blob) {
+                ui.composites.download._blobToFileDownload(blob, filename);
               }
-              const svgText = ui.composites.download._getSvgText();
               // Blob to overcome size limitations for data URLs (e.g. 4MB in Chrome)
-              const mimeType = "image/svg+xml",
-                blob = new Blob([svgText], {type: mimeType});
-              ui.composites.download._blobToFileDownload(blob, filename);
-            },
-
-            _getSvgText(){
-              const svgElement = ui.elements.graphContainer.getElementsByTagName("svg")[0];
-              let svgText = svgElement.outerHTML;
-              if(!svgText.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)){
-                svgText = svgText.replace(/^<svg/, '<svg xmlns="http://www.w3.org/2000/svg"');
-              }
-              if(!svgText.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)){
-                svgText = svgText.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"');
-              }
-              svgText = '<?xml version="1.0" standalone="no"?>\r\n' + svgText;
-              return svgText;
-            },
-
-            _getSvgDataUrl(){
-              const svgText = ui.composites.download._getSvgText();
-              return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgText);
-            },
-
-            _rasterImage(filename, format, resolutionFactor=5.0){
-              if(state.shownData.general.node_image_fetching_failed){
-                ui.composites.download._warnAboutMissingImage();
-              }
-              const svg = ui.elements.graphContainer.getElementsByTagName("svg")[0],
-                width = svg.getAttribute("width"),
-                height = svg.getAttribute("height"),
-                image = new Image;
-              image.src = ui.composites.download._getSvgDataUrl();
-              image.onload = function(){
-                const canvas = document.createElement("canvas");
-                canvas.setAttribute("width", width*resolutionFactor);
-                canvas.setAttribute("height", height*resolutionFactor);
-                const context = canvas.getContext("2d");
-                context.drawImage(image, 0, 0, width*resolutionFactor, height*resolutionFactor);
-                const mimeType = "image/" + format;
-                function finishedBlobCallback(blob){
-                  ui.composites.download._blobToFileDownload(blob, filename);
-                }
-                // Blob to overcome size limitations for data URLs (e.g. 4MB in Chrome)
-                canvas.toBlob(finishedBlobCallback, mimeType, 1.0);
-              }
-            },
-
-            _warnAboutMissingImage(){
-              const message = "Caution: " +
-                "Some images inside the nodes of the graph may be missing in the " +
-                "downloaded picture. Their URLs could not be converted to data URLs. " +
-                "This can have different reasons. For example, the provided image URL may " +
-                "be incorrect, your internet connection may be interrupted, the server that " +
-                "provides the images may not be responsive, or the server's security settings " +
-                "may prevent fetching images via JavaScript code.";
-              alert(message);
-            },
-
-            _blobToFileDownload(blob, filename){
-              const url = URL.createObjectURL(blob),
-                a = document.createElement("a");
-              function handleClick(){
-                setTimeout(function(){
-                  // Long waiting time before removal for slow devices like mobile phones
-                  URL.revokeObjectURL(url);
-                  this.removeEventListener("click", handleClick);
-                }, 20000);
-              };
-              document.body.appendChild(a);
-              a.href = url;
-              a.download = filename;
-              a.addEventListener("click", handleClick, false);
-              a.click();
-              document.body.removeChild(a);
-            },
-          },
-
-          selection(element, optionList, valueList=undefined) {
-            while(element.hasChildNodes()){
-              element.removeChild(element.firstChild);
-            }
-            for(let i=0; i<optionList.length; i++){
-              let text = optionList[i];
-              let value = text;
-              if(valueList){
-                value = valueList[i];
-              }
-              let opt = document.createElement("option");
-              opt.appendChild(document.createTextNode(text));
-              opt.value = value;
-              element.appendChild(opt);
+              canvas.toBlob(finishedBlobCallback, mimeType, 1.0);
             }
           },
 
-          tooltip:{
-            show(xShift=null, yShift=null){
-              if(isFinite(xShift) && xShift !== null){
-                ui.elements.tooltipContainer.style.left =  parseInt(xShift) + "px";
-              }
-              if(isFinite(yShift) && yShift !== null){
-                ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
-              }
-              ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
-              ui.elements.tooltipContainer.style.visibility = "visible";
-              ui.elements.tooltipContainer.style.opacity = 1.0;
-            },
-
-            hide(){
-              ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
-              ui.elements.tooltipContainer.style.visibility = "hidden";
-              ui.elements.tooltipContainer.style.opacity = 0.0;
-            },
+          _warnAboutMissingImage() {
+            const message = "Caution: " +
+              "Some images inside the nodes of the graph may be missing in the " +
+              "downloaded picture. Their URLs could not be converted to data URLs. " +
+              "This can have different reasons. For example, the provided image URL may " +
+              "be incorrect, your internet connection may be interrupted, the server that " +
+              "provides the images may not be responsive, or the server's security settings " +
+              "may prevent fetching images via JavaScript code.";
+            alert(message);
           },
 
-          progressBar:{
-            create(){
-              // Main container
-              this.mainContainer = document.createElement("div");
-              this.mainContainer.id = "§RANDOM_ID§-progress-container";
-              this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
-              ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
-              // Text container
-              const numNodes = state.parsedData.nodes.length;
-              this.textContainer = document.createElement("div");
-              this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
-              this.textContainer.style.textAlign = "center";
-              // Bar container
-              this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
-              this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
-              this.innerBarContainer.style.width = "0%";
-              // Add them to DOM
-              this.outerBarContainer.appendChild(this.innerBarContainer);
-              this.mainContainer.appendChild(this.textContainer);
-              this.mainContainer.appendChild(this.outerBarContainer);
-              ui.elements.graphContainer.appendChild(this.mainContainer);
-            },
+          _blobToFileDownload(blob, filename) {
+            const url = URL.createObjectURL(blob),
+              a = document.createElement("a");
+            function handleClick() {
+              setTimeout(function () {
+                // Long waiting time before removal for slow devices like mobile phones
+                URL.revokeObjectURL(url);
+                this.removeEventListener("click", handleClick);
+              }, 20000);
+            };
+            document.body.appendChild(a);
+            a.href = url;
+            a.download = filename;
+            a.addEventListener("click", handleClick, false);
+            a.click();
+            document.body.removeChild(a);
+          },
+        },
 
-            update(percentage){
-              this.innerBarContainer.style.width = percentage + "%";
-            },
-
-            remove(){
-              ui.elements.graphContainer.removeChild(this.mainContainer);
+        selection(element, optionList, valueList = undefined) {
+          while (element.hasChildNodes()) {
+            element.removeChild(element.firstChild);
+          }
+          for (let i = 0; i < optionList.length; i++) {
+            let text = optionList[i];
+            let value = text;
+            if (valueList) {
+              value = valueList[i];
             }
+            let opt = document.createElement("option");
+            opt.appendChild(document.createTextNode(text));
+            opt.value = value;
+            element.appendChild(opt);
+          }
+        },
+
+        tooltip: {
+          show(xShift = null, yShift = null) {
+            if (isFinite(xShift) && xShift !== null) {
+              ui.elements.tooltipContainer.style.left = parseInt(xShift) + "px";
+            }
+            if (isFinite(yShift) && yShift !== null) {
+              ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
+            }
+            ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
+            ui.elements.tooltipContainer.style.visibility = "visible";
+            ui.elements.tooltipContainer.style.opacity = 1.0;
           },
 
-          graph:{
-            createGraph(){
-              // Remove existing elements
-              ui.deleteChildElements(ui.elements.graphContainer);
+          hide() {
+            ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
+            ui.elements.tooltipContainer.style.visibility = "hidden";
+            ui.elements.tooltipContainer.style.opacity = 0.0;
+          },
+        },
 
-              // Create new elements
-              // - Menu toggle button
-              if(state.showMenuToggleButton){
-                const menuDiv = document.createElement("div");
-                if(state.showMenu){
-                  menuDiv.innerText = ui.symbols.menuShown;
-                } else {
-                  menuDiv.innerText = ui.symbols.menuHidden;
-                }
-                menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
-                menuDiv.onclick = ui.composites.menu.toggle;
-                ui.elements.graphContainer.appendChild(menuDiv);
-                ui.elements.menuToggleDiv = menuDiv;
+        progressBar: {
+          create() {
+            // Main container
+            this.mainContainer = document.createElement("div");
+            this.mainContainer.id = "§RANDOM_ID§-progress-container";
+            this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
+            ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
+            // Text container
+            const numNodes = state.parsedData.nodes.length;
+            this.textContainer = document.createElement("div");
+            this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
+            this.textContainer.style.textAlign = "center";
+            // Bar container
+            this.outerBarContainer = document.createElement("div");
+            this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
+            this.innerBarContainer = document.createElement("div");
+            this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
+            this.innerBarContainer.style.width = "0%";
+            // Add them to DOM
+            this.outerBarContainer.appendChild(this.innerBarContainer);
+            this.mainContainer.appendChild(this.textContainer);
+            this.mainContainer.appendChild(this.outerBarContainer);
+            ui.elements.graphContainer.appendChild(this.mainContainer);
+          },
+
+          update(percentage) {
+            this.innerBarContainer.style.width = percentage + "%";
+          },
+
+          remove() {
+            ui.elements.graphContainer.removeChild(this.mainContainer);
+          }
+        },
+
+        graph: {
+          createGraph() {
+            // Remove existing elements
+            ui.deleteChildElements(ui.elements.graphContainer);
+
+            // Create new elements
+            // - Menu toggle button
+            if (state.showMenuToggleButton) {
+              const menuDiv = document.createElement("div");
+              if (state.showMenu) {
+                menuDiv.innerText = ui.symbols.menuShown;
+              } else {
+                menuDiv.innerText = ui.symbols.menuHidden;
               }
+              menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
+              menuDiv.onclick = ui.composites.menu.toggle;
+              ui.elements.graphContainer.appendChild(menuDiv);
+              ui.elements.menuToggleDiv = menuDiv;
+            }
 
-              // - Details toggle button
-              if(state.showDetailsToggleButton){
-                const detailsDiv = document.createElement("div");
-                if(state.showDetails){
-                  detailsDiv.innerText = ui.symbols.detailsShown;
-                } else {
-                  detailsDiv.innerText = ui.symbols.detailsHidden;
-                }
-                detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
-                detailsDiv.onclick = ui.composites.details.toggle;
-                ui.elements.graphContainer.appendChild(detailsDiv);
-                ui.elements.detailsToggleDiv = detailsDiv;
+            // - Details toggle button
+            if (state.showDetailsToggleButton) {
+              const detailsDiv = document.createElement("div");
+              if (state.showDetails) {
+                detailsDiv.innerText = ui.symbols.detailsShown;
+              } else {
+                detailsDiv.innerText = ui.symbols.detailsHidden;
               }
+              detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
+              detailsDiv.onclick = ui.composites.details.toggle;
+              ui.elements.graphContainer.appendChild(detailsDiv);
+              ui.elements.detailsToggleDiv = detailsDiv;
+            }
 
-              // - Graph drawing area
-              const svg = d3.select("#§RANDOM_ID§-graph-div").append("svg");
-              state.currentGraphParts.svg = svg;
-              svg
-                .attr("width", state.graphContainerWidth)
-                .attr("height", state.graphContainerHeight);
-              // - Background rectangle
-              const backgroundRect = svg.append("rect")
-                .attr("id", "§RANDOM_ID§-background")
-                .attr("width", state.graphContainerWidth)
-                .attr("height", state.graphContainerHeight)
-                .attr("fill", state.shownData.general.background_color);
-              state.currentGraphParts.backgroundRect = backgroundRect;
-              // - Zoomable and draggable group as graph drawing area
-              const view = svg.append("g").attr("id", "§RANDOM_ID§-zoomable-graph-group");
-              state.currentGraphParts.view = view;
-              function zoomed(event) {
-                view.attr("transform", event.transform);
-              }
-              const zoom = d3.zoom()
-                .on("zoom", zoomed);
-              state.currentGraphParts.zoom = zoom;
-              const xShift = parseInt(ui.elements.graphContainer.clientWidth) / 2.0,
-                yShift = parseInt(ui.elements.graphContainer.clientHeight) / 2.0;
-              svg
-                .call(zoom)
-                .call(zoom.transform, d3.zoomIdentity.translate(xShift, yShift).scale(state.initZoomFactor))
-                .on("dblclick.zoom", null);
+            // - Graph drawing area
+            const svg = d3.select("#§RANDOM_ID§-graph-div").append("svg");
+            state.currentGraphParts.svg = svg;
+            svg
+              .attr("width", state.graphContainerWidth)
+              .attr("height", state.graphContainerHeight);
+            // - Background rectangle
+            const backgroundRect = svg.append("rect")
+              .attr("id", "§RANDOM_ID§-background")
+              .attr("width", state.graphContainerWidth)
+              .attr("height", state.graphContainerHeight)
+              .attr("fill", state.shownData.general.background_color);
+            state.currentGraphParts.backgroundRect = backgroundRect;
+            // - Zoomable and draggable group as graph drawing area
+            const view = svg.append("g").attr("id", "§RANDOM_ID§-zoomable-graph-group");
+            state.currentGraphParts.view = view;
+            function zoomed(event) {
+              view.attr("transform", event.transform);
+            }
+            const zoom = d3.zoom()
+              .on("zoom", zoomed);
+            state.currentGraphParts.zoom = zoom;
+            const xShift = parseInt(ui.elements.graphContainer.clientWidth) / 2.0,
+              yShift = parseInt(ui.elements.graphContainer.clientHeight) / 2.0;
+            svg
+              .call(zoom)
+              .call(zoom.transform, d3.zoomIdentity.translate(xShift, yShift).scale(state.initZoomFactor))
+              .on("dblclick.zoom", null);
 
-              // - Bind data to DOM elements
-              //   Note: Elements are creates in separate group elements to have layers that are in front or back
-              ui.composites.graph.bindGraphDataToViewDOM(state.shownData, view);
+            // - Bind data to DOM elements
+            //   Note: Elements are creates in separate group elements to have layers that are in front or back
+            ui.composites.graph.bindGraphDataToViewDOM(state.shownData, view);
 
-              // - Add representations for all graph elements and
-              //   add movement of graph elements by force-directed layout simulation
-              //   Note: This is done differently for small or large graphs
-              const numNodes = state.shownData.nodes.length;
-              if(numNodes <= state.largeGraphThreshold){
-                // Small graph: shown immediately, moving from begin on
+            // - Add representations for all graph elements and
+            //   add movement of graph elements by force-directed layout simulation
+            //   Note: This is done differently for small or large graphs
+            const numNodes = state.shownData.nodes.length;
+            if (numNodes <= state.largeGraphThreshold) {
+              // Small graph: shown immediately, moving from begin on
+              ui.composites.graph.createSimulation();
+              ui.composites.graph.createAllGraphElements()
+              ui.composites.graph.simulationManager.simulation.on(
+                "tick", ui.composites.graph.updateAllActiveElementPositions);
+            } else {
+              // Large graph: shown after initial layout, moving only on later user interaction
+              if (state.layoutAlgorithmActive) {
+                ui.composites.graph.createSimulation();
+                ui.composites.graph.calcLayoutWithProgressBar();
+              } else {
                 ui.composites.graph.createSimulation();
                 ui.composites.graph.createAllGraphElements()
-                ui.composites.graph.simulationManager.simulation.on(
-                  "tick", ui.composites.graph.updateAllActiveElementPositions);
-              } else {
-                // Large graph: shown after initial layout, moving only on later user interaction
-                if(state.layoutAlgorithmActive) {
-                  ui.composites.graph.createSimulation();
+                ui.composites.graph.simulationManager.simulation.on("tick", function () {
+                  ui.composites.graph.removeAllGraphElements();
                   ui.composites.graph.calcLayoutWithProgressBar();
-                } else{
-                  ui.composites.graph.createSimulation();
-                  ui.composites.graph.createAllGraphElements()
-                  ui.composites.graph.simulationManager.simulation.on("tick", function(){
-                    ui.composites.graph.removeAllGraphElements();
-                    ui.composites.graph.calcLayoutWithProgressBar();
-                  });
+                });
+              }
+            }
+          },
+
+          updateGraphDrawingArea() {
+            state.currentGraphParts.svg
+              .attr("width", state.graphContainerWidth)
+              .attr("height", state.graphContainerHeight);
+            state.currentGraphParts.backgroundRect
+              .attr("width", state.graphContainerWidth)
+              .attr("height", state.graphContainerHeight);
+          },
+
+          bindGraphDataToViewDOM(data, view) {
+            // Note: The order of the following groups decides which SVG elements are drawn
+            //       in back and which are drawn in front (there is no z-order property in SVG)
+            // Edges
+            state.currentGraphParts.edgeMainGroup = view.append("g")
+              .attr("id", "§RANDOM_ID§-edge-group")
+              .style("display", ui.convert.boolToDisplayStyle(state.showEdges));
+            state.currentGraphParts.edgeGroups = state.currentGraphParts.edgeMainGroup
+              .selectAll("g")
+              .data(data.edges)
+              .join("g");
+            // Nodes
+            state.currentGraphParts.nodeMainGroup = view.append("g")
+              .attr("id", "§RANDOM_ID§-node-group")
+              .style("display", ui.convert.boolToDisplayStyle(state.showNodes));
+            state.currentGraphParts.nodeGroups = state.currentGraphParts.nodeMainGroup
+              .selectAll("g")
+              .data(data.nodes)
+              .join("g");
+            // Edge labels: minimal data duplication in DOM by storing only indices to original array
+            const edgeLabelData = [];
+            for (let i = 0; i < data.edges.length; i++) {
+              edgeLabelData.push(i);
+            }
+            state.currentGraphParts.edgeLabelMainGroup = view.append("g")
+              .attr("id", "§RANDOM_ID§-edge-label-group")
+              .style("display", ui.convert.boolToDisplayStyle(state.showEdgeLabels));
+            state.currentGraphParts.edgeLabelGroups = state.currentGraphParts.edgeLabelMainGroup
+              .selectAll("g")
+              .data(edgeLabelData)
+              .join("g");
+            // Node labels: minimal data duplication in DOM by storing only indices to original array
+            const nodeLabelData = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              nodeLabelData.push(i);
+            }
+            state.currentGraphParts.nodeLabelMainGroup = view.append("g")
+              .attr("id", "§RANDOM_ID§-node-label-group");
+            state.currentGraphParts.nodeLabelGroups = state.currentGraphParts.nodeLabelMainGroup
+              .style("display", ui.convert.boolToDisplayStyle(state.showNodeLabels))
+              .selectAll("g")
+              .data(nodeLabelData)
+              .join("g");
+            // Node images
+            const nodeImageData = [];
+            if (state.parsedData.general.contains_node_image) {
+              for (let i = 0; i < data.nodes.length; i++) {
+                const node = data.nodes[i];
+                if (node.image) {
+                  nodeImageData.push(i);
                 }
               }
-            },
+            }
+            state.currentGraphParts.nodeImageMainGroup = view.append("g")
+              .attr("id", "§RANDOM_ID§-node-image-group")
+              .style("display", ui.convert.boolToDisplayStyle(state.showNodeImages));
+            state.currentGraphParts.nodeImageGroups = state.currentGraphParts.nodeImageMainGroup
+              .selectAll("g")
+              .data(nodeImageData)
+              .join("g");
+          },
 
-            updateGraphDrawingArea(){
-              state.currentGraphParts.svg
-                .attr("width", state.graphContainerWidth)
-                .attr("height", state.graphContainerHeight);
-              state.currentGraphParts.backgroundRect
-                .attr("width", state.graphContainerWidth)
-                .attr("height", state.graphContainerHeight);
-            },
+          calcLayoutWithProgressBar() {
+            // Irregular update of element positions
+            state.parsedData.tickCounter = 0;
+            state.parsedData.tickRefresher = 3;
+            function updateEveryNthTick() {
+              state.parsedData.tickCounter++;
+              if (state.parsedData.tickCounter >= state.parsedData.tickRefresher) {
+                state.parsedData.tickCounter = 0;
+                ui.composites.graph.updateAllActiveElementPositions();
+              }
+            }
+            // Prevent spending a large portion of calculation time close to alpha min (0.001)
+            const numNodes = state.shownData.nodes.length;
+            if (numNodes >= 25000) {
+              ui.composites.graph.simulationManager.simulation.alphaMin(0.03);
+              state.parsedData.tickRefresher = 15;
+            } else if (numNodes >= 10000) {
+              ui.composites.graph.simulationManager.simulation.alphaMin(0.02);
+              state.parsedData.tickRefresher = 7;
+            } else if (numNodes >= 5000) {
+              ui.composites.graph.simulationManager.simulation.alphaMin(0.01);
+              state.parsedData.tickRefresher = 5;
+            }
+            state.parsedData.startAlpha = ui.composites.graph.simulationManager.simulation.alpha();
+            state.parsedData.stopAlpha = ui.composites.graph.simulationManager.simulation.alphaMin();
+            state.parsedData.rangeAlpha = state.parsedData.startAlpha - state.parsedData.stopAlpha;
+            // - Progress bar: only if large graph, stops simulation to get initial static image
+            // Layout start
+            ui.composites.progressBar.create();
+            // Layout update
+            ui.composites.graph.simulationManager.simulation.on("tick", function () {
+              const currentAlpha = ui.composites.graph.simulationManager.simulation.alpha(),
+                remaining = (currentAlpha - state.parsedData.stopAlpha) / state.parsedData.rangeAlpha,
+                progressPercentage = (1.0 - remaining) * 100.0;
+              ui.composites.progressBar.update(progressPercentage);
+            });
+            // Layout finished
+            ui.composites.graph.simulationManager.simulation.on("end", function () {
+              ui.composites.graph.simulationManager.simulation.on("end", null);
+              ui.composites.graph.simulationManager.simulation.on("tick", null);
+              // Remove progress bar and show graph
+              ui.composites.progressBar.remove();
+              ui.composites.graph.createAllGraphElements();
+              // Afterwards: Update element positions not on every tick but only on every n-th tick
+              ui.composites.graph.simulationManager.simulation.on("tick", updateEveryNthTick);
+              ui.composites.graph.simulationManager.simulation.on("end", ui.composites.graph.updateAllActiveElementPositions);
+            });
+          },
 
-            bindGraphDataToViewDOM(data, view){
-              // Note: The order of the following groups decides which SVG elements are drawn
-              //       in back and which are drawn in front (there is no z-order property in SVG)
-              // Edges
-              state.currentGraphParts.edgeMainGroup = view.append("g")
-                .attr("id", "§RANDOM_ID§-edge-group")
-                .style("display", ui.convert.boolToDisplayStyle(state.showEdges));
-              state.currentGraphParts.edgeGroups = state.currentGraphParts.edgeMainGroup
-                .selectAll("g")
-                .data(data.edges)
-                .join("g");
-              // Nodes
-              state.currentGraphParts.nodeMainGroup = view.append("g")
-                .attr("id", "§RANDOM_ID§-node-group")
-                .style("display", ui.convert.boolToDisplayStyle(state.showNodes));
-              state.currentGraphParts.nodeGroups = state.currentGraphParts.nodeMainGroup
-                .selectAll("g")
-                .data(data.nodes)
-                .join("g");
-              // Edge labels: minimal data duplication in DOM by storing only indices to original array
-              const edgeLabelData = [];
-              for(let i=0; i<data.edges.length; i++){
-                edgeLabelData.push(i);
-              }
-              state.currentGraphParts.edgeLabelMainGroup = view.append("g")
-                .attr("id", "§RANDOM_ID§-edge-label-group")
-                .style("display", ui.convert.boolToDisplayStyle(state.showEdgeLabels));
-              state.currentGraphParts.edgeLabelGroups = state.currentGraphParts.edgeLabelMainGroup
-                .selectAll("g")
-                .data(edgeLabelData)
-                .join("g");
-              // Node labels: minimal data duplication in DOM by storing only indices to original array
-              const nodeLabelData = [];
-              for (let i=0; i<data.nodes.length; i++){
-                nodeLabelData.push(i);
-              }
-              state.currentGraphParts.nodeLabelMainGroup = view.append("g")
-                .attr("id", "§RANDOM_ID§-node-label-group");
-              state.currentGraphParts.nodeLabelGroups = state.currentGraphParts.nodeLabelMainGroup
-                .style("display", ui.convert.boolToDisplayStyle(state.showNodeLabels))
-                .selectAll("g")
-                .data(nodeLabelData)
-                .join("g");
-              // Node images
-              const nodeImageData = [];
-              if(state.parsedData.general.contains_node_image){
-                for(let i=0; i<data.nodes.length; i++){
-                  const node = data.nodes[i];
-                  if(node.image){
-                    nodeImageData.push(i);
+          createAllGraphElements() {
+            ui.composites.graph.createNodes();
+            ui.composites.graph.createEdges();
+            ui.composites.graph.createEdgeLabels();
+            ui.composites.graph.createNodeLabels();
+            ui.composites.graph.createNodeImages();
+          },
+
+          removeAllGraphElements() {
+            ui.composites.graph.removeNodes();
+            ui.composites.graph.removeEdges();
+            ui.composites.graph.removeEdgeLabels();
+            ui.composites.graph.removeNodeLabels();
+            ui.composites.graph.removeNodeImages();
+          },
+
+          updateAllActiveElementPositions() {
+            if (state.showNodes) {
+              ui.composites.graph.updateNodePositions();
+            }
+            if (state.showNodeImages) {
+              ui.composites.graph.updateNodeImagePositions();
+            }
+            if (state.showNodeLabels) {
+              ui.composites.graph.updateNodeLabelPositions();
+            }
+            if (state.showEdges || state.showEdgeLabels) {
+              // Caution: updateEdgeLabelPositions() depends on data calculated in updateEdgePositions()
+              ui.composites.graph.updateEdgePositions();
+            }
+            if (state.showEdgeLabels) {
+              ui.composites.graph.updateEdgeLabelPositions();
+            }
+          },
+
+          createSimulation() {
+            ui.composites.graph.simulationManager.initialize();
+            if (!state.layoutAlgorithmActive) {
+              ui.composites.graph.simulationManager.stop();
+            }
+            ui.composites.graph.simulationManager.setAllForces();
+          },
+
+          // Nodes
+          createNodes() {
+            const nodeGroups = state.currentGraphParts.nodeGroups;
+            // 1) Remove existing elements
+            ui.composites.graph.removeNodes();
+            // 2) Create new elements
+            // - Node shape
+            state.currentGraphParts.nodeCircles = nodeGroups.filter(d => (d.shape != "rectangle" && d.shape != "hexagon")).append("circle")
+              .attr("fill", d => d.color)
+              .attr("opacity", d => d.opacity)
+              .attr("r", d => d.size_half)
+              .attr("stroke", d => d.border_color)
+              .attr("stroke-width", d => d.border_size);
+            state.currentGraphParts.nodeRectangles = nodeGroups.filter(d => d.shape == "rectangle").append("rect")
+              .attr("fill", d => d.color)
+              .attr("opacity", d => d.opacity)
+              .attr("width", d => d.size)
+              .attr("height", d => d.size)
+              .attr("stroke", d => d.border_color)
+              .attr("stroke-width", d => d.border_size);
+            state.currentGraphParts.nodeHexagons = nodeGroups.filter(d => d.shape == "hexagon").append("path")
+              .attr("fill", d => d.color)
+              .attr("opacity", d => d.opacity)
+              .attr("stroke", d => d.border_color)
+              .attr("stroke-width", d => d.border_size);
+            // - Node hover behavior 1: tooltip
+            // http://bl.ocks.org/d3noob/a22c42db65eb00d4e369
+            if (state.parsedData.general.contains_node_hover) {
+              const nodeHover = nodeGroups.filter(d => d.hover)
+                .on("mouseover.tooltip", function (event, d) {
+                  if (state.nodeHoverTooltip) {
+                    ui.elements.tooltipContainer.innerHTML = d.hover;
+                    const cont = ui.elements.mainContainer,
+                      contAbsX = cont.offsetLeft,
+                      contAbsY = cont.offsetTop,
+                      contBoundingRect = cont.getBoundingClientRect(),
+                      contClientX = contBoundingRect.left,
+                      contClientY = contBoundingRect.top,
+                      contWidth = contBoundingRect.width;
+                    let deltaX = event.clientX - contClientX,
+                      deltaY = event.clientY - contClientY,
+                      deltaXMax = contWidth * 0.85;
+                    if (deltaX > deltaXMax) {
+                      deltaX = deltaXMax;
+                    }
+                    const xShift = contAbsX + deltaX + 7,
+                      yShift = contAbsY + deltaY + 14;
+                    ui.composites.tooltip.show(xShift, yShift);
                   }
+                })
+                .on("mouseout.tooltip", function (event, d) {
+                  if (state.nodeHoverTooltip) {
+                    ui.composites.tooltip.hide();
+                  }
+                });
+            }
+            // Node hover behavior 2: Highlighting incident edges and adjacent nodes
+            // https://bl.ocks.org/almsuarez/4333a12d2531d6c1f6f22b74f2c57102
+            function setNodeOpacityByAdjacency(d, node, adjacentNodes, lowerOpacity) {
+              if (adjacentNodes.has(d) || d === node) {
+                return 1.0;
+              } else {
+                return lowerOpacity;
+              }
+            }
+            function setEdgeOpacityByIncidence(d, incidentEdges, lowerOpacity) {
+              if (incidentEdges.has(d)) {
+                return 1.0;
+              } else {
+                return lowerOpacity;
+              }
+            }
+            function resetOpacity(d) {
+              return 1.0;
+            }
+            function highlightNodeNeighborhood(event, node) {
+              if (state.nodeHoverNeighborhood) {
+                const adjacentNodes = state.shownData.adjacency.map.get(node),
+                  incidentEdges = state.shownData.incidence.map.get(node);
+                if (state.showNodes) {
+                  state.currentGraphParts.nodeGroups
+                    .attr("opacity", d => setNodeOpacityByAdjacency(d, node, adjacentNodes, 0.2));
+                }
+                if (state.showNodeImages) {
+                  state.currentGraphParts.nodeImageGroups
+                    .attr("opacity", dIndex => setNodeOpacityByAdjacency(state.shownData.nodes[dIndex], node, adjacentNodes, 0.12));
+                }
+                if (state.showNodeLabels) {
+                  state.currentGraphParts.nodeLabelGroups
+                    .attr("opacity", dIndex => setNodeOpacityByAdjacency(state.shownData.nodes[dIndex], node, adjacentNodes, 0.07));
+                }
+                if (state.showEdges) {
+                  state.currentGraphParts.edgeGroups
+                    .attr("opacity", d => setEdgeOpacityByIncidence(d, incidentEdges, 0.07));
+                }
+                if (state.showEdgeLabels) {
+                  state.currentGraphParts.edgeLabelGroups
+                    .attr("opacity", dIndex => setEdgeOpacityByIncidence(state.shownData.edges[dIndex], incidentEdges, 0.07));
                 }
               }
-              state.currentGraphParts.nodeImageMainGroup = view.append("g")
-                .attr("id", "§RANDOM_ID§-node-image-group")
-                .style("display", ui.convert.boolToDisplayStyle(state.showNodeImages));
-              state.currentGraphParts.nodeImageGroups = state.currentGraphParts.nodeImageMainGroup
-                .selectAll("g")
-                .data(nodeImageData)
-                .join("g");
-            },
-
-            calcLayoutWithProgressBar(){
-              // Irregular update of element positions
-              state.parsedData.tickCounter = 0;
-              state.parsedData.tickRefresher = 3;
-              function updateEveryNthTick(){
-                state.parsedData.tickCounter++;
-                if(state.parsedData.tickCounter >= state.parsedData.tickRefresher){
-                  state.parsedData.tickCounter = 0;
+            }
+            function unhighlightNodeNeighborhood(event, node) {
+              if (state.nodeHoverNeighborhood) {
+                if (state.showNodes) {
+                  state.currentGraphParts.nodeGroups
+                    .attr("opacity", resetOpacity);
+                }
+                if (state.showNodeImages) {
+                  state.currentGraphParts.nodeImageGroups
+                    .attr("opacity", resetOpacity);
+                }
+                if (state.showNodeLabels) {
+                  state.currentGraphParts.nodeLabelGroups
+                    .attr("opacity", resetOpacity);
+                }
+                if (state.showEdges) {
+                  state.currentGraphParts.edgeGroups
+                    .attr("opacity", resetOpacity);
+                }
+                if (state.showEdgeLabels) {
+                  state.currentGraphParts.edgeLabelGroups
+                    .attr("opacity", resetOpacity);
+                }
+              }
+            }
+            nodeGroups.on("mouseover.neighborhood", highlightNodeNeighborhood);
+            nodeGroups.on("mouseout.neighborhood", unhighlightNodeNeighborhood);
+            // - Node click behavior: details in separate container
+            function nodeClicked(event, node) {
+              let htmlText = "<div>Node: " + String(node.id) + "</div>";
+              if (typeof (node.click) !== "undefined" && node.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
+              }
+              ui.elements.detailsBody.innerHTML = htmlText;
+            }
+            nodeGroups.on("click", nodeClicked);
+            // - Node drag behavior: position fixation or release
+            // https://stackoverflow.com/questions/42605261/d3-event-active-purpose-in-drag-dropping-circles
+            function dragNodes(simulation) {
+              let xAtDragStart = undefined,
+                yAtDragStart = undefined;
+              function dragstarted(event, d) {
+                if (!event.active && state.layoutAlgorithmActive) {
+                  simulation.alphaTarget(0.3).restart();
+                }
+                d.fx = d.x;
+                d.fy = d.y;
+                if (!state.nodeDragFix) {
+                  xAtDragStart = d.x;
+                  yAtDragStart = d.y;
+                }
+              }
+              function dragged(event, d) {
+                d.fx = event.x;
+                d.fy = event.y;
+                if (!state.layoutAlgorithmActive) {
+                  d.x = d.fx;
+                  d.y = d.fy;
                   ui.composites.graph.updateAllActiveElementPositions();
                 }
               }
-              // Prevent spending a large portion of calculation time close to alpha min (0.001)
-              const numNodes = state.shownData.nodes.length;
-              if(numNodes >= 25000){
-                ui.composites.graph.simulationManager.simulation.alphaMin(0.03);
-                state.parsedData.tickRefresher = 15;
-              } else if(numNodes >= 10000){
-                ui.composites.graph.simulationManager.simulation.alphaMin(0.02);
-                state.parsedData.tickRefresher = 7;
-              } else if(numNodes >= 5000){
-                ui.composites.graph.simulationManager.simulation.alphaMin(0.01);
-                state.parsedData.tickRefresher = 5;
+              function dragended(event, d) {
+                if (!event.active) {
+                  simulation.alphaTarget(0.0);
+                }
+                if (!state.layoutAlgorithmActive) {
+                  simulation.stop();
+                }
+                if (!state.nodeDragFix) {
+                  // Release a node if clicked and dragged a bit, but not if just clicked
+                  if (Math.abs(event.x - xAtDragStart) > 0.1 || Math.abs(event.y - yAtDragStart) > 0.1) {
+                    d.fx = null;
+                    d.fy = null;
+                  }
+                }
               }
-              state.parsedData.startAlpha = ui.composites.graph.simulationManager.simulation.alpha();
-              state.parsedData.stopAlpha = ui.composites.graph.simulationManager.simulation.alphaMin();
-              state.parsedData.rangeAlpha = state.parsedData.startAlpha - state.parsedData.stopAlpha;
-              // - Progress bar: only if large graph, stops simulation to get initial static image
-              // Layout start
-              ui.composites.progressBar.create();
-              // Layout update
-              ui.composites.graph.simulationManager.simulation.on("tick", function(){
-                const currentAlpha = ui.composites.graph.simulationManager.simulation.alpha(),
-                  remaining = (currentAlpha - state.parsedData.stopAlpha) / state.parsedData.rangeAlpha,
-                  progressPercentage = (1.0 - remaining) * 100.0;
-                ui.composites.progressBar.update(progressPercentage);
+              return d3.drag()
+                .on("start", dragstarted)
+                .on("drag", dragged)
+                .on("end", dragended);
+            }
+            state.currentGraphParts.nodeGroups
+              .call(dragNodes(ui.composites.graph.simulationManager.simulation));
+            // 3) Position new elements
+            ui.composites.graph.updateNodePositions();
+          },
+
+          removeNodes() {
+            state.currentGraphParts.nodeGroups.selectAll("*").remove();
+          },
+
+          updateNodeVisibilities() {
+            state.currentGraphParts.nodeMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodes));
+            ui.composites.graph.updateNodePositions();
+          },
+
+          updateNodeSizes() {
+            ui.composites.graph.createNodes();
+            // Update elements depending on node size
+            ui.composites.graph.createEdges();
+            ui.composites.graph.createNodeLabels();
+            ui.composites.graph.updateNodeImageSizes();
+            ui.composites.graph.updateNodeImagePositions();
+            ui.composites.graph.updateEdgeLabelPositions();
+          },
+
+          updateNodePositions() {
+            state.currentGraphParts.nodeCircles
+              .attr("cx", d => d.x)
+              .attr("cy", d => d.y);
+            state.currentGraphParts.nodeRectangles
+              .attr("x", d => d.x - d.size_half)
+              .attr("y", d => d.y - d.size_half);
+            state.currentGraphParts.nodeHexagons
+              .attr("d", function (d) {
+                const r = d.size_for_hexagon_r,
+                  rh = d.size_for_hexagon_rh,
+                  rs = d.size_for_hexagon_rs,
+                  x0 = d.x + r,
+                  y0 = d.y,
+                  x1 = d.x + rh,
+                  y1 = d.y + rs,
+                  x2 = d.x - rh,
+                  y2 = y1,
+                  x3 = d.x - r,
+                  y3 = d.y,
+                  x4 = x2,
+                  y4 = d.y - rs,
+                  x5 = x1,
+                  y5 = y4;
+                return "M " + x0 + " " + y0 + " L " + x1 + " " + y1 + " L " + x2 + " " + y2 +
+                  " L " + x3 + " " + y3 + " L " + x4 + " " + y4 + " L " + x5 + " " + y5 + " Z";
               });
-              // Layout finished
-              ui.composites.graph.simulationManager.simulation.on("end", function(){
-                ui.composites.graph.simulationManager.simulation.on("end", null);
-                ui.composites.graph.simulationManager.simulation.on("tick", null);
-                // Remove progress bar and show graph
-                ui.composites.progressBar.remove();
-                ui.composites.graph.createAllGraphElements();
-                // Afterwards: Update element positions not on every tick but only on every n-th tick
-                ui.composites.graph.simulationManager.simulation.on("tick", updateEveryNthTick);
-                ui.composites.graph.simulationManager.simulation.on("end", ui.composites.graph.updateAllActiveElementPositions);
-              });
-            },
+          },
 
-            createAllGraphElements(){
-              ui.composites.graph.createNodes();
-              ui.composites.graph.createEdges();
-              ui.composites.graph.createEdgeLabels();
-              ui.composites.graph.createNodeLabels();
-              ui.composites.graph.createNodeImages();
-            },
-
-            removeAllGraphElements(){
-              ui.composites.graph.removeNodes();
-              ui.composites.graph.removeEdges();
-              ui.composites.graph.removeEdgeLabels();
-              ui.composites.graph.removeNodeLabels();
-              ui.composites.graph.removeNodeImages();
-            },
-
-            updateAllActiveElementPositions(){
-              if(state.showNodes){
-                ui.composites.graph.updateNodePositions();
-              }
-              if(state.showNodeImages){
-                ui.composites.graph.updateNodeImagePositions();
-              }
-              if(state.showNodeLabels){
-                ui.composites.graph.updateNodeLabelPositions();
-              }
-              if(state.showEdges || state.showEdgeLabels){
-                // Caution: updateEdgeLabelPositions() depends on data calculated in updateEdgePositions()
-                ui.composites.graph.updateEdgePositions();
-              }
-              if(state.showEdgeLabels){
-                ui.composites.graph.updateEdgeLabelPositions();
-              }
-            },
-
-            createSimulation(){
-              ui.composites.graph.simulationManager.initialize();
-              if(!state.layoutAlgorithmActive){
-                ui.composites.graph.simulationManager.stop();
-              }
-              ui.composites.graph.simulationManager.setAllForces();
-            },
-
-            // Nodes
-            createNodes(){
-              const nodeGroups = state.currentGraphParts.nodeGroups;
-              // 1) Remove existing elements
-              ui.composites.graph.removeNodes();
-              // 2) Create new elements
-              // - Node shape
-              state.currentGraphParts.nodeCircles = nodeGroups.filter(d => (d.shape != "rectangle" && d.shape != "hexagon")).append("circle")
-                .attr("fill", d => d.color)
-                .attr("opacity", d => d.opacity)
-                .attr("r", d => d.size_half)
-                .attr("stroke", d => d.border_color)
-                .attr("stroke-width", d => d.border_size);
-              state.currentGraphParts.nodeRectangles = nodeGroups.filter(d => d.shape == "rectangle").append("rect")
-                .attr("fill", d => d.color)
-                .attr("opacity", d => d.opacity)
-                .attr("width", d => d.size)
-                .attr("height", d => d.size)
-                .attr("stroke", d => d.border_color)
-                .attr("stroke-width", d => d.border_size);
-              state.currentGraphParts.nodeHexagons = nodeGroups.filter(d => d.shape == "hexagon").append("path")
-                .attr("fill", d => d.color)
-                .attr("opacity", d => d.opacity)
-                .attr("stroke", d => d.border_color)
-                .attr("stroke-width", d => d.border_size);
-              // - Node hover behavior 1: tooltip
-              // http://bl.ocks.org/d3noob/a22c42db65eb00d4e369
-              if(state.parsedData.general.contains_node_hover){
-                const nodeHover = nodeGroups.filter(d => d.hover)
-                  .on("mouseover.tooltip", function(event, d){
-                    if(state.nodeHoverTooltip){
-                      ui.elements.tooltipContainer.innerHTML = d.hover;
-                      const cont = ui.elements.mainContainer,
-                        contAbsX = cont.offsetLeft,
-                        contAbsY = cont.offsetTop,
-                        contBoundingRect = cont.getBoundingClientRect(),
-                        contClientX = contBoundingRect.left,
-                        contClientY = contBoundingRect.top,
-                        contWidth = contBoundingRect.width;
-                      let deltaX = event.clientX - contClientX,
-                        deltaY = event.clientY - contClientY,
-                        deltaXMax = contWidth * 0.85;
-                      if(deltaX > deltaXMax){
-                        deltaX = deltaXMax;
-                      }
-                      const xShift = contAbsX + deltaX + 7,
-                        yShift = contAbsY + deltaY + 14;
-                      ui.composites.tooltip.show(xShift, yShift);
-                    }
+          // Node images
+          createNodeImages() {
+            const nodeImageGroups = state.currentGraphParts.nodeImageGroups,
+              data = state.shownData;
+            // 1) Remove existing elements
+            ui.composites.graph.removeNodeImages();
+            // 2) Create new elements
+            state.currentGraphParts.nodeImages = nodeImageGroups.append("image")
+              .style("pointer-events", "none")
+              .attr("height", dIndex => data.nodes[dIndex].image_size)
+              .attr("width", dIndex => data.nodes[dIndex].image_size)
+              .attr("xlink:href", function (dIndex) {
+                const imageElement = this,
+                  originalImageUrl = data.nodes[dIndex].image,
+                  nodeId = data.nodes[dIndex].id;
+                fetch(originalImageUrl)
+                  // Try to fetch the data from the original URL and store the image as new data URL
+                  .then(function (response) { return response.blob(); })
+                  .then(function (blob) {
+                    const reader = new FileReader();
+                    reader.addEventListener("load", function () {
+                      d3.select(imageElement).attr("xlink:href", reader.result);
+                    }, false);
+                    reader.readAsDataURL(blob);
                   })
-                  .on("mouseout.tooltip", function(event, d){
-                    if(state.nodeHoverTooltip){
-                      ui.composites.tooltip.hide();
-                    }
+                  // If failed keep the original URL (e.g. because server does not allow CORS)
+                  .catch(function (error) {
+                    const message = 'Warning: Fetching image for node ' + nodeId + ' with ' +
+                      'URL "' + originalImageUrl + '" failed.';
+                    console.log(message);
+                    state.shownData.general.node_image_fetching_failed = true;
                   });
-              }
-              // Node hover behavior 2: Highlighting incident edges and adjacent nodes
-              // https://bl.ocks.org/almsuarez/4333a12d2531d6c1f6f22b74f2c57102
-              function setNodeOpacityByAdjacency(d, node, adjacentNodes, lowerOpacity){
-                if(adjacentNodes.has(d) || d === node){
-                  return 1.0;
-                } else{
-                  return lowerOpacity;
-                }
-              }
-              function setEdgeOpacityByIncidence(d, incidentEdges, lowerOpacity){
-                if(incidentEdges.has(d)){
-                  return 1.0;
-                } else{
-                  return lowerOpacity;
-                }
-              }
-              function resetOpacity(d){
-                return 1.0;
-              }
-              function highlightNodeNeighborhood(event, node){
-                if(state.nodeHoverNeighborhood){
-                  const adjacentNodes = state.shownData.adjacency.map.get(node),
-                    incidentEdges = state.shownData.incidence.map.get(node);
-                  if(state.showNodes){
-                    state.currentGraphParts.nodeGroups
-                      .attr("opacity", d => setNodeOpacityByAdjacency(d, node, adjacentNodes, 0.2));
-                  }
-                  if(state.showNodeImages){
-                    state.currentGraphParts.nodeImageGroups
-                      .attr("opacity", dIndex => setNodeOpacityByAdjacency(state.shownData.nodes[dIndex], node, adjacentNodes, 0.12));
-                  }
-                  if(state.showNodeLabels){
-                    state.currentGraphParts.nodeLabelGroups
-                      .attr("opacity", dIndex => setNodeOpacityByAdjacency(state.shownData.nodes[dIndex], node, adjacentNodes, 0.07));
-                  }
-                  if(state.showEdges){
-                    state.currentGraphParts.edgeGroups
-                      .attr("opacity", d => setEdgeOpacityByIncidence(d, incidentEdges, 0.07));
-                  }
-                  if(state.showEdgeLabels){
-                    state.currentGraphParts.edgeLabelGroups
-                      .attr("opacity", dIndex => setEdgeOpacityByIncidence(state.shownData.edges[dIndex], incidentEdges, 0.07));
-                  }
-                }
-              }
-              function unhighlightNodeNeighborhood(event, node){
-                if(state.nodeHoverNeighborhood){
-                  if(state.showNodes){
-                    state.currentGraphParts.nodeGroups
-                      .attr("opacity", resetOpacity);
-                  }
-                  if(state.showNodeImages){
-                    state.currentGraphParts.nodeImageGroups
-                      .attr("opacity", resetOpacity);
-                  }
-                  if(state.showNodeLabels){
-                    state.currentGraphParts.nodeLabelGroups
-                      .attr("opacity", resetOpacity);
-                  }
-                  if(state.showEdges){
-                    state.currentGraphParts.edgeGroups
-                      .attr("opacity", resetOpacity);
-                  }
-                  if(state.showEdgeLabels){
-                    state.currentGraphParts.edgeLabelGroups
-                      .attr("opacity", resetOpacity);
-                  }
-                }
-              }
-              nodeGroups.on("mouseover.neighborhood", highlightNodeNeighborhood);
-              nodeGroups.on("mouseout.neighborhood", unhighlightNodeNeighborhood);
-              // - Node click behavior: details in separate container
-              function nodeClicked(event, node){
-                let htmlText = "<div>Node: " + String(node.id) + "</div>";
-                if(typeof(node.click) !== "undefined" && node.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
-                }
-                ui.elements.detailsBody.innerHTML = htmlText;
-              }
-              nodeGroups.on("click", nodeClicked);
-              // - Node drag behavior: position fixation or release
-              // https://stackoverflow.com/questions/42605261/d3-event-active-purpose-in-drag-dropping-circles
-              function dragNodes(simulation) {
-                let xAtDragStart = undefined,
-                  yAtDragStart = undefined;
-                function dragstarted(event, d){
-                  if(!event.active && state.layoutAlgorithmActive) {
-                    simulation.alphaTarget(0.3).restart();
-                  }
-                  d.fx = d.x;
-                  d.fy = d.y;
-                  if(!state.nodeDragFix){
-                    xAtDragStart = d.x;
-                    yAtDragStart = d.y;
-                  }
-                }
-                function dragged(event, d){
-                  d.fx = event.x;
-                  d.fy = event.y;
-                  if(!state.layoutAlgorithmActive){
-                    d.x = d.fx;
-                    d.y = d.fy;
-                    ui.composites.graph.updateAllActiveElementPositions();
-                  }
-                }
-                function dragended(event, d){
-                  if (!event.active) {
-                    simulation.alphaTarget(0.0);
-                  }
-                  if(!state.layoutAlgorithmActive){
-                    simulation.stop();
-                  }
-                  if(!state.nodeDragFix){
-                    // Release a node if clicked and dragged a bit, but not if just clicked
-                    if(Math.abs(event.x - xAtDragStart) > 0.1 || Math.abs(event.y - yAtDragStart) > 0.1){
-                      d.fx = null;
-                      d.fy = null;
-                    }
-                  }
-                }
-                return d3.drag()
-                  .on("start", dragstarted)
-                  .on("drag", dragged)
-                  .on("end", dragended);
-              }
-              state.currentGraphParts.nodeGroups
-                .call(dragNodes(ui.composites.graph.simulationManager.simulation));
-              // 3) Position new elements
-              ui.composites.graph.updateNodePositions();
-            },
+                return originalImageUrl;
+              });
 
-            removeNodes(){
-              state.currentGraphParts.nodeGroups.selectAll("*").remove();
-            },
+            // 3) Position new elements
+            ui.composites.graph.updateNodeImagePositions();
+          },
 
-            updateNodeVisibilities(){
-              state.currentGraphParts.nodeMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodes));
-              ui.composites.graph.updateNodePositions();
-            },
+          removeNodeImages() {
+            state.currentGraphParts.nodeImageGroups.selectAll("*").remove();
+          },
 
-            updateNodeSizes(){
-              ui.composites.graph.createNodes();
-              // Update elements depending on node size
-              ui.composites.graph.createEdges();
-              ui.composites.graph.createNodeLabels();
-              ui.composites.graph.updateNodeImageSizes();
-              ui.composites.graph.updateNodeImagePositions();
-              ui.composites.graph.updateEdgeLabelPositions();
-            },
+          updateNodeImagePositions() {
+            state.currentGraphParts.nodeImages
+              .attr("x", function (dIndex) {
+                const node = state.shownData.nodes[dIndex];
+                return node.x - node.image_size_half;
+              })
+              .attr("y", function (dIndex) {
+                const node = state.shownData.nodes[dIndex];
+                return node.y - node.image_size_half;
+              })
+          },
 
-            updateNodePositions(){
-              state.currentGraphParts.nodeCircles
-                .attr("cx", d => d.x)
-                .attr("cy", d => d.y);
-              state.currentGraphParts.nodeRectangles
-                .attr("x", d => d.x - d.size_half)
-                .attr("y", d => d.y - d.size_half);
-              state.currentGraphParts.nodeHexagons
-                .attr("d", function(d){
-                  const r = d.size_for_hexagon_r,
-                    rh = d.size_for_hexagon_rh,
-                    rs = d.size_for_hexagon_rs,
-                    x0 = d.x + r,
-                    y0 = d.y,
-                    x1 = d.x + rh,
-                    y1 = d.y + rs,
-                    x2 = d.x - rh,
-                    y2 = y1,
-                    x3 = d.x - r,
-                    y3 = d.y,
-                    x4 = x2,
-                    y4 = d.y - rs,
-                    x5 = x1,
-                    y5 = y4;
-                  return "M " + x0 + " " + y0 + " L " + x1 + " " + y1 + " L " + x2 + " " + y2 +
-                    " L " + x3 + " " + y3 + " L " + x4 + " " + y4 + " L " + x5 + " " + y5 + " Z";
-                });
-            },
+          updateNodeImageSizes() {
+            const data = state.shownData;
+            state.currentGraphParts.nodeImages
+              .attr("height", dIndex => data.nodes[dIndex].image_size)
+              .attr("width", dIndex => data.nodes[dIndex].image_size)
+          },
 
-            // Node images
-            createNodeImages(){
-              const nodeImageGroups = state.currentGraphParts.nodeImageGroups,
-                data = state.shownData;
-              // 1) Remove existing elements
-              ui.composites.graph.removeNodeImages();
-              // 2) Create new elements
-              state.currentGraphParts.nodeImages = nodeImageGroups.append("image")
-                .style("pointer-events", "none")
-                .attr("height", dIndex => data.nodes[dIndex].image_size)
-                .attr("width", dIndex => data.nodes[dIndex].image_size)
-                .attr("xlink:href", function(dIndex){
-                  const imageElement = this,
-                    originalImageUrl = data.nodes[dIndex].image,
-                    nodeId = data.nodes[dIndex].id;
-                  fetch(originalImageUrl)
-                    // Try to fetch the data from the original URL and store the image as new data URL
-                    .then(function(response){return response.blob();})
-                    .then(function(blob){
-                      const reader = new FileReader();
-                      reader.addEventListener("load", function () {
-                        d3.select(imageElement).attr("xlink:href", reader.result);
-                      }, false);
-                      reader.readAsDataURL(blob);
-                    })
-                    // If failed keep the original URL (e.g. because server does not allow CORS)
-                    .catch(function(error){
-                      const message = 'Warning: Fetching image for node ' + nodeId + ' with ' +
-                        'URL "' + originalImageUrl + '" failed.';
-                      console.log(message);
-                      state.shownData.general.node_image_fetching_failed = true;
-                    });
-                  return originalImageUrl;
-                });
-
-              // 3) Position new elements
-              ui.composites.graph.updateNodeImagePositions();
-            },
-
-            removeNodeImages(){
-              state.currentGraphParts.nodeImageGroups.selectAll("*").remove();
-            },
-
-            updateNodeImagePositions(){
-              state.currentGraphParts.nodeImages
-                .attr("x", function(dIndex){
-                  const node = state.shownData.nodes[dIndex];
-                  return node.x - node.image_size_half;
-                })
-                .attr("y", function(dIndex){
-                  const node = state.shownData.nodes[dIndex];
-                  return node.y - node.image_size_half;
-                })
-            },
-
-            updateNodeImageSizes(){
-              const data = state.shownData;
-              state.currentGraphParts.nodeImages
-                .attr("height", dIndex => data.nodes[dIndex].image_size)
-                .attr("width", dIndex => data.nodes[dIndex].image_size)
-            },
-
-            // Node labels
-            createNodeLabels(){
-              const nodeLabelGroups = state.currentGraphParts.nodeLabelGroups,
-                data = state.shownData;
-              // 1) Remove existing elements
-              ui.composites.graph.removeNodeLabels();
-              // 2) Create new elements
-              // - Node label backgrounds
-              if(state.showNodeLabelBorders){
-                state.currentGraphParts.nodeLabelBackground = nodeLabelGroups.append("text")
-                  .attr("text-anchor", "middle")
-                  .attr("dy", dIndex => data.nodes[dIndex].relative_label_placement)
-                  .attr("font-size", dIndex => data.nodes[dIndex].label_size)
-                  .style("pointer-events", "none")
-                  .style("stroke", state.shownData.general.background_color)
-                  .style("stroke-width", 2.0)
-                  .text(dIndex => data.nodes[dIndex].label);
-                if(state.nodeLabelFont !== null){
-                  state.currentGraphParts.nodeLabelBackground
-                    .attr("font-family", state.nodeLabelFont);
-                }
-              }
-
-              // - Node label texts
-              state.currentGraphParts.nodeLabel = nodeLabelGroups.append("text")
+          // Node labels
+          createNodeLabels() {
+            const nodeLabelGroups = state.currentGraphParts.nodeLabelGroups,
+              data = state.shownData;
+            // 1) Remove existing elements
+            ui.composites.graph.removeNodeLabels();
+            // 2) Create new elements
+            // - Node label backgrounds
+            if (state.showNodeLabelBorders) {
+              state.currentGraphParts.nodeLabelBackground = nodeLabelGroups.append("text")
                 .attr("text-anchor", "middle")
                 .attr("dy", dIndex => data.nodes[dIndex].relative_label_placement)
                 .attr("font-size", dIndex => data.nodes[dIndex].label_size)
                 .style("pointer-events", "none")
-                .style("fill", dIndex => data.nodes[dIndex].label_color)
+                .style("stroke", state.shownData.general.background_color)
+                .style("stroke-width", 2.0)
                 .text(dIndex => data.nodes[dIndex].label);
-              if(state.nodeLabelFont !== null){
-                state.currentGraphParts.nodeLabel
+              if (state.nodeLabelFont !== null) {
+                state.currentGraphParts.nodeLabelBackground
                   .attr("font-family", state.nodeLabelFont);
               }
-              // 3) Position new elements
-              ui.composites.graph.updateNodeLabelPositions();
-            },
+            }
 
-            removeNodeLabels(){
-              state.currentGraphParts.nodeLabelGroups.selectAll("*").remove();
-            },
-
-            updateNodeLabelPositions(){
-              // Translation (via fast SVG text position)
-              if(state.showNodeLabelBorders){
-                state.currentGraphParts.nodeLabelBackground
-                  .attr("x", dIndex => state.shownData.nodes[dIndex].x)
-                  .attr("y", dIndex => state.shownData.nodes[dIndex].y);
-              }
+            // - Node label texts
+            state.currentGraphParts.nodeLabel = nodeLabelGroups.append("text")
+              .attr("text-anchor", "middle")
+              .attr("dy", dIndex => data.nodes[dIndex].relative_label_placement)
+              .attr("font-size", dIndex => data.nodes[dIndex].label_size)
+              .style("pointer-events", "none")
+              .style("fill", dIndex => data.nodes[dIndex].label_color)
+              .text(dIndex => data.nodes[dIndex].label);
+            if (state.nodeLabelFont !== null) {
               state.currentGraphParts.nodeLabel
+                .attr("font-family", state.nodeLabelFont);
+            }
+            // 3) Position new elements
+            ui.composites.graph.updateNodeLabelPositions();
+          },
+
+          removeNodeLabels() {
+            state.currentGraphParts.nodeLabelGroups.selectAll("*").remove();
+          },
+
+          updateNodeLabelPositions() {
+            // Translation (via fast SVG text position)
+            if (state.showNodeLabelBorders) {
+              state.currentGraphParts.nodeLabelBackground
                 .attr("x", dIndex => state.shownData.nodes[dIndex].x)
                 .attr("y", dIndex => state.shownData.nodes[dIndex].y);
-              // Rotation (via slow SVG transform)
-              if(state.nodeLabelRotation !== 0.0){
-                function rotate(dIndex){
-                  const angle = -state.nodeLabelRotation,
-                    node = state.shownData.nodes[dIndex];
-                  return "rotate(" + angle + "," + node.x + "," + node.y + ")";
-                }
-                if(state.showNodeLabelBorders){
-                  state.currentGraphParts.nodeLabelBackground
-                    .attr("transform", rotate);
-                }
-                state.currentGraphParts.nodeLabel
+            }
+            state.currentGraphParts.nodeLabel
+              .attr("x", dIndex => state.shownData.nodes[dIndex].x)
+              .attr("y", dIndex => state.shownData.nodes[dIndex].y);
+            // Rotation (via slow SVG transform)
+            if (state.nodeLabelRotation !== 0.0) {
+              function rotate(dIndex) {
+                const angle = -state.nodeLabelRotation,
+                  node = state.shownData.nodes[dIndex];
+                return "rotate(" + angle + "," + node.x + "," + node.y + ")";
+              }
+              if (state.showNodeLabelBorders) {
+                state.currentGraphParts.nodeLabelBackground
                   .attr("transform", rotate);
               }
-            },
-
-            updateNodeLabelPlacements(){
-              if(state.showNodeLabelBorders){
-                state.currentGraphParts.nodeLabelBackground
-                  .attr("dy", dIndex => state.shownData.nodes[dIndex].relative_label_placement);
-              }
               state.currentGraphParts.nodeLabel
+                .attr("transform", rotate);
+            }
+          },
+
+          updateNodeLabelPlacements() {
+            if (state.showNodeLabelBorders) {
+              state.currentGraphParts.nodeLabelBackground
                 .attr("dy", dIndex => state.shownData.nodes[dIndex].relative_label_placement);
-            },
+            }
+            state.currentGraphParts.nodeLabel
+              .attr("dy", dIndex => state.shownData.nodes[dIndex].relative_label_placement);
+          },
 
-            // Edges
-            createEdges(){
-              const edgeGroups = state.currentGraphParts.edgeGroups,
-                data = state.shownData,
-                svg = state.currentGraphParts.svg,
-                arrowSize = state.shownData.general.arrow_size;
+          // Edges
+          createEdges() {
+            const edgeGroups = state.currentGraphParts.edgeGroups,
+              data = state.shownData,
+              svg = state.currentGraphParts.svg,
+              arrowSize = state.shownData.general.arrow_size;
 
-              // 1) Remove existing elements
-              ui.composites.graph.removeEdges();
-              svg.select("#§RANDOM_ID§-arrow-marker").remove();
-              // 2) Create new elements
-              // - Paths
-              state.currentGraphParts.edgePaths = edgeGroups.append("path")
-                .attr("fill", "none")
-                .attr("stroke", d => d.color)
-                .attr("stroke-opacity", d => d.opacity)
-                .attr("stroke-width", d => d.size)
-                .attr("stroke-linecap", "round");
-              // - Arrow marker for directed graphs
-              if(data.general.directed){
-                const arrowSizeDouble = arrowSize * 2.0,
-                  arrowSizeHalf = arrowSize / 2.0;
-                const marker = svg.append("marker")
-                  .attr("id", "§RANDOM_ID§-arrow-marker")
-                  .attr("markerUnits", "userSpaceOnUse")
-                  .attr("viewBox", "0 0 " + arrowSizeDouble + " " + arrowSizeDouble)
-                  .attr("refX", 0)
-                  .attr("refY", arrowSizeHalf)
-                  .attr("orient", "auto")
-                  .attr("markerWidth", arrowSize)
-                  .attr("markerHeight", arrowSize)
-                  .attr("xoverflow", "visible")
-                  .append("path")
-                    .attr("d", "M 0 0 L " + arrowSizeDouble + " " + arrowSizeHalf + " L 0 " + arrowSize + " z")
-                    .attr("fill", state.shownData.general.arrow_color)
-                state.currentGraphParts.edgePaths
-                  .attr("marker-end", "url(#§RANDOM_ID§-arrow-marker)");
-              }
-              // - Edge hover behavior
-              if(state.parsedData.general.contains_edge_hover){
-                const edgeHover = edgeGroups.filter(d => d.hover)
-                  .on("mouseover", function(event, d){
-                    if(state.edgeHoverTooltip){
-                      ui.elements.tooltipContainer.innerHTML = d.hover;
-                      const cont = ui.elements.mainContainer,
-                        contAbsX = cont.offsetLeft,
-                        contAbsY = cont.offsetTop,
-                        contBoundingRect = cont.getBoundingClientRect(),
-                        contClientX = contBoundingRect.left,
-                        contClientY = contBoundingRect.top,
-                        contWidth = contBoundingRect.width;
-                      let deltaX = event.clientX - contClientX,
-                        deltaY = event.clientY - contClientY,
-                        deltaXMax = contWidth * 0.9;
-                      if(deltaX > deltaXMax){
-                        deltaX = deltaXMax;
-                      }
-                      const xShift = contAbsX + deltaX + 7,
-                        yShift = contAbsY + deltaY + 14;
-                      ui.composites.tooltip.show(xShift, yShift);
-                    }
-                  })
-                  .on("mouseout", function(event, d){
-                    ui.composites.tooltip.hide();
-                  });
-              }
-              // - Edge click behavior
-              function edgeClicked(event, edge){
-                let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
-                if(typeof(edge.click) !== "undefined" && edge.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
-                }
-                ui.elements.detailsBody.innerHTML = htmlText;
-              }
-              edgeGroups.on("click", edgeClicked);
-              // 3) Position new elements
-              ui.composites.graph.updateEdgePositions();
-            },
-
-            removeEdges(){
-              state.currentGraphParts.edgeGroups.selectAll("*").remove();
-            },
-
-            updateEdgeSizes(){
-              ui.composites.graph.createEdges();
-            },
-
-            _calcStraightEdgePosition(d){
-              const uv = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, d.target.x, d.target.y),
-                arrowSize = state.shownData.general.arrow_size;
-              let sourceSizeHalf = d.source.size_half,
-                targetSizeHalf = d.target.size_half;
-              if(d.source.shape == "rectangle"){
-                sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv);
-              }
-              if(d.target.shape == "rectangle"){
-                targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv);
-              }
-              const curveLength = uv.len - sourceSizeHalf - targetSizeHalf,
-                arrowSpacer = (curveLength > arrowSize) ? arrowSize : (curveLength - 0.01),
-                sourceSpacer = sourceSizeHalf + d.source.border_size_half,
-                targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer;
-              const xStart = d.source.x + (uv.dx * sourceSpacer),
-                yStart = d.source.y + (uv.dy * sourceSpacer),
-                xEnd = d.target.x - (uv.dx * targetSpacer),
-                yEnd = d.target.y - (uv.dy * targetSpacer);
-              d.xLabelPoint = (xStart + xEnd) / 2.0;  // equivalent: xStart + ((xEnd - xStart) / 2.0);
-              d.yLabelPoint = (yStart + yEnd) / 2.0;  // equivalent: yStart + ((yEnd - yStart) / 2.0);
-              const path = "M " + xStart + " " + yStart + " L " + xEnd + " " + yEnd;
-              return path;
-            },
-
-            _calcCurvedEdgePosition(d){
-              // Quadratic bezier curve
-              let sourceSizeHalf = d.source.size_half,
-                targetSizeHalf = d.target.size_half;
-              const arrowSize = state.shownData.general.arrow_size,
-                dx = d.target.x - d.source.x,
-                dy = d.target.y - d.source.y,
-                len = Math.sqrt(dx**2 + dy**2),
-                dxHalf = dx / 2.0,
-                dyHalf = dy / 2.0,
-                lenHalf = len / 2.0,
-                lenHalfCorrected = lenHalf + (sourceSizeHalf - targetSizeHalf) / 2.0 - arrowSize;  // equivalent: sourceSizeHalf + (len - sourceSizeHalf - targetSizeHalf) / 2.0 - arrowSize;
-                const nodeSizeCorrectionFactor = lenHalfCorrected / lenHalf,
-                xBezier = d.source.x + dxHalf * nodeSizeCorrectionFactor + (dyHalf * d.multi_edge_curvature_factor),
-                yBezier = d.source.y + dyHalf * nodeSizeCorrectionFactor - (dxHalf * d.multi_edge_curvature_factor),
-                uv1 = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, xBezier, yBezier),
-                uv2 = ui.composites.graph.calcUnitVector(xBezier, yBezier, d.target.x, d.target.y);
-              if(d.source.shape == "rectangle"){
-                sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv1);
-              }
-              if(d.target.shape == "rectangle"){
-                targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv2);
-              }
-              const curveLength = (uv1.len + uv2.len) - sourceSizeHalf - targetSizeHalf,
-                arrowSpacer = (curveLength > arrowSize) ? arrowSize : (curveLength - 0.01),
-                sourceSpacer = sourceSizeHalf + d.source.border_size_half,
-                targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer;
-              const xStart = d.source.x + (uv1.dx * sourceSpacer),
-                yStart = d.source.y + (uv1.dy * sourceSpacer),
-                xEnd = d.target.x - (uv2.dx * targetSpacer),
-                yEnd = d.target.y - (uv2.dy * targetSpacer),
-                xMidpoint = xStart + ((xEnd - xStart) / 2.0),
-                yMidpoint = yStart + ((yEnd - yStart) / 2.0);
-              d.xLabelPoint = (xMidpoint + xBezier) / 2.0;  // equivalent: xMidpoint + ((xBezier - xMidpoint) / 2.0);
-              d.yLabelPoint = (yMidpoint + yBezier) / 2.0;  // equivalent: yMidpoint + ((yBezier - yMidpoint) / 2.0);
-              const path = "M " + xStart + " " + yStart + " Q " + xBezier + " " + yBezier + ", " + xEnd + " " + yEnd;
-              return path;
-            },
-
-            _calcSelfEdgePosition(d){
-              // Cubic bezier curve
-              let sourceSizeHalf = d.source.size_half,
-                targetSizeHalf = d.target.size_half;
-              const arrowSize = state.shownData.general.arrow_size,
-                dx = d.source.size + 10.0 * d.multi_edge_counter + 5.0 * Math.abs(d.multi_edge_curvature_factor),
-                dy = d.source.size * 1.5 + 20.0 * d.multi_edge_counter + 10.0 * Math.abs(d.multi_edge_curvature_factor);
-              let xBezier1 = null, xBezier2 = null, yBezier1 = null, yBezier2 = null;
-              if(d.multi_edge_curvature_factor >= 0.0){
-                xBezier1 = d.source.x - dx;
-                xBezier2 = d.source.x + dx;
-                yBezier1 = d.source.y - dy;
-                yBezier2 = yBezier1;
-              } else{
-                xBezier1 = d.source.x + dx;
-                xBezier2 = d.source.x - dx;
-                yBezier1 = d.source.y - dy;
-                yBezier2 = yBezier1;
-              }
-              const uv1 = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, xBezier1, yBezier1),
-                uv2 = ui.composites.graph.calcUnitVector(xBezier2, yBezier2, d.target.x, d.target.y);
-              if(d.source.shape == "rectangle"){
-                sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv1);
-              }
-              if(d.target.shape == "rectangle"){
-                targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv2);
-              }
-              const arrowSpacer = arrowSize,
-                sourceSpacer = sourceSizeHalf + d.source.border_size_half,
-                targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer,
-                xStart = d.source.x + (uv1.dx * sourceSpacer),
-                yStart = d.source.y + (uv1.dy * sourceSpacer),
-                xEnd = d.target.x - (uv2.dx * targetSpacer),
-                yEnd = d.target.y - (uv2.dy * targetSpacer);
-              d.xLabelPoint = d.source.x;
-              d.yLabelPoint = d.source.y - dy * 0.8;
-              const path = "M " + xStart + " " + yStart + " C " + xBezier1 + " " + yBezier1 + ", " + xBezier2 + " " + yBezier2 + ", " + xEnd + " " + yEnd;
-              return path;
-            },
-
-            updateEdgePositions(){
-              const arrowSize = state.shownData.general.arrow_size;
+            // 1) Remove existing elements
+            ui.composites.graph.removeEdges();
+            svg.select("#§RANDOM_ID§-arrow-marker").remove();
+            // 2) Create new elements
+            // - Paths
+            state.currentGraphParts.edgePaths = edgeGroups.append("path")
+              .attr("fill", "none")
+              .attr("stroke", d => d.color)
+              .attr("stroke-opacity", d => d.opacity)
+              .attr("stroke-width", d => d.size)
+              .attr("stroke-linecap", "round");
+            // - Arrow marker for directed graphs
+            if (data.general.directed) {
+              const arrowSizeDouble = arrowSize * 2.0,
+                arrowSizeHalf = arrowSize / 2.0;
+              const marker = svg.append("marker")
+                .attr("id", "§RANDOM_ID§-arrow-marker")
+                .attr("markerUnits", "userSpaceOnUse")
+                .attr("viewBox", "0 0 " + arrowSizeDouble + " " + arrowSizeDouble)
+                .attr("refX", 0)
+                .attr("refY", arrowSizeHalf)
+                .attr("orient", "auto")
+                .attr("markerWidth", arrowSize)
+                .attr("markerHeight", arrowSize)
+                .attr("xoverflow", "visible")
+                .append("path")
+                .attr("d", "M 0 0 L " + arrowSizeDouble + " " + arrowSizeHalf + " L 0 " + arrowSize + " z")
+                .attr("fill", state.shownData.general.arrow_color)
               state.currentGraphParts.edgePaths
-                .attr("d", function(d){
-                  let path;
-                  if(d.source === d.target){
-                    // Case 1: Self edge (drawn curved)
-                    path = ui.composites.graph._calcSelfEdgePosition(d);
-                  } else{
-                    // Case 2: Normal edge (drawn straight or curved)
-                    if(state.edgeCurvature === 0.0){
-                      path = ui.composites.graph._calcStraightEdgePosition(d);
-                    } else {
-                      path = ui.composites.graph._calcCurvedEdgePosition(d);
+                .attr("marker-end", "url(#§RANDOM_ID§-arrow-marker)");
+            }
+            // - Edge hover behavior
+            if (state.parsedData.general.contains_edge_hover) {
+              const edgeHover = edgeGroups.filter(d => d.hover)
+                .on("mouseover", function (event, d) {
+                  if (state.edgeHoverTooltip) {
+                    ui.elements.tooltipContainer.innerHTML = d.hover;
+                    const cont = ui.elements.mainContainer,
+                      contAbsX = cont.offsetLeft,
+                      contAbsY = cont.offsetTop,
+                      contBoundingRect = cont.getBoundingClientRect(),
+                      contClientX = contBoundingRect.left,
+                      contClientY = contBoundingRect.top,
+                      contWidth = contBoundingRect.width;
+                    let deltaX = event.clientX - contClientX,
+                      deltaY = event.clientY - contClientY,
+                      deltaXMax = contWidth * 0.9;
+                    if (deltaX > deltaXMax) {
+                      deltaX = deltaXMax;
                     }
+                    const xShift = contAbsX + deltaX + 7,
+                      yShift = contAbsY + deltaY + 14;
+                    ui.composites.tooltip.show(xShift, yShift);
                   }
-                  return path;
                 })
-            },
-
-            calcUnitVector(x1, y1, x2, y2){
-              const dx = x2 - x1,
-                dy = y2 - y1,
-                len = Math.sqrt(dx**2 + dy**2);
-              return {dx: dx/len, dy: dy/len, len: len};
-            },
-
-            adaptLenForRectShape(spacer, vec){
-              return spacer / Math.max(Math.abs(vec.dx), Math.abs(vec.dy));
-            },
-
-            // Edge labels
-            createEdgeLabels(){
-              const edgeLabelGroups = state.currentGraphParts.edgeLabelGroups,
-                data = state.shownData;
-              // 1) Remove existing elements
-              ui.composites.graph.removeEdgeLabels();
-              // 2) Create new elements
-              function verticalEdgePosFunc(dIndex){
-                const edgeLabelSize = data.edges[dIndex].label_size;
-                return edgeLabelSize / 2.6;
+                .on("mouseout", function (event, d) {
+                  ui.composites.tooltip.hide();
+                });
+            }
+            // - Edge click behavior
+            function edgeClicked(event, edge) {
+              let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
+              if (typeof (edge.click) !== "undefined" && edge.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
               }
-              // - Edge label backgrounds
-              if(state.showEdgeLabelBorders){
-                state.currentGraphParts.edgeLabelBackground = edgeLabelGroups.append("text")
-                  .attr("text-anchor", "middle")
-                  .attr("dy", verticalEdgePosFunc)
-                  .attr("font-size", dIndex => data.edges[dIndex].label_size)
-                  .style("pointer-events", "none")
-                  .style("stroke", state.shownData.general.background_color)
-                  .style("stroke-width", 1.4)
-                  .text(dIndex => data.edges[dIndex].label);
-                if(state.edgeLabelFont !== null){
-                  state.currentGraphParts.edgeLabelBackground
-                    .attr("font-family", state.edgeLabelFont);
+              ui.elements.detailsBody.innerHTML = htmlText;
+            }
+            edgeGroups.on("click", edgeClicked);
+            // 3) Position new elements
+            ui.composites.graph.updateEdgePositions();
+          },
+
+          removeEdges() {
+            state.currentGraphParts.edgeGroups.selectAll("*").remove();
+          },
+
+          updateEdgeSizes() {
+            ui.composites.graph.createEdges();
+          },
+
+          _calcStraightEdgePosition(d) {
+            const uv = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, d.target.x, d.target.y),
+              arrowSize = state.shownData.general.arrow_size;
+            let sourceSizeHalf = d.source.size_half,
+              targetSizeHalf = d.target.size_half;
+            if (d.source.shape == "rectangle") {
+              sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv);
+            }
+            if (d.target.shape == "rectangle") {
+              targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv);
+            }
+            const curveLength = uv.len - sourceSizeHalf - targetSizeHalf,
+              arrowSpacer = (curveLength > arrowSize) ? arrowSize : (curveLength - 0.01),
+              sourceSpacer = sourceSizeHalf + d.source.border_size_half,
+              targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer;
+            const xStart = d.source.x + (uv.dx * sourceSpacer),
+              yStart = d.source.y + (uv.dy * sourceSpacer),
+              xEnd = d.target.x - (uv.dx * targetSpacer),
+              yEnd = d.target.y - (uv.dy * targetSpacer);
+            d.xLabelPoint = (xStart + xEnd) / 2.0;  // equivalent: xStart + ((xEnd - xStart) / 2.0);
+            d.yLabelPoint = (yStart + yEnd) / 2.0;  // equivalent: yStart + ((yEnd - yStart) / 2.0);
+            const path = "M " + xStart + " " + yStart + " L " + xEnd + " " + yEnd;
+            return path;
+          },
+
+          _calcCurvedEdgePosition(d) {
+            // Quadratic bezier curve
+            let sourceSizeHalf = d.source.size_half,
+              targetSizeHalf = d.target.size_half;
+            const arrowSize = state.shownData.general.arrow_size,
+              dx = d.target.x - d.source.x,
+              dy = d.target.y - d.source.y,
+              len = Math.sqrt(dx ** 2 + dy ** 2),
+              dxHalf = dx / 2.0,
+              dyHalf = dy / 2.0,
+              lenHalf = len / 2.0,
+              lenHalfCorrected = lenHalf + (sourceSizeHalf - targetSizeHalf) / 2.0 - arrowSize;  // equivalent: sourceSizeHalf + (len - sourceSizeHalf - targetSizeHalf) / 2.0 - arrowSize;
+            const nodeSizeCorrectionFactor = lenHalfCorrected / lenHalf,
+              xBezier = d.source.x + dxHalf * nodeSizeCorrectionFactor + (dyHalf * d.multi_edge_curvature_factor),
+              yBezier = d.source.y + dyHalf * nodeSizeCorrectionFactor - (dxHalf * d.multi_edge_curvature_factor),
+              uv1 = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, xBezier, yBezier),
+              uv2 = ui.composites.graph.calcUnitVector(xBezier, yBezier, d.target.x, d.target.y);
+            if (d.source.shape == "rectangle") {
+              sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv1);
+            }
+            if (d.target.shape == "rectangle") {
+              targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv2);
+            }
+            const curveLength = (uv1.len + uv2.len) - sourceSizeHalf - targetSizeHalf,
+              arrowSpacer = (curveLength > arrowSize) ? arrowSize : (curveLength - 0.01),
+              sourceSpacer = sourceSizeHalf + d.source.border_size_half,
+              targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer;
+            const xStart = d.source.x + (uv1.dx * sourceSpacer),
+              yStart = d.source.y + (uv1.dy * sourceSpacer),
+              xEnd = d.target.x - (uv2.dx * targetSpacer),
+              yEnd = d.target.y - (uv2.dy * targetSpacer),
+              xMidpoint = xStart + ((xEnd - xStart) / 2.0),
+              yMidpoint = yStart + ((yEnd - yStart) / 2.0);
+            d.xLabelPoint = (xMidpoint + xBezier) / 2.0;  // equivalent: xMidpoint + ((xBezier - xMidpoint) / 2.0);
+            d.yLabelPoint = (yMidpoint + yBezier) / 2.0;  // equivalent: yMidpoint + ((yBezier - yMidpoint) / 2.0);
+            const path = "M " + xStart + " " + yStart + " Q " + xBezier + " " + yBezier + ", " + xEnd + " " + yEnd;
+            return path;
+          },
+
+          _calcSelfEdgePosition(d) {
+            // Cubic bezier curve
+            let sourceSizeHalf = d.source.size_half,
+              targetSizeHalf = d.target.size_half;
+            const arrowSize = state.shownData.general.arrow_size,
+              dx = d.source.size + 10.0 * d.multi_edge_counter + 5.0 * Math.abs(d.multi_edge_curvature_factor),
+              dy = d.source.size * 1.5 + 20.0 * d.multi_edge_counter + 10.0 * Math.abs(d.multi_edge_curvature_factor);
+            let xBezier1 = null, xBezier2 = null, yBezier1 = null, yBezier2 = null;
+            if (d.multi_edge_curvature_factor >= 0.0) {
+              xBezier1 = d.source.x - dx;
+              xBezier2 = d.source.x + dx;
+              yBezier1 = d.source.y - dy;
+              yBezier2 = yBezier1;
+            } else {
+              xBezier1 = d.source.x + dx;
+              xBezier2 = d.source.x - dx;
+              yBezier1 = d.source.y - dy;
+              yBezier2 = yBezier1;
+            }
+            const uv1 = ui.composites.graph.calcUnitVector(d.source.x, d.source.y, xBezier1, yBezier1),
+              uv2 = ui.composites.graph.calcUnitVector(xBezier2, yBezier2, d.target.x, d.target.y);
+            if (d.source.shape == "rectangle") {
+              sourceSizeHalf = ui.composites.graph.adaptLenForRectShape(sourceSizeHalf, uv1);
+            }
+            if (d.target.shape == "rectangle") {
+              targetSizeHalf = ui.composites.graph.adaptLenForRectShape(targetSizeHalf, uv2);
+            }
+            const arrowSpacer = arrowSize,
+              sourceSpacer = sourceSizeHalf + d.source.border_size_half,
+              targetSpacer = targetSizeHalf + d.target.border_size_half + arrowSpacer,
+              xStart = d.source.x + (uv1.dx * sourceSpacer),
+              yStart = d.source.y + (uv1.dy * sourceSpacer),
+              xEnd = d.target.x - (uv2.dx * targetSpacer),
+              yEnd = d.target.y - (uv2.dy * targetSpacer);
+            d.xLabelPoint = d.source.x;
+            d.yLabelPoint = d.source.y - dy * 0.8;
+            const path = "M " + xStart + " " + yStart + " C " + xBezier1 + " " + yBezier1 + ", " + xBezier2 + " " + yBezier2 + ", " + xEnd + " " + yEnd;
+            return path;
+          },
+
+          updateEdgePositions() {
+            const arrowSize = state.shownData.general.arrow_size;
+            state.currentGraphParts.edgePaths
+              .attr("d", function (d) {
+                let path;
+                if (d.source === d.target) {
+                  // Case 1: Self edge (drawn curved)
+                  path = ui.composites.graph._calcSelfEdgePosition(d);
+                } else {
+                  // Case 2: Normal edge (drawn straight or curved)
+                  if (state.edgeCurvature === 0.0) {
+                    path = ui.composites.graph._calcStraightEdgePosition(d);
+                  } else {
+                    path = ui.composites.graph._calcCurvedEdgePosition(d);
+                  }
                 }
-              }
-              // - Edge label texts
-              state.currentGraphParts.edgeLabel = edgeLabelGroups.append("text")
+                return path;
+              })
+          },
+
+          calcUnitVector(x1, y1, x2, y2) {
+            const dx = x2 - x1,
+              dy = y2 - y1,
+              len = Math.sqrt(dx ** 2 + dy ** 2);
+            return { dx: dx / len, dy: dy / len, len: len };
+          },
+
+          adaptLenForRectShape(spacer, vec) {
+            return spacer / Math.max(Math.abs(vec.dx), Math.abs(vec.dy));
+          },
+
+          // Edge labels
+          createEdgeLabels() {
+            const edgeLabelGroups = state.currentGraphParts.edgeLabelGroups,
+              data = state.shownData;
+            // 1) Remove existing elements
+            ui.composites.graph.removeEdgeLabels();
+            // 2) Create new elements
+            function verticalEdgePosFunc(dIndex) {
+              const edgeLabelSize = data.edges[dIndex].label_size;
+              return edgeLabelSize / 2.6;
+            }
+            // - Edge label backgrounds
+            if (state.showEdgeLabelBorders) {
+              state.currentGraphParts.edgeLabelBackground = edgeLabelGroups.append("text")
                 .attr("text-anchor", "middle")
                 .attr("dy", verticalEdgePosFunc)
                 .attr("font-size", dIndex => data.edges[dIndex].label_size)
                 .style("pointer-events", "none")
-                .style("fill", dIndex => data.edges[dIndex].label_color)
+                .style("stroke", state.shownData.general.background_color)
+                .style("stroke-width", 1.4)
                 .text(dIndex => data.edges[dIndex].label);
-              if(state.edgeLabelFont !== null){
-                state.currentGraphParts.edgeLabel
+              if (state.edgeLabelFont !== null) {
+                state.currentGraphParts.edgeLabelBackground
                   .attr("font-family", state.edgeLabelFont);
               }
-              // 3) Position new elements
-              ui.composites.graph.updateEdgeLabelPositions();
-            },
-
-            removeEdgeLabels(){
-              state.currentGraphParts.edgeLabelGroups.selectAll("*").remove();
-            },
-
-            updateEdgeLabelPositions(){
-              // Translation (via fast SVG text position)
-              if(state.showEdgeLabelBorders){
-                state.currentGraphParts.edgeLabelBackground
-                  .attr("x", function(dIndex){
-                    return state.shownData.edges[dIndex].xLabelPoint;
-                  })
-                  .attr("y", function(dIndex){
-                    return state.shownData.edges[dIndex].yLabelPoint;
-                  });
-              }
+            }
+            // - Edge label texts
+            state.currentGraphParts.edgeLabel = edgeLabelGroups.append("text")
+              .attr("text-anchor", "middle")
+              .attr("dy", verticalEdgePosFunc)
+              .attr("font-size", dIndex => data.edges[dIndex].label_size)
+              .style("pointer-events", "none")
+              .style("fill", dIndex => data.edges[dIndex].label_color)
+              .text(dIndex => data.edges[dIndex].label);
+            if (state.edgeLabelFont !== null) {
               state.currentGraphParts.edgeLabel
-                .attr("x", function(dIndex){
+                .attr("font-family", state.edgeLabelFont);
+            }
+            // 3) Position new elements
+            ui.composites.graph.updateEdgeLabelPositions();
+          },
+
+          removeEdgeLabels() {
+            state.currentGraphParts.edgeLabelGroups.selectAll("*").remove();
+          },
+
+          updateEdgeLabelPositions() {
+            // Translation (via fast SVG text position)
+            if (state.showEdgeLabelBorders) {
+              state.currentGraphParts.edgeLabelBackground
+                .attr("x", function (dIndex) {
                   return state.shownData.edges[dIndex].xLabelPoint;
                 })
-                .attr("y", function(dIndex){
+                .attr("y", function (dIndex) {
                   return state.shownData.edges[dIndex].yLabelPoint;
                 });
-              // Rotation (via slow SVG transform)
-              if(state.edgeLabelRotation !== 0.0){
-                function rotate(dIndex){
-                  const angle = -state.edgeLabelRotation,
-                    edge = state.shownData.edges[dIndex];
-                  return "rotate(" + angle + "," + edge.xLabelPoint + "," + edge.yLabelPoint + ")";
-                }
-                if(state.showEdgeLabelBorders){
-                  state.currentGraphParts.edgeLabelBackground
-                    .attr("transform", rotate);
-                }
-                state.currentGraphParts.edgeLabel
+            }
+            state.currentGraphParts.edgeLabel
+              .attr("x", function (dIndex) {
+                return state.shownData.edges[dIndex].xLabelPoint;
+              })
+              .attr("y", function (dIndex) {
+                return state.shownData.edges[dIndex].yLabelPoint;
+              });
+            // Rotation (via slow SVG transform)
+            if (state.edgeLabelRotation !== 0.0) {
+              function rotate(dIndex) {
+                const angle = -state.edgeLabelRotation,
+                  edge = state.shownData.edges[dIndex];
+                return "rotate(" + angle + "," + edge.xLabelPoint + "," + edge.yLabelPoint + ")";
+              }
+              if (state.showEdgeLabelBorders) {
+                state.currentGraphParts.edgeLabelBackground
                   .attr("transform", rotate);
               }
-            },
-
-            // Layout algorithm
-            simulationManager:{
-              simulation: null,
-              initialize() {
-                this.simulation = d3.forceSimulation(state.shownData.nodes);
-              },
-              move(){
-                if(state.layoutAlgorithmActive){
-                  this.simulation.alpha(1.0);
-                  this.simulation.restart();
-                }
-              },
-              stop(){
-                this.simulation.stop();
-              },
-              releaseFixedNodes(){
-                state.currentGraphParts.nodeGroups
-                  .each(function(node){
-                    node.fx = null;
-                    node.fy = null;
-                  });
-              },
-              setAllForces(){
-                this.setCenteringForce();
-                this.setCollisionForce();
-                this.setLinksForce();
-                this.setManyBodyForce();
-                this.setXPositioningForce();
-                this.setYPositioningForce();
-              },
-              setCenteringForce(){
-                let centeringForce = null;
-                if(state.useCenteringForce){
-                  centeringForce = d3.forceCenter()
-                    .x(0.0)
-                    .y(0.0);
-                }
-                this.simulation.force("centering", centeringForce);
-              },
-              setCollisionForce(){
-                let collisionForce = null;
-                if(state.useCollisionForce){
-                  collisionForce = d3.forceCollide()
-                    .radius(state.collisionForceRadius)
-                    .strength(state.collisionForceStrength);
-                }
-                this.simulation.force("collision", collisionForce);
-              },
-              setLinksForce(){
-                let linksForce = null;
-                if(state.useLinksForce){
-                  const nodes = state.shownData.nodes,
-                    edges = state.shownData.edges;
-                  if(!state.shownData.edgeCounts){
-                    const count = {};
-                    for(let i=0; i<edges.length; i++){
-                      const edge = edges[i];
-                      count[edge.source.id] = (count[edge.source.id] || 0) + 1;
-                      count[edge.target.id] = (count[edge.target.id] || 0) + 1;
-                    }
-                    state.shownData.edgeCounts = count;
-                  }
-                  linksForce = d3.forceLink(state.shownData.edges)
-                    .distance(state.linksForceDistance)
-                    .strength(function(d) {
-                      // Adapted from https://github.com/d3/d3-force/blob/master/src/link.js
-                      const fixedConnectivity = Math.min(
-                        state.shownData.edgeCounts[d.source.id],
-                        state.shownData.edgeCounts[d.target.id]
-                      );
-                      const adjustableStrength = 2.0 * state.linksForceStrength;
-                      return adjustableStrength / fixedConnectivity;
-                    });
-                }
-                this.simulation.force("links", linksForce);
-              },
-              setManyBodyForce(){
-                let manyBodyForce = null;
-                if(state.useManyBodyForce){
-                  manyBodyForce = d3.forceManyBody()
-                    .strength(state.manyBodyForceStrength)
-                    .theta(state.manyBodyForceTheta);
-                  if(state.useManyBodyForceMinDistance){
-                    manyBodyForce.distanceMin(state.manyBodyForceMinDistance);
-                  } else{
-                    manyBodyForce.distanceMin(0.0);
-                  }
-                  if(state.useManyBodyForceMaxDistance){
-                    manyBodyForce.distanceMax(state.manyBodyForceMaxDistance);
-                  } else{
-                    manyBodyForce.distanceMax(Infinity);
-                  }
-                }
-                this.simulation.force("many-body", manyBodyForce);
-              },
-              setXPositioningForce(){
-                let xPositioningForce = null;
-                if(state.useXPositioningForce){
-                  xPositioningForce = d3.forceX()
-                    .strength(state.xPositioningForceStrength)
-                    .x(0.0);
-                }
-                this.simulation.force("x-positioning", xPositioningForce);
-              },
-              setYPositioningForce(){
-                let yPositioningForce = null;
-                if(state.useYPositioningForce){
-                  yPositioningForce = d3.forceY()
-                    .strength(state.yPositioningForceStrength)
-                    .y(0.0);
-                }
-                this.simulation.force("y-positioning", yPositioningForce);
-              },
-            },
-          },
-        },
-
-        init(){
-          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
-          // Containers
-          ui.composites.responsiveContainer.init();
-          // Graph selection (only visible if multiple graphs in data)
-          if(state.rawData.length > 1){
-            ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            const optionList = [],
-              valueList = [];
-            let label;
-            for(let i=0; i<state.rawData.length; i++){
-              const graph = state.rawData[i];
-              try{
-                label = String(graph.label);
-                if(label === "undefined" || label === ""){
-                  throw "Invalid label";
-                }
-              } catch(e){
-                label = "Unnamed graph";
-              }
-              const name = String(i+1) + ": " + label;
-              optionList.push(name);
-              valueList.push(String(i));
+              state.currentGraphParts.edgeLabel
+                .attr("transform", rotate);
             }
-            ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
-          }
-          // General (menu item)
-          ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
-          // Data selection (menu item)
-          ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
-          // - Node size
-          ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
-          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-          ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-          ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-          // - Edge size
-          ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
-          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-          ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-          ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
-          // Nodes
-          ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
-          ui.elements.nodeCheckbox.checked = state.showNodes;
-          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
-          ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
-          ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
-          ui.elements.nodeHoverNeighborhoodCheckbox.checked = state.nodeHoverNeighborhood;
-          ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
-          // Node images
-          ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
-          ui.elements.nodeImageMetaControl.style.display = false;
-          ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
-          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
-          ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
-          // Node labels
-          ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
-          ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
-          ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
-          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
-          ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
-          ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(state.nodeLabelRotation);
-          ui.elements.nodeLabelRotationSlider.value = state.nodeLabelRotation;
-          // Edges
-          ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
-          ui.elements.edgeCheckbox.checked = state.showEdges;
-          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
-          ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
-          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
-          ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
-          ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
-          // Edge labels
-          ui.composites.menu.setItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody, false);
-          ui.elements.edgeLabelCheckbox.checked = state.showEdgeLabels;
-          ui.elements.edgeLabelBorderCheckbox.checked = state.showEdgeLabelBorders;
-          ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeLabelSizeFactor);
-          ui.elements.edgeLabelSizeFactorSlider.value = state.edgeLabelSizeFactor;
-          ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(state.edgeLabelRotation);
-          ui.elements.edgeLabelRotationSlider.value = state.edgeLabelRotation;
+          },
+
           // Layout algorithm
-          ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
-          ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
-          ui.elements.manyBodyForceCheckbox.checked = state.useManyBodyForce;
-          ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
-          ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(state.manyBodyForceStrength);
-          ui.elements.manyBodyForceStrengthSlider.value = state.manyBodyForceStrength;
-          ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(state.manyBodyForceTheta);
-          ui.elements.manyBodyForceThetaSlider.value = state.manyBodyForceTheta;
-          ui.elements.manyBodyForceMinDistCheckbox.checked = state.useManyBodyForceMinDistance;
-          ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
-          ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
-          ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
-          ui.elements.manyBodyForceMaxDistCheckbox.checked = state.useManyBodyForceMaxDistance;
-          ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
-          ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
-          ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
-          ui.elements.linksForceCheckbox.checked = state.useLinksForce;
-          ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
-          ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(state.linksForceDistance);
-          ui.elements.linksForceDistanceSlider.value = state.linksForceDistance;
-          ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(state.linksForceStrength);
-          ui.elements.linksForceStrengthSlider.value = state.linksForceStrength;
-          ui.elements.collisionForceCheckbox.checked = state.useCollisionForce;
-          ui.elements.collisionForceContainer.style.opacity = ui.convert.boolToOpacity(state.useCollisionForce);
-          ui.elements.collisionForceRadiusText.innerHTML = ui.convert.numberToText(state.collisionForceRadius);
-          ui.elements.collisionForceRadiusSlider.value = state.collisionForceRadius;
-          ui.elements.collisionForceStrengthText.innerHTML = ui.convert.numberToText(state.collisionForceStrength);
-          ui.elements.collisionForceStrengthSlider.value = state.collisionForceStrength;
-          ui.elements.xPositioningForceCheckbox.checked = state.useXPositioningForce;
-          ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
-          ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.xPositioningForceStrength);
-          ui.elements.xPositioningForceStrengthSlider.value = state.xPositioningForceStrength;
-          ui.elements.yPositioningForceCheckbox.checked = state.useYPositioningForce;
-          ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
-          ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.yPositioningForceStrength);
-          ui.elements.yPositioningForceStrengthSlider.value = state.yPositioningForceStrength;
-          ui.elements.centeringForceCheckbox.checked = state.useCenteringForce;
-
-          ui.initSelectionValues();
+          simulationManager: {
+            simulation: null,
+            initialize() {
+              this.simulation = d3.forceSimulation(state.shownData.nodes);
+            },
+            move() {
+              if (state.layoutAlgorithmActive) {
+                this.simulation.alpha(1.0);
+                this.simulation.restart();
+              }
+            },
+            stop() {
+              this.simulation.stop();
+            },
+            releaseFixedNodes() {
+              state.currentGraphParts.nodeGroups
+                .each(function (node) {
+                  node.fx = null;
+                  node.fy = null;
+                });
+            },
+            setAllForces() {
+              this.setCenteringForce();
+              this.setCollisionForce();
+              this.setLinksForce();
+              this.setManyBodyForce();
+              this.setXPositioningForce();
+              this.setYPositioningForce();
+            },
+            setCenteringForce() {
+              let centeringForce = null;
+              if (state.useCenteringForce) {
+                centeringForce = d3.forceCenter()
+                  .x(0.0)
+                  .y(0.0);
+              }
+              this.simulation.force("centering", centeringForce);
+            },
+            setCollisionForce() {
+              let collisionForce = null;
+              if (state.useCollisionForce) {
+                collisionForce = d3.forceCollide()
+                  .radius(state.collisionForceRadius)
+                  .strength(state.collisionForceStrength);
+              }
+              this.simulation.force("collision", collisionForce);
+            },
+            setLinksForce() {
+              let linksForce = null;
+              if (state.useLinksForce) {
+                const nodes = state.shownData.nodes,
+                  edges = state.shownData.edges;
+                if (!state.shownData.edgeCounts) {
+                  const count = {};
+                  for (let i = 0; i < edges.length; i++) {
+                    const edge = edges[i];
+                    count[edge.source.id] = (count[edge.source.id] || 0) + 1;
+                    count[edge.target.id] = (count[edge.target.id] || 0) + 1;
+                  }
+                  state.shownData.edgeCounts = count;
+                }
+                linksForce = d3.forceLink(state.shownData.edges)
+                  .distance(state.linksForceDistance)
+                  .strength(function (d) {
+                    // Adapted from https://github.com/d3/d3-force/blob/master/src/link.js
+                    const fixedConnectivity = Math.min(
+                      state.shownData.edgeCounts[d.source.id],
+                      state.shownData.edgeCounts[d.target.id]
+                    );
+                    const adjustableStrength = 2.0 * state.linksForceStrength;
+                    return adjustableStrength / fixedConnectivity;
+                  });
+              }
+              this.simulation.force("links", linksForce);
+            },
+            setManyBodyForce() {
+              let manyBodyForce = null;
+              if (state.useManyBodyForce) {
+                manyBodyForce = d3.forceManyBody()
+                  .strength(state.manyBodyForceStrength)
+                  .theta(state.manyBodyForceTheta);
+                if (state.useManyBodyForceMinDistance) {
+                  manyBodyForce.distanceMin(state.manyBodyForceMinDistance);
+                } else {
+                  manyBodyForce.distanceMin(0.0);
+                }
+                if (state.useManyBodyForceMaxDistance) {
+                  manyBodyForce.distanceMax(state.manyBodyForceMaxDistance);
+                } else {
+                  manyBodyForce.distanceMax(Infinity);
+                }
+              }
+              this.simulation.force("many-body", manyBodyForce);
+            },
+            setXPositioningForce() {
+              let xPositioningForce = null;
+              if (state.useXPositioningForce) {
+                xPositioningForce = d3.forceX()
+                  .strength(state.xPositioningForceStrength)
+                  .x(0.0);
+              }
+              this.simulation.force("x-positioning", xPositioningForce);
+            },
+            setYPositioningForce() {
+              let yPositioningForce = null;
+              if (state.useYPositioningForce) {
+                yPositioningForce = d3.forceY()
+                  .strength(state.yPositioningForceStrength)
+                  .y(0.0);
+              }
+              this.simulation.force("y-positioning", yPositioningForce);
+            },
+          },
         },
+      },
 
-        initSelectionValues(){
-          function setSelectionOptionsAndValue(element, options, value){
-            if(!options.includes(value)){
-              value = options[0];
+      init() {
+        ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
+        // Containers
+        ui.composites.responsiveContainer.init();
+        // Graph selection (only visible if multiple graphs in data)
+        if (state.rawData.length > 1) {
+          ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          const optionList = [],
+            valueList = [];
+          let label;
+          for (let i = 0; i < state.rawData.length; i++) {
+            const graph = state.rawData[i];
+            try {
+              label = String(graph.label);
+              if (label === "undefined" || label === "") {
+                throw "Invalid label";
+              }
+            } catch (e) {
+              label = "Unnamed graph";
             }
-            ui.composites.selection(element, options);
-            element.value = value;
+            const name = String(i + 1) + ": " + label;
+            optionList.push(name);
+            valueList.push(String(i));
           }
-          // Node label text data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeLabelTextDataSourceSelect,
-            state.parsedData.general.node_properties.node_label_text_data_sources,
-            state.nodeLabelTextDataSource,
-          );
-          // Edge label text data source
-          setSelectionOptionsAndValue(
-            ui.elements.edgeLabelTextDataSourceSelect,
-            state.parsedData.general.edge_properties.edge_label_text_data_sources,
-            state.edgeLabelTextDataSource,
-          );
-          // Node size data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeSizeDataSourceSelect,
-            state.parsedData.general.node_properties.node_size_data_sources,
-            state.nodeSizeDataSource,
-          );
-          // Edge size data source
-          setSelectionOptionsAndValue(
-            ui.elements.edgeSizeDataSourceSelect,
-            state.parsedData.general.edge_properties.edge_size_data_sources,
-            state.edgeSizeDataSource,
-          );
-        },
+          ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
+        }
+        // General (menu item)
+        ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
+        // Data selection (menu item)
+        ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
+        // - Node size
+        ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
+        ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+        ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+        ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+        ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
+        ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+        // - Edge size
+        ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
+        ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+        ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+        ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+        ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+        ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+        // Nodes
+        ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
+        ui.elements.nodeCheckbox.checked = state.showNodes;
+        ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
+        ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
+        ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
+        ui.elements.nodeHoverNeighborhoodCheckbox.checked = state.nodeHoverNeighborhood;
+        ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
+        // Node images
+        ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
+        ui.elements.nodeImageMetaControl.style.display = false;
+        ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
+        ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
+        ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
+        // Node labels
+        ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
+        ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
+        ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
+        ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
+        ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
+        ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(state.nodeLabelRotation);
+        ui.elements.nodeLabelRotationSlider.value = state.nodeLabelRotation;
+        // Edges
+        ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
+        ui.elements.edgeCheckbox.checked = state.showEdges;
+        ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
+        ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
+        ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
+        ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
+        ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
+        // Edge labels
+        ui.composites.menu.setItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody, false);
+        ui.elements.edgeLabelCheckbox.checked = state.showEdgeLabels;
+        ui.elements.edgeLabelBorderCheckbox.checked = state.showEdgeLabelBorders;
+        ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeLabelSizeFactor);
+        ui.elements.edgeLabelSizeFactorSlider.value = state.edgeLabelSizeFactor;
+        ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(state.edgeLabelRotation);
+        ui.elements.edgeLabelRotationSlider.value = state.edgeLabelRotation;
+        // Layout algorithm
+        ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
+        ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
+        ui.elements.manyBodyForceCheckbox.checked = state.useManyBodyForce;
+        ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
+        ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(state.manyBodyForceStrength);
+        ui.elements.manyBodyForceStrengthSlider.value = state.manyBodyForceStrength;
+        ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(state.manyBodyForceTheta);
+        ui.elements.manyBodyForceThetaSlider.value = state.manyBodyForceTheta;
+        ui.elements.manyBodyForceMinDistCheckbox.checked = state.useManyBodyForceMinDistance;
+        ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
+        ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
+        ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
+        ui.elements.manyBodyForceMaxDistCheckbox.checked = state.useManyBodyForceMaxDistance;
+        ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
+        ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
+        ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
+        ui.elements.linksForceCheckbox.checked = state.useLinksForce;
+        ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
+        ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(state.linksForceDistance);
+        ui.elements.linksForceDistanceSlider.value = state.linksForceDistance;
+        ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(state.linksForceStrength);
+        ui.elements.linksForceStrengthSlider.value = state.linksForceStrength;
+        ui.elements.collisionForceCheckbox.checked = state.useCollisionForce;
+        ui.elements.collisionForceContainer.style.opacity = ui.convert.boolToOpacity(state.useCollisionForce);
+        ui.elements.collisionForceRadiusText.innerHTML = ui.convert.numberToText(state.collisionForceRadius);
+        ui.elements.collisionForceRadiusSlider.value = state.collisionForceRadius;
+        ui.elements.collisionForceStrengthText.innerHTML = ui.convert.numberToText(state.collisionForceStrength);
+        ui.elements.collisionForceStrengthSlider.value = state.collisionForceStrength;
+        ui.elements.xPositioningForceCheckbox.checked = state.useXPositioningForce;
+        ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
+        ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.xPositioningForceStrength);
+        ui.elements.xPositioningForceStrengthSlider.value = state.xPositioningForceStrength;
+        ui.elements.yPositioningForceCheckbox.checked = state.useYPositioningForce;
+        ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
+        ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.yPositioningForceStrength);
+        ui.elements.yPositioningForceStrengthSlider.value = state.yPositioningForceStrength;
+        ui.elements.centeringForceCheckbox.checked = state.useCenteringForce;
 
-        deleteChildElements(element){
-          while(element.firstChild){
-            element.removeChild(element.firstChild);
+        ui.initSelectionValues();
+      },
+
+      initSelectionValues() {
+        function setSelectionOptionsAndValue(element, options, value) {
+          if (!options.includes(value)) {
+            value = options[0];
           }
+          ui.composites.selection(element, options);
+          element.value = value;
+        }
+        // Node label text data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeLabelTextDataSourceSelect,
+          state.parsedData.general.node_properties.node_label_text_data_sources,
+          state.nodeLabelTextDataSource,
+        );
+        // Edge label text data source
+        setSelectionOptionsAndValue(
+          ui.elements.edgeLabelTextDataSourceSelect,
+          state.parsedData.general.edge_properties.edge_label_text_data_sources,
+          state.edgeLabelTextDataSource,
+        );
+        // Node size data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeSizeDataSourceSelect,
+          state.parsedData.general.node_properties.node_size_data_sources,
+          state.nodeSizeDataSource,
+        );
+        // Edge size data source
+        setSelectionOptionsAndValue(
+          ui.elements.edgeSizeDataSourceSelect,
+          state.parsedData.general.edge_properties.edge_size_data_sources,
+          state.edgeSizeDataSource,
+        );
+      },
+
+      deleteChildElements(element) {
+        while (element.firstChild) {
+          element.removeChild(element.firstChild);
+        }
+      },
+
+      convert: {
+        numberToText(number, numDigits = 2) {
+          return String(Number(number).toFixed(numDigits));
         },
 
-        convert:{
-          numberToText(number, numDigits=2) {
-            return String(Number(number).toFixed(numDigits));
-          },
-
-          boolToDisplayStyle(isVisible){
-            if(isVisible){
-              return "block";
-            }
-            return "none";
-          },
-
-          boolToOpacity(isActive){
-            if(isActive){
-              return 1.0;
-            }
-            return 0.25;
-          },
+        boolToDisplayStyle(isVisible) {
+          if (isVisible) {
+            return "block";
+          }
+          return "none";
         },
 
-        setBehavior(){
-          // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
-          window.onresize = function(){
+        boolToOpacity(isActive) {
+          if (isActive) {
+            return 1.0;
+          }
+          return 0.25;
+        },
+      },
+
+      setBehavior() {
+        // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
+        window.onresize = function () {
+          ui.composites.responsiveContainer.adaptToResize();
+          ui.composites.graph.updateGraphDrawingArea();
+        }
+        // Container resize
+        ui.elements.graphContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
+          if (currentHeight != state.graphContainerHeight) {
             ui.composites.responsiveContainer.adaptToResize();
             ui.composites.graph.updateGraphDrawingArea();
           }
-          // Container resize
-          ui.elements.graphContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
-            if(currentHeight != state.graphContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
-          };
-          ui.elements.detailsContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-            if(currentHeight != state.detailsContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-            }
-          };
-          // Tooltip
-          ui.elements.tooltipContainer.onmouseover = function(){
-            ui.composites.tooltip.show();
+        };
+        ui.elements.detailsContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+          if (currentHeight != state.detailsContainerHeight) {
+            ui.composites.responsiveContainer.adaptToResize();
           }
-          ui.elements.tooltipContainer.onmouseout = function(){
-            ui.composites.tooltip.hide();
+        };
+        // Tooltip
+        ui.elements.tooltipContainer.onmouseover = function () {
+          ui.composites.tooltip.show();
+        }
+        ui.elements.tooltipContainer.onmouseout = function () {
+          ui.composites.tooltip.hide();
+        }
+        // General menu
+        ui.elements.generalHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
+        };
+        ui.elements.resetButton.onclick = function () {
+          app.restart();
+        };
+        ui.elements.fullscreenButton.onclick = function () {
+          if (document.fullscreenElement) {
+            document.exitFullscreen();
+          } else {
+            ui.elements.mainContainer.requestFullscreen()
+              .catch(function (err) {
+                alert("Error attempting to enable full-screen mode: " + err.message);
+              });
           }
-          // General menu
-          ui.elements.generalHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
-          };
-          ui.elements.resetButton.onclick = function(){
-            app.restart();
-          };
-          ui.elements.fullscreenButton.onclick = function(){
-            if(document.fullscreenElement){
-              document.exitFullscreen();
-            } else{
-              ui.elements.mainContainer.requestFullscreen()
-                .catch(function(err){
-                  alert("Error attempting to enable full-screen mode: " + err.message);
-                });
-            }
-          };
-          ui.elements.mainContainer.onfullscreenchange = function(){
-            if(document.fullscreenElement){
-              ui.elements.fullscreenButton.innerText = "Exit full screen";
-            } else{
-              ui.elements.fullscreenButton.innerText = "Enter full screen";
-            }
-            // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
-            setTimeout(function(){
-              ui.composites.responsiveContainer.adaptToFullscreen();
-              ui.composites.graph.updateGraphDrawingArea();
-            }, 250);
-          };
-          ui.elements.svgExportButton.onclick = function(){
-            ui.composites.download.svg("graph.svg");
-          };
-          ui.elements.pngExportButton.onclick = function(){
-            ui.composites.download.png("graph.png");
-          };
-          ui.elements.jpgExportButton.onclick = function(){
-            ui.composites.download.jpg("graph.jpg");
-          };
-          // Data menu
-          ui.elements.dataHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
-          };
-          // - Graph selection
-          ui.elements.graphSelection.onchange = function(){
-            const chosenGraphIndex = parseInt(this.value);
-            state.manager.parseChosenData(chosenGraphIndex);
-            state.manager.prepareShownData();
-            ui.initSelectionValues();
-            ui.composites.graph.createGraph();
-          };
-          // - Node label text
-          ui.elements.nodeLabelTextDataSourceSelect.onchange = function(){
-            state.nodeLabelTextDataSource = this.value;
-            state.manager.updateNodeLabelTexts();
-          };
-          // - Edge label text
-          ui.elements.edgeLabelTextDataSourceSelect.onchange = function(){
-            state.edgeLabelTextDataSource = this.value;
-            state.manager.updateEdgeLabelTexts();
-          };
-          // - Node size
-          ui.elements.nodeSizeDataSourceSelect.onchange = function(){
-            state.nodeSizeDataSource = this.value;
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationCheckbox.onchange = function(){
-            state.useNodeSizeNormalization = this.checked;
-            ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.onchange = function(){
-            state.nodeSizeNormalizationMin = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax){
-              state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-            }
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.onchange = function(){
-            state.nodeSizeNormalizationMax = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin){
-              state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-            }
-            state.manager.updateNodeSizes();
-          };
-          // - Edge size
-          ui.elements.edgeSizeDataSourceSelect.onchange = function(){
-            state.edgeSizeDataSource = this.value;
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationCheckbox.onchange = function(){
-            state.useEdgeSizeNormalization = this.checked;
-            ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.onchange = function(){
-            state.edgeSizeNormalizationMin = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax){
-              state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.onchange = function(){
-            state.edgeSizeNormalizationMax = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin){
-              state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          // Nodes menu
-          ui.elements.nodeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
-          };
-          ui.elements.nodeCheckbox.onchange = function(){
-            state.showNodes = this.checked;
-            ui.composites.graph.updateNodeVisibilities();
-          };
-          ui.elements.nodeSizeFactorSlider.oninput = function(){
-            ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeFactorSlider.onchange = function(){
-            state.nodeSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeDragFixCheckbox.onchange = function(){
-            state.nodeDragFix = this.checked;
-          };
-          ui.elements.nodeHoverNeighborhoodCheckbox.onchange = function(){
-            state.nodeHoverNeighborhood = this.checked;
-          };
-          ui.elements.nodeHoverTooltipCheckbox.onchange = function(){
-            state.nodeHoverTooltip = this.checked;
-          };
-          ui.elements.nodeReleaseButton.onclick = function(){
-            ui.composites.graph.simulationManager.releaseFixedNodes();
-            ui.composites.graph.simulationManager.move();
-          };
-          // Node images menu
-          ui.elements.nodeImageHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
-          };
-          ui.elements.nodeImageCheckbox.onchange = function(){
-            state.showNodeImages = this.checked;
-            state.currentGraphParts.nodeImageMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodeImages));
-            ui.composites.graph.updateNodeImagePositions();
-          };
-          ui.elements.nodeImageSizeFactorSlider.oninput = function(){
-            ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeImageSizeFactorSlider.onchange = function(){
-            state.nodeImageSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeImageSizes();
-          };
-          // Node labels menu
-          ui.elements.nodeLabelHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
-          };
-          ui.elements.nodeLabelCheckbox.onchange = function(){
-            state.showNodeLabels = this.checked;
-            state.currentGraphParts.nodeLabelMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodeLabels));
-            ui.composites.graph.updateNodeLabelPositions();
-          };
-          ui.elements.nodeLabelBorderCheckbox.onchange = function(){
-            state.showNodeLabelBorders = this.checked;
-            ui.composites.graph.createNodeLabels();
-          };
-          ui.elements.nodeLabelSizeFactorSlider.oninput = function(){
-            ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeLabelSizeFactorSlider.onchange = function(){
-            state.nodeLabelSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeLabelSizes();
-          };
-          ui.elements.nodeLabelRotationSlider.oninput = function(){
-            ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeLabelRotationSlider.onchange = function(){
-            state.nodeLabelRotation = parseFloat(this.value);
-            state.manager.updateNodeLabelRotations();
-          };
-          // Edges menu
-          ui.elements.edgeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
-          };
-          ui.elements.edgeCheckbox.onchange = function(){
-            state.showEdges = this.checked;
-            state.currentGraphParts.edgeMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showEdges));
-            ui.composites.graph.updateEdgePositions();
-          };
-          ui.elements.edgeSizeFactorSlider.oninput = function(){
-            ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeFactorSlider.onchange = function(){
-            state.edgeSizeFactor = parseFloat(this.value);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeCurvatureSlider.oninput = function(){
-            ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeCurvatureSlider.onchange = function(){
-            state.edgeCurvature = parseFloat(this.value);
-            state.manager.updateEdgeCurvatures();
-          };
-          ui.elements.edgeHoverTooltipCheckbox.onchange = function(){
-            state.edgeHoverTooltip = this.checked;
-          };
-          // Edge labels menu
-          ui.elements.edgeLabelHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody);
-          };
-          ui.elements.edgeLabelCheckbox.onchange = function(){
-            state.showEdgeLabels = this.checked;
-            state.currentGraphParts.edgeLabelMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showEdgeLabels));
-            ui.composites.graph.updateEdgeLabelPositions();
-          };
-          ui.elements.edgeLabelBorderCheckbox.onchange = function(){
-            state.showEdgeLabelBorders = this.checked;
-            ui.composites.graph.createEdgeLabels();
-          };
-          ui.elements.edgeLabelSizeFactorSlider.oninput = function(){
-            ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeLabelSizeFactorSlider.onchange = function(){
-            state.edgeLabelSizeFactor = parseFloat(this.value);
-            state.manager.updateEdgeLabelSizes();
-          };
-          ui.elements.edgeLabelRotationSlider.oninput = function(){
-            ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeLabelRotationSlider.onchange = function(){
-            state.edgeLabelRotation = parseFloat(this.value);
-            state.manager.updateEdgeLabelRotations();
-          };
-          // Layout algorithm menu
-          ui.elements.layoutAlgorithmHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
-          };
-          ui.elements.simulationCheckbox.onchange = function(){
-            state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
-            if(state.layoutAlgorithmActive){
-              ui.composites.graph.simulationManager.move();
-            } else {
-              ui.composites.graph.simulationManager.stop();
-            }
+        };
+        ui.elements.mainContainer.onfullscreenchange = function () {
+          if (document.fullscreenElement) {
+            ui.elements.fullscreenButton.innerText = "Exit full screen";
+          } else {
+            ui.elements.fullscreenButton.innerText = "Enter full screen";
           }
-          ui.elements.manyBodyForceCheckbox.onchange = function(){
-            state.useManyBodyForce = this.checked;
-            ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.manyBodyForceStrengthSlider.oninput = function(){
-            ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceStrengthSlider.onchange = function(){
-            state.manyBodyForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceThetaSlider.oninput = function(){
-            ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceThetaSlider.onchange = function(){
-            state.manyBodyForceTheta = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceMinDistCheckbox.onchange = function(){
-            state.useManyBodyForceMinDistance = this.checked;
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
-          }
-          ui.elements.manyBodyForceMinDistSlider.oninput = function(){
-            ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceMinDistSlider.onchange = function(){
-            state.manyBodyForceMinDistance = parseFloat(this.value);
-            if(state.manyBodyForceMinDistance > state.manyBodyForceMaxDistance){
-              state.manyBodyForceMaxDistance = state.manyBodyForceMinDistance;
-              ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
-              ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
-            }
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceMaxDistCheckbox.onchange = function(){
-            state.useManyBodyForceMaxDistance = this.checked;
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
-          }
-          ui.elements.manyBodyForceMaxDistSlider.oninput = function(){
-            ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceMaxDistSlider.onchange = function(){
-            state.manyBodyForceMaxDistance = parseFloat(this.value);
-            if(state.manyBodyForceMaxDistance < state.manyBodyForceMinDistance){
-              state.manyBodyForceMinDistance = state.manyBodyForceMaxDistance;
-              ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
-              ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
-            }
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.linksForceCheckbox.onchange = function(){
-            state.useLinksForce = this.checked;
-            ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
-            ui.composites.graph.simulationManager.setLinksForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.linksForceDistanceSlider.oninput = function(){
-            ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.linksForceDistanceSlider.onchange = function(){
-            state.linksForceDistance = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setLinksForce();
-            if(state.useLinksForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.linksForceStrengthSlider.oninput = function(){
-            ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.linksForceStrengthSlider.onchange = function(){
-            state.linksForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setLinksForce();
-            if(state.useLinksForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.collisionForceCheckbox.onchange = function(){
-            state.useCollisionForce = this.checked;
-            ui.elements.collisionForceContainer.style.opacity = ui.convert.boolToOpacity(state.useCollisionForce);
-            ui.composites.graph.simulationManager.setCollisionForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.collisionForceRadiusSlider.oninput = function(){
-            ui.elements.collisionForceRadiusText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.collisionForceRadiusSlider.onchange = function(){
-            state.collisionForceRadius = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setCollisionForce();
-            if(state.useCollisionForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.collisionForceStrengthSlider.oninput = function(){
-            ui.elements.collisionForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.collisionForceStrengthSlider.onchange = function(){
-            state.collisionForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setCollisionForce();
-            if(state.useCollisionForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.xPositioningForceCheckbox.onchange = function(){
-            state.useXPositioningForce = this.checked;
-            ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
-            ui.composites.graph.simulationManager.setXPositioningForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.xPositioningForceStrengthSlider.oninput = function(){
-            ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.xPositioningForceStrengthSlider.onchange = function(){
-            state.xPositioningForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setXPositioningForce();
-            if(state.useXPositioningForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.yPositioningForceCheckbox.onchange = function(){
-            state.useYPositioningForce = this.checked;
-            ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
-            ui.composites.graph.simulationManager.setYPositioningForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.yPositioningForceStrengthSlider.oninput = function(){
-            ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.yPositioningForceStrengthSlider.onchange = function(){
-            state.yPositioningForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setYPositioningForce();
-            if(state.useYPositioningForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.centeringForceCheckbox.onchange = function(){
-            state.useCenteringForce = this.checked;
-            ui.composites.graph.simulationManager.setCenteringForce();
-            ui.composites.graph.simulationManager.move();
-          };
-        },
-      }
-
-      const app = {
-        start(){
-          state.manager.fetchRawDataFromTemplating();
-          state.manager.parseChosenData(0);
+          // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
+          setTimeout(function () {
+            ui.composites.responsiveContainer.adaptToFullscreen();
+            ui.composites.graph.updateGraphDrawingArea();
+          }, 250);
+        };
+        ui.elements.svgExportButton.onclick = function () {
+          ui.composites.download.svg("graph.svg");
+        };
+        ui.elements.pngExportButton.onclick = function () {
+          ui.composites.download.png("graph.png");
+        };
+        ui.elements.jpgExportButton.onclick = function () {
+          ui.composites.download.jpg("graph.jpg");
+        };
+        // Data menu
+        ui.elements.dataHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
+        };
+        // - Graph selection
+        ui.elements.graphSelection.onchange = function () {
+          const chosenGraphIndex = parseInt(this.value);
+          state.manager.parseChosenData(chosenGraphIndex);
           state.manager.prepareShownData();
-          ui.init();
-          // Wait a bit to finish UI rendering, then start potentially slow layout computation
-          setTimeout(function(){
-            ui.composites.graph.createGraph();
-            ui.setBehavior();
-          }, 400);
-          // Reduce risk of getting stuck with a wrong drawing area size
-          function checkIfSizeUpdateRequired(){
-            if(ui.elements.graphContainer.clientWidth != state.graphContainerWidth){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
+          ui.initSelectionValues();
+          ui.composites.graph.createGraph();
+        };
+        // - Node label text
+        ui.elements.nodeLabelTextDataSourceSelect.onchange = function () {
+          state.nodeLabelTextDataSource = this.value;
+          state.manager.updateNodeLabelTexts();
+        };
+        // - Edge label text
+        ui.elements.edgeLabelTextDataSourceSelect.onchange = function () {
+          state.edgeLabelTextDataSource = this.value;
+          state.manager.updateEdgeLabelTexts();
+        };
+        // - Node size
+        ui.elements.nodeSizeDataSourceSelect.onchange = function () {
+          state.nodeSizeDataSource = this.value;
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationCheckbox.onchange = function () {
+          state.useNodeSizeNormalization = this.checked;
+          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.onchange = function () {
+          state.nodeSizeNormalizationMin = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax) {
+            state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
           }
-          [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function(delay){
-            setTimeout(checkIfSizeUpdateRequired, delay*1000);
-          })
-        },
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.onchange = function () {
+          state.nodeSizeNormalizationMax = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin) {
+            state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+          }
+          state.manager.updateNodeSizes();
+        };
+        // - Edge size
+        ui.elements.edgeSizeDataSourceSelect.onchange = function () {
+          state.edgeSizeDataSource = this.value;
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationCheckbox.onchange = function () {
+          state.useEdgeSizeNormalization = this.checked;
+          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.onchange = function () {
+          state.edgeSizeNormalizationMin = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax) {
+            state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.onchange = function () {
+          state.edgeSizeNormalizationMax = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin) {
+            state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        // Nodes menu
+        ui.elements.nodeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
+        };
+        ui.elements.nodeCheckbox.onchange = function () {
+          state.showNodes = this.checked;
+          ui.composites.graph.updateNodeVisibilities();
+        };
+        ui.elements.nodeSizeFactorSlider.oninput = function () {
+          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeFactorSlider.onchange = function () {
+          state.nodeSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeDragFixCheckbox.onchange = function () {
+          state.nodeDragFix = this.checked;
+        };
+        ui.elements.nodeHoverNeighborhoodCheckbox.onchange = function () {
+          state.nodeHoverNeighborhood = this.checked;
+        };
+        ui.elements.nodeHoverTooltipCheckbox.onchange = function () {
+          state.nodeHoverTooltip = this.checked;
+        };
+        ui.elements.nodeReleaseButton.onclick = function () {
+          ui.composites.graph.simulationManager.releaseFixedNodes();
+          ui.composites.graph.simulationManager.move();
+        };
+        // Node images menu
+        ui.elements.nodeImageHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
+        };
+        ui.elements.nodeImageCheckbox.onchange = function () {
+          state.showNodeImages = this.checked;
+          state.currentGraphParts.nodeImageMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodeImages));
+          ui.composites.graph.updateNodeImagePositions();
+        };
+        ui.elements.nodeImageSizeFactorSlider.oninput = function () {
+          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeImageSizeFactorSlider.onchange = function () {
+          state.nodeImageSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeImageSizes();
+        };
+        // Node labels menu
+        ui.elements.nodeLabelHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
+        };
+        ui.elements.nodeLabelCheckbox.onchange = function () {
+          state.showNodeLabels = this.checked;
+          state.currentGraphParts.nodeLabelMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showNodeLabels));
+          ui.composites.graph.updateNodeLabelPositions();
+        };
+        ui.elements.nodeLabelBorderCheckbox.onchange = function () {
+          state.showNodeLabelBorders = this.checked;
+          ui.composites.graph.createNodeLabels();
+        };
+        ui.elements.nodeLabelSizeFactorSlider.oninput = function () {
+          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeLabelSizeFactorSlider.onchange = function () {
+          state.nodeLabelSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeLabelSizes();
+        };
+        ui.elements.nodeLabelRotationSlider.oninput = function () {
+          ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeLabelRotationSlider.onchange = function () {
+          state.nodeLabelRotation = parseFloat(this.value);
+          state.manager.updateNodeLabelRotations();
+        };
+        // Edges menu
+        ui.elements.edgeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
+        };
+        ui.elements.edgeCheckbox.onchange = function () {
+          state.showEdges = this.checked;
+          state.currentGraphParts.edgeMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showEdges));
+          ui.composites.graph.updateEdgePositions();
+        };
+        ui.elements.edgeSizeFactorSlider.oninput = function () {
+          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeFactorSlider.onchange = function () {
+          state.edgeSizeFactor = parseFloat(this.value);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeCurvatureSlider.oninput = function () {
+          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeCurvatureSlider.onchange = function () {
+          state.edgeCurvature = parseFloat(this.value);
+          state.manager.updateEdgeCurvatures();
+        };
+        ui.elements.edgeHoverTooltipCheckbox.onchange = function () {
+          state.edgeHoverTooltip = this.checked;
+        };
+        // Edge labels menu
+        ui.elements.edgeLabelHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody);
+        };
+        ui.elements.edgeLabelCheckbox.onchange = function () {
+          state.showEdgeLabels = this.checked;
+          state.currentGraphParts.edgeLabelMainGroup.style("display", ui.convert.boolToDisplayStyle(state.showEdgeLabels));
+          ui.composites.graph.updateEdgeLabelPositions();
+        };
+        ui.elements.edgeLabelBorderCheckbox.onchange = function () {
+          state.showEdgeLabelBorders = this.checked;
+          ui.composites.graph.createEdgeLabels();
+        };
+        ui.elements.edgeLabelSizeFactorSlider.oninput = function () {
+          ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeLabelSizeFactorSlider.onchange = function () {
+          state.edgeLabelSizeFactor = parseFloat(this.value);
+          state.manager.updateEdgeLabelSizes();
+        };
+        ui.elements.edgeLabelRotationSlider.oninput = function () {
+          ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeLabelRotationSlider.onchange = function () {
+          state.edgeLabelRotation = parseFloat(this.value);
+          state.manager.updateEdgeLabelRotations();
+        };
+        // Layout algorithm menu
+        ui.elements.layoutAlgorithmHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
+        };
+        ui.elements.simulationCheckbox.onchange = function () {
+          state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
+          if (state.layoutAlgorithmActive) {
+            ui.composites.graph.simulationManager.move();
+          } else {
+            ui.composites.graph.simulationManager.stop();
+          }
+        }
+        ui.elements.manyBodyForceCheckbox.onchange = function () {
+          state.useManyBodyForce = this.checked;
+          ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.manyBodyForceStrengthSlider.oninput = function () {
+          ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceStrengthSlider.onchange = function () {
+          state.manyBodyForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceThetaSlider.oninput = function () {
+          ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceThetaSlider.onchange = function () {
+          state.manyBodyForceTheta = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceMinDistCheckbox.onchange = function () {
+          state.useManyBodyForceMinDistance = this.checked;
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
+        }
+        ui.elements.manyBodyForceMinDistSlider.oninput = function () {
+          ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceMinDistSlider.onchange = function () {
+          state.manyBodyForceMinDistance = parseFloat(this.value);
+          if (state.manyBodyForceMinDistance > state.manyBodyForceMaxDistance) {
+            state.manyBodyForceMaxDistance = state.manyBodyForceMinDistance;
+            ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
+            ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
+          }
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceMaxDistCheckbox.onchange = function () {
+          state.useManyBodyForceMaxDistance = this.checked;
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
+        }
+        ui.elements.manyBodyForceMaxDistSlider.oninput = function () {
+          ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceMaxDistSlider.onchange = function () {
+          state.manyBodyForceMaxDistance = parseFloat(this.value);
+          if (state.manyBodyForceMaxDistance < state.manyBodyForceMinDistance) {
+            state.manyBodyForceMinDistance = state.manyBodyForceMaxDistance;
+            ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
+            ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
+          }
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.linksForceCheckbox.onchange = function () {
+          state.useLinksForce = this.checked;
+          ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
+          ui.composites.graph.simulationManager.setLinksForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.linksForceDistanceSlider.oninput = function () {
+          ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.linksForceDistanceSlider.onchange = function () {
+          state.linksForceDistance = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setLinksForce();
+          if (state.useLinksForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.linksForceStrengthSlider.oninput = function () {
+          ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.linksForceStrengthSlider.onchange = function () {
+          state.linksForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setLinksForce();
+          if (state.useLinksForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.collisionForceCheckbox.onchange = function () {
+          state.useCollisionForce = this.checked;
+          ui.elements.collisionForceContainer.style.opacity = ui.convert.boolToOpacity(state.useCollisionForce);
+          ui.composites.graph.simulationManager.setCollisionForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.collisionForceRadiusSlider.oninput = function () {
+          ui.elements.collisionForceRadiusText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.collisionForceRadiusSlider.onchange = function () {
+          state.collisionForceRadius = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setCollisionForce();
+          if (state.useCollisionForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.collisionForceStrengthSlider.oninput = function () {
+          ui.elements.collisionForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.collisionForceStrengthSlider.onchange = function () {
+          state.collisionForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setCollisionForce();
+          if (state.useCollisionForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.xPositioningForceCheckbox.onchange = function () {
+          state.useXPositioningForce = this.checked;
+          ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
+          ui.composites.graph.simulationManager.setXPositioningForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.xPositioningForceStrengthSlider.oninput = function () {
+          ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.xPositioningForceStrengthSlider.onchange = function () {
+          state.xPositioningForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setXPositioningForce();
+          if (state.useXPositioningForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.yPositioningForceCheckbox.onchange = function () {
+          state.useYPositioningForce = this.checked;
+          ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
+          ui.composites.graph.simulationManager.setYPositioningForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.yPositioningForceStrengthSlider.oninput = function () {
+          ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.yPositioningForceStrengthSlider.onchange = function () {
+          state.yPositioningForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setYPositioningForce();
+          if (state.useYPositioningForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.centeringForceCheckbox.onchange = function () {
+          state.useCenteringForce = this.checked;
+          ui.composites.graph.simulationManager.setCenteringForce();
+          ui.composites.graph.simulationManager.move();
+        };
+      },
+    }
 
-        restart(){
-          ui.composites.graph.simulationManager.stop();
-          app.start();
-        },
-      }
+    const app = {
+      start() {
+        state.manager.fetchRawDataFromTemplating();
+        state.manager.parseChosenData(0);
+        state.manager.prepareShownData();
+        ui.init();
+        // Wait a bit to finish UI rendering, then start potentially slow layout computation
+        setTimeout(function () {
+          ui.composites.graph.createGraph();
+          ui.setBehavior();
+        }, 400);
+        // Reduce risk of getting stuck with a wrong drawing area size
+        function checkIfSizeUpdateRequired() {
+          if (ui.elements.graphContainer.clientWidth != state.graphContainerWidth) {
+            ui.composites.responsiveContainer.adaptToResize();
+            ui.composites.graph.updateGraphDrawingArea();
+          }
+        }
+        [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function (delay) {
+          setTimeout(checkIfSizeUpdateRequired, delay * 1000);
+        })
+      },
 
-      // Start website dynamics
-      app.start();
-    });
-  </script>
+      restart() {
+        ui.composites.graph.simulationManager.stop();
+        app.start();
+      },
+    }
+
+    // Start website dynamics
+    app.start();
+  });
+</script>
 §SUFFIX§

--- a/gravis/_internal/plotting/templates/d3.html
+++ b/gravis/_internal/plotting/templates/d3.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1056,6 +1115,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -2231,17 +2291,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2458,15 +2512,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -3534,6 +3583,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/d3.html
+++ b/gravis/_internal/plotting/templates/d3.html
@@ -413,8 +413,8 @@
 
   #legend {
     position: absolute;
-    top: 10px;
-    left: 10px;
+    top: 20px;
+    left: 20px;
     z-index: 1000;
   }
 </style>

--- a/gravis/_internal/plotting/templates/d3.html
+++ b/gravis/_internal/plotting/templates/d3.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -118,6 +163,7 @@
       align-items: center;
       margin-top: 1px;
       margin-bottom: 1px;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-label {
       all: initial;
@@ -125,6 +171,7 @@
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
       cursor: pointer;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-slider {
       width: 100%;
@@ -137,14 +184,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +206,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +217,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +232,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +243,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +252,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +288,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +302,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +318,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +328,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +344,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1056,6 +1117,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1291,21 +1353,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1316,10 +1395,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2231,17 +2310,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2458,15 +2531,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -3534,6 +3602,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/three.html
+++ b/gravis/_internal/plotting/templates/three.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -118,6 +163,7 @@
       align-items: center;
       margin-top: 1px;
       margin-bottom: 1px;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-label {
       all: initial;
@@ -125,6 +171,7 @@
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
       cursor: pointer;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-slider {
       width: 100%;
@@ -137,14 +184,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +206,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +217,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +232,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +243,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +252,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +288,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +302,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +318,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +328,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +344,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1031,6 +1092,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1267,21 +1329,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1293,10 +1372,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2146,17 +2225,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2338,19 +2411,14 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
-              // this.mainContainer.appendChild(this.outerBarContainer);  // Hide bar (not updated)
+              this.mainContainer.appendChild(this.outerBarContainer);
               ui.elements.graphContainer.appendChild(this.mainContainer);
             },
 
@@ -2923,6 +2991,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/three.html
+++ b/gravis/_internal/plotting/templates/three.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1031,6 +1090,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -2146,17 +2206,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2338,19 +2392,14 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
-              // this.mainContainer.appendChild(this.outerBarContainer);  // Hide bar (not updated)
+              this.mainContainer.appendChild(this.outerBarContainer);
               ui.elements.graphContainer.appendChild(this.mainContainer);
             },
 
@@ -2923,6 +2972,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/three.html
+++ b/gravis/_internal/plotting/templates/three.html
@@ -1,545 +1,629 @@
 §PREFIX§
-  <style>
-    /* Main divisions */
-    #§RANDOM_ID§-main-div {
-      line-height: normal;
-      box-sizing: content-box;
-      padding: 3px;
-      background-color: var(--§RANDOM_ID§-background-color);
-      color: var(--§RANDOM_ID§-text-color);
-      --§RANDOM_ID§-background-color: #ffffff;
-      --§RANDOM_ID§-text-color: #222222;
-      --§RANDOM_ID§-text-color-subtle: #666666;
-      --§RANDOM_ID§-accent-color: #006429;
-      --§RANDOM_ID§-surface-color: #f5f5f5;
-      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
-      --§RANDOM_ID§-surface-color-strong: #dddddd;
-      --§RANDOM_ID§-surface-color-overlay: #ffffff;
-      --§RANDOM_ID§-border-color: #cccccc;
-      --§RANDOM_ID§-border-color-strong: #bbbbbb;
-      --§RANDOM_ID§-border-color-hover: #999999;
-      --§RANDOM_ID§-tooltip-background: #ffffff;
-      --§RANDOM_ID§-tooltip-text: #111111;
-      --§RANDOM_ID§-details-separator: #333333;
-      --§RANDOM_ID§-progress-border: #000000;
-      --§RANDOM_ID§-progress-fill: #000000;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
-    }
-    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
-      --§RANDOM_ID§-background-color: #1f1f25;
-      --§RANDOM_ID§-text-color: #f0f0f5;
-      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
-      --§RANDOM_ID§-accent-color: #7ddba3;
-      --§RANDOM_ID§-surface-color: #2d303c;
-      --§RANDOM_ID§-surface-color-muted: #343746;
-      --§RANDOM_ID§-surface-color-strong: #3d4050;
-      --§RANDOM_ID§-surface-color-overlay: #282a36;
-      --§RANDOM_ID§-border-color: #43465a;
-      --§RANDOM_ID§-border-color-strong: #50546a;
-      --§RANDOM_ID§-border-color-hover: #5e637c;
-      --§RANDOM_ID§-tooltip-background: #2f3241;
-      --§RANDOM_ID§-tooltip-text: #f0f2ff;
-      --§RANDOM_ID§-details-separator: #5e637c;
-      --§RANDOM_ID§-progress-border: #f0f2ff;
-      --§RANDOM_ID§-progress-fill: #7ddba3;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
-    }
-    #§RANDOM_ID§-left-div {
-      float: left;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-div {
-      float: left;
-      height: 100%;
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-inner-div {
-      padding-left: 5px;
-      padding-right: 2px;
-      overflow-x: hidden;
-      overflow-y: auto;
-      height: 100%;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+<style>
+  /* Main divisions */
+  #§RANDOM_ID§-main-div {
+    line-height: normal;
+    box-sizing: content-box;
+    padding: 3px;
+    background-color: var(--§RANDOM_ID§-background-color);
+    color: var(--§RANDOM_ID§-text-color);
+    --§RANDOM_ID§-background-color: #ffffff;
+    --§RANDOM_ID§-text-color: #222222;
+    --§RANDOM_ID§-text-color-subtle: #666666;
+    --§RANDOM_ID§-accent-color: #006429;
+    --§RANDOM_ID§-surface-color: #f5f5f5;
+    --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+    --§RANDOM_ID§-surface-color-strong: #dddddd;
+    --§RANDOM_ID§-surface-color-overlay: #ffffff;
+    --§RANDOM_ID§-border-color: #cccccc;
+    --§RANDOM_ID§-border-color-strong: #bbbbbb;
+    --§RANDOM_ID§-border-color-hover: #999999;
+    --§RANDOM_ID§-tooltip-background: #ffffff;
+    --§RANDOM_ID§-tooltip-text: #111111;
+    --§RANDOM_ID§-details-separator: #333333;
+    --§RANDOM_ID§-progress-border: #000000;
+    --§RANDOM_ID§-progress-fill: #000000;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+  }
 
-    /* Graph and details (contained in left-inner-div) */
-    #§RANDOM_ID§-graph-div {
-      overflow: hidden;
-      resize: vertical;
-      position: relative;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-div {
-      overflow: auto;
-      resize: vertical;
-      margin-top: 5px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-head {
-      user-select: none;
-      padding-left: 4px !important;
-      padding-top: 4px !important;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color-subtle);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-details-body {
-      padding: 10px;
-      padding-top: 6px;
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+  #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+    --§RANDOM_ID§-background-color: #1f1f25;
+    --§RANDOM_ID§-text-color: #f0f0f5;
+    --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+    --§RANDOM_ID§-accent-color: #7ddba3;
+    --§RANDOM_ID§-surface-color: #2d303c;
+    --§RANDOM_ID§-surface-color-muted: #343746;
+    --§RANDOM_ID§-surface-color-strong: #3d4050;
+    --§RANDOM_ID§-surface-color-overlay: #282a36;
+    --§RANDOM_ID§-border-color: #43465a;
+    --§RANDOM_ID§-border-color-strong: #50546a;
+    --§RANDOM_ID§-border-color-hover: #5e637c;
+    --§RANDOM_ID§-tooltip-background: #2f3241;
+    --§RANDOM_ID§-tooltip-text: #f0f2ff;
+    --§RANDOM_ID§-details-separator: #5e637c;
+    --§RANDOM_ID§-progress-border: #f0f2ff;
+    --§RANDOM_ID§-progress-fill: #7ddba3;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
+  }
 
-    /* Control menu (contained in right-inner-div) */
-    .§RANDOM_ID§-menu-item-head {
-      font-size: 11px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      cursor: pointer;
-      padding-left: 5px;
-      padding-right: 0px;
-      padding-top: 5px;
-      padding-bottom: 5px;
-      margin-bottom: 5px;
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
-      background-color: var(--§RANDOM_ID§-surface-color);
-      border-color: var(--§RANDOM_ID§-border-color-hover);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
-    }
-    .§RANDOM_ID§-menu-item-body {
-      margin-left: 5px;
-      margin-bottom: 10px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-head {
-      font-size: 9px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-weight: 600;
-      color: var(--§RANDOM_ID§-accent-color);
-      cursor: default;
-      margin-bottom: 2px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-body {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      margin-left: 7px;
-      margin-bottom: 5px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-labeled-input {
-      all: initial;
-      display: flex;
-      align-items: center;
-      margin-top: 1px;
-      margin-bottom: 1px;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-label {
-      all: initial;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      cursor: pointer;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-slider {
-      width: 100%;
-      margin-bottom: 2px;
-    }
-    .§RANDOM_ID§-slider::-moz-focus-outer {
-      border: 0;
-    }
-    .§RANDOM_ID§-slider-text-left {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      color: var(--§RANDOM_ID§-text-color);
-      float: left;
-      margin-top: 2px;
-    }
-    .§RANDOM_ID§-slider-text-right {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      float: right;
-    }
-    .§RANDOM_ID§-checkbox {
-      margin-left: 0px !important;
-      margin-right: 4px !important;
-      margin-top: 2px !important;
-      margin-bottom: 2px !important;
-      padding: 0px !important;
-    }
+  #§RANDOM_ID§-left-div {
+    float: left;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-div {
+    float: left;
+    height: 100%;
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-inner-div {
+    padding-left: 5px;
+    padding-right: 2px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100%;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Graph and details (contained in left-inner-div) */
+  #§RANDOM_ID§-graph-div {
+    overflow: hidden;
+    resize: vertical;
+    position: relative;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-div {
+    overflow: auto;
+    resize: vertical;
+    margin-top: 5px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-head {
+    user-select: none;
+    padding-left: 4px !important;
+    padding-top: 4px !important;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color-subtle);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-details-body {
+    padding: 10px;
+    padding-top: 6px;
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Control menu (contained in right-inner-div) */
+  .§RANDOM_ID§-menu-item-head {
+    font-size: 11px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    cursor: pointer;
+    padding-left: 5px;
+    padding-right: 0px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-bottom: 5px;
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+    background-color: var(--§RANDOM_ID§-surface-color);
+    border-color: var(--§RANDOM_ID§-border-color-hover);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
+  }
+
+  .§RANDOM_ID§-menu-item-body {
+    margin-left: 5px;
+    margin-bottom: 10px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-head {
+    font-size: 9px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-weight: 600;
+    color: var(--§RANDOM_ID§-accent-color);
+    cursor: default;
+    margin-bottom: 2px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-body {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    margin-left: 7px;
+    margin-bottom: 5px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-labeled-input {
+    all: initial;
+    display: flex;
+    align-items: center;
+    margin-top: 1px;
+    margin-bottom: 1px;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-label {
+    all: initial;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    cursor: pointer;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-slider {
+    width: 100%;
+    margin-bottom: 2px;
+  }
+
+  .§RANDOM_ID§-slider::-moz-focus-outer {
+    border: 0;
+  }
+
+  .§RANDOM_ID§-slider-text-left {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    color: var(--§RANDOM_ID§-text-color);
+    float: left;
+    margin-top: 2px;
+  }
+
+  .§RANDOM_ID§-slider-text-right {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    float: right;
+  }
+
+  .§RANDOM_ID§-checkbox {
+    margin-left: 0px !important;
+    margin-right: 4px !important;
+    margin-top: 2px !important;
+    margin-bottom: 2px !important;
+    padding: 0px !important;
+  }
+
+  .§RANDOM_ID§-select {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color);
+    width: 100%;
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 5px;
+    padding-right: 10px;
+    margin-right: 5px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: var(--§RANDOM_ID§-select-arrow);
+    background-repeat: no-repeat;
+    background-position: right 4px top 50%;
+    background-size: 6px;
+  }
+
+  @-moz-document url-prefix() {
+
+    /* Dirty hack to remove dotted border on focus */
     .§RANDOM_ID§-select {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color);
-      width: 100%;
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 5px;
-      padding-right: 10px;
-      margin-right: 5px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+      color: transparent !important;
+      text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
+    }
+  }
 
-      -moz-appearance: none;
-      -webkit-appearance: none;
-      appearance: none;
-      background-image: var(--§RANDOM_ID§-select-arrow);
-      background-repeat: no-repeat;
-      background-position: right 4px top 50%;
-      background-size: 6px;
-    }
-    @-moz-document url-prefix() {
-      /* Dirty hack to remove dotted border on focus */
-      .§RANDOM_ID§-select {
-        color: transparent !important;
-        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
-      }
-    }
-    .§RANDOM_ID§-select:after {
-      cursor: pointer;
-    }
-    .§RANDOM_ID§-button {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-muted);
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 10px;
-      padding-right: 10px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
-    }
-    .§RANDOM_ID§-button:hover {
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
-      background-color: var(--§RANDOM_ID§-surface-color);
-    }
-    .§RANDOM_ID§-button:active {
-      background-color: var(--§RANDOM_ID§-surface-color-strong);
-    }
-    .§RANDOM_ID§-button::-moz-focus-inner {
-      border: 0;
-    }
-    /* Hidden menu items */
-    #§RANDOM_ID§-graph-select-div {
-      display: none;
-    }
-    #§RANDOM_ID§-node-size-norm-div {
-      display: none;
-    }
-    #§RANDOM_ID§-edge-size-norm-div {
-      display: none;
-    }
+  .§RANDOM_ID§-select:after {
+    cursor: pointer;
+  }
 
-    /* Graph */
-    #§RANDOM_ID§-tooltip-div {
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42001;
-      opacity: 0;
-      visibility: hidden;
-      position: absolute !important;
-      max-width: 40%;
-      padding: 5px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: var(--§RANDOM_ID§-tooltip-text);
-      background-color: var(--§RANDOM_ID§-tooltip-background);
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button, #§RANDOM_ID§-details-toggle-button, #§RANDOM_ID§-progress-container {
-      font-size: 14px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42000;
-      cursor: pointer;
-      position: absolute;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      border-radius: 4px;
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button {
-      top: 0;
-      right: 0;
-      padding-left: 6px;
-      padding-right: 6px;
-      padding-top: 12px;
-      padding-bottom: 12px;
-      border-top: 0px;
-      border-right: 0px;
-      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
-      border-left: 1px solid var(--§RANDOM_ID§-border-color);
-    }
-    #§RANDOM_ID§-details-toggle-button {
-      bottom: 0;
-      left: 0;
-      padding-left: 19px;
-      padding-right: 19px;
-      padding-top: 0.5px;
-      padding-bottom: 2px;
-      border-top: 1px solid var(--§RANDOM_ID§-border-color);
-      border-right: 1px solid var(--§RANDOM_ID§-border-color);
-      border-bottom: 0px;
-      border-left: 0px;
-    }
-    #§RANDOM_ID§-progress-container {
-      font-size: 10px;
-      text-align: center;
-      top: 46%;
-      left: 15%;
-      width: 70%;
-      padding: 8px;
-      border: none;
-      box-shadow: none;
-    }
+  .§RANDOM_ID§-button {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-muted);
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  }
 
-    .§RANDOM_ID§-progress-bar-outer {
-      border: 1px solid var(--§RANDOM_ID§-progress-border);
-      border-radius: 4px;
-      margin-top: 1ex;
-      padding: 1px;
-    }
-    .§RANDOM_ID§-progress-bar-inner {
-      background-color: var(--§RANDOM_ID§-progress-fill);
-      width: 0%;
-      height: 8px;
-      border-radius: 3px;
-    }
+  .§RANDOM_ID§-button:hover {
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+    background-color: var(--§RANDOM_ID§-surface-color);
+  }
 
-    /* Details */
-    #§RANDOM_ID§-details-user-provided {
-      margin-top: 3px;
-      padding-top: 3.5px;
-      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
-      line-height: normal;
-      box-sizing: content-box;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    #§RANDOM_ID§-details-user-provided ul {
-      list-style-position: inside;
-      padding-left: 6px;
-    }
-  </style>
+  .§RANDOM_ID§-button:active {
+    background-color: var(--§RANDOM_ID§-surface-color-strong);
+  }
 
-  <div id="§RANDOM_ID§-main-div">
-    <div id="§RANDOM_ID§-tooltip-div"></div>
+  .§RANDOM_ID§-button::-moz-focus-inner {
+    border: 0;
+  }
 
-    <div id="§RANDOM_ID§-left-div">
-      <div id="§RANDOM_ID§-left-inner-div">
-        <div id="§RANDOM_ID§-graph-div"></div>
-        <div id="§RANDOM_ID§-details-div">
-          <div id="§RANDOM_ID§-details-head">
-            Details for selected element
-          </div>
-          <div id="§RANDOM_ID§-details-body">
-          </div>
+  /* Hidden menu items */
+  #§RANDOM_ID§-graph-select-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-node-size-norm-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-edge-size-norm-div {
+    display: none;
+  }
+
+  /* Graph */
+  #§RANDOM_ID§-tooltip-div {
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42001;
+    opacity: 0;
+    visibility: hidden;
+    position: absolute !important;
+    max-width: 40%;
+    padding: 5px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--§RANDOM_ID§-tooltip-text);
+    background-color: var(--§RANDOM_ID§-tooltip-background);
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button,
+  #§RANDOM_ID§-details-toggle-button,
+  #§RANDOM_ID§-progress-container {
+    font-size: 14px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42000;
+    cursor: pointer;
+    position: absolute;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    border-radius: 4px;
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button {
+    top: 0;
+    right: 0;
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-top: 0px;
+    border-right: 0px;
+    border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+    border-left: 1px solid var(--§RANDOM_ID§-border-color);
+  }
+
+  #§RANDOM_ID§-details-toggle-button {
+    bottom: 0;
+    left: 0;
+    padding-left: 19px;
+    padding-right: 19px;
+    padding-top: 0.5px;
+    padding-bottom: 2px;
+    border-top: 1px solid var(--§RANDOM_ID§-border-color);
+    border-right: 1px solid var(--§RANDOM_ID§-border-color);
+    border-bottom: 0px;
+    border-left: 0px;
+  }
+
+  #§RANDOM_ID§-progress-container {
+    font-size: 10px;
+    text-align: center;
+    top: 46%;
+    left: 15%;
+    width: 70%;
+    padding: 8px;
+    border: none;
+    box-shadow: none;
+  }
+
+  .§RANDOM_ID§-progress-bar-outer {
+    border: 1px solid var(--§RANDOM_ID§-progress-border);
+    border-radius: 4px;
+    margin-top: 1ex;
+    padding: 1px;
+  }
+
+  .§RANDOM_ID§-progress-bar-inner {
+    background-color: var(--§RANDOM_ID§-progress-fill);
+    width: 0%;
+    height: 8px;
+    border-radius: 3px;
+  }
+
+  /* Details */
+  #§RANDOM_ID§-details-user-provided {
+    margin-top: 3px;
+    padding-top: 3.5px;
+    border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
+    line-height: normal;
+    box-sizing: content-box;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  #§RANDOM_ID§-details-user-provided ul {
+    list-style-position: inside;
+    padding-left: 6px;
+  }
+
+  /* Legend */
+
+  #legend {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+  }
+</style>
+
+<div id="§RANDOM_ID§-main-div">
+  <div id="legend">§LEGEND-CODE§</div>
+  <div id="§RANDOM_ID§-tooltip-div"></div>
+
+  <div id="§RANDOM_ID§-left-div">
+    <div id="§RANDOM_ID§-left-inner-div">
+      <div id="§RANDOM_ID§-graph-div"></div>
+      <div id="§RANDOM_ID§-details-div">
+        <div id="§RANDOM_ID§-details-head">
+          Details for selected element
+        </div>
+        <div id="§RANDOM_ID§-details-body">
         </div>
       </div>
     </div>
+  </div>
 
-    <div id="§RANDOM_ID§-right-div">
-      <div id="§RANDOM_ID§-right-inner-div">
-        <!-- Menu: General -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-general-head">
-          General
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-general-body">
-          <!-- Sub-menu: State -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              App state
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-reset"
-                      type="button">Reset</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Display mode (fullscreen or not) -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Display mode
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-fullscreen-button"
-                      type="button">Enter full screen</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Export -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Export
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-png"
-                      type="button">PNG</button>
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-jpg"
-                      type="button">JPG</button>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Data -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-data-head">
-          Data selection
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-data-body">
-          <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
-          <div id="§RANDOM_ID§-graph-select-div">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Graph
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-graph-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node label text -->
-          <div id="§RANDOM_ID§-node-label-data-source-div">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Node label text
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-label-data-source-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node size -->
+  <div id="§RANDOM_ID§-right-div">
+    <div id="§RANDOM_ID§-right-inner-div">
+      <!-- Menu: General -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-general-head">
+        General
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-general-body">
+        <!-- Sub-menu: State -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Node size
+            App state
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-reset" type="button">Reset</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Display mode (fullscreen or not) -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Display mode
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-fullscreen-button" type="button">Enter full
+              screen</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Export -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Export
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-png" type="button">PNG</button>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-jpg" type="button">JPG</button>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Data -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-data-head">
+        Data selection
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-data-body">
+        <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
+        <div id="§RANDOM_ID§-graph-select-div">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Graph
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-graph-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node label text -->
+        <div id="§RANDOM_ID§-node-label-data-source-div">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Node label text
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-label-data-source-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Node size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-node-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-min-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-max-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Edge size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Edge size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-edge-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-edge-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-min-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-max-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Nodes -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-head">
+        Nodes
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-checkbox">Show nodes</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
             <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-size-data-source-select"></select>
-            </div>
-            <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-node-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
-            </div>
-            <div id="§RANDOM_ID§-node-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-min-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-max-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
-              </div>
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
             </div>
           </div>
-          <!-- Sub-menu: Edge size -->
+        </div>
+        <!-- Sub-menu: Position -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Edge size
+            Position
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
-            <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-edge-size-data-source-select"></select>
-            </div>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-node-release-button" type="button">Release fixed
+              nodes</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Drag behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Drag behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
             <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-edge-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
-            </div>
-            <div id="§RANDOM_ID§-edge-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-min-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-max-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-drag-fix-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
             </div>
           </div>
         </div>
-        <!-- Menu: Nodes -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-head">
-          Nodes
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
+            </div>
+          </div>
         </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-body">
+      </div>
+      <!-- Menu: Node images -->
+      <div id="§RANDOM_ID§-node-image-meta-control">
+        <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-image-head">
+          Node images
+        </div>
+        <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-image-body">
           <!-- Sub-menu: Visibility -->
           <div>
             <div class="§RANDOM_ID§-menu-subitem-head">
@@ -547,11 +631,8 @@
             </div>
             <div class="§RANDOM_ID§-menu-subitem-body">
               <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-checkbox">Show nodes</label>
+                <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-image-checkbox" type="checkbox">
+                <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
               </div>
             </div>
           </div>
@@ -561,3025 +642,2877 @@
               Size
             </div>
             <div class="§RANDOM_ID§-menu-subitem-body">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Position -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Position
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-node-release-button"
-                      type="button">Release fixed nodes</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Drag behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Drag behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-drag-fix-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if provided)</label>
-              </div>
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-image-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-image-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
             </div>
           </div>
         </div>
-        <!-- Menu: Node images -->
-        <div id="§RANDOM_ID§-node-image-meta-control">
-          <div class="§RANDOM_ID§-menu-item-head"
-               id="§RANDOM_ID§-node-image-head">
-            Node images
+      </div>
+      <!-- Menu: Node labels -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-label-head">
+        Node labels
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-label-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
           </div>
-          <div class="§RANDOM_ID§-menu-item-body"
-               id="§RANDOM_ID§-node-image-body">
-            <!-- Sub-menu: Visibility -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Visibility
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-border-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-label-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-label-size-factor-slider" type="range" min="0.01"
+              max="5.0" step="0.01">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Edges -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-edge-head">
+        Edges
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-edge-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-checkbox">Show edges</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-factor-slider" type="range" min="0.01" max="5.0"
+              step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Form -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Form
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-curvature-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-curvature-slider" type="range" min="-1.2" max="1.2"
+              step="0.02">
+          </div>
+        </div>
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Layout algorithm -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-layout-algorithm-head">
+        Layout algorithm
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-layout-algorithm-body">
+
+        <!-- Sub-menu: Simulation -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Simulation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-simulation-active-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Many-body force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Many-body force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-checkbox">On</label>
+            </div>
+            <div id="§RANDOM_ID§-many-body-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-strength-slider" type="range"
+                  min="-2000.0" max="200.0" step="0.01" style="direction:rtl;">
               </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Theta</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-theta-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-theta-slider" type="range" min="0.01"
+                  max="2.0" step="0.001">
+              </div>
+              <div style="margin-top: 6px;">
                 <div class="§RANDOM_ID§-labeled-input">
-                  <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-node-image-checkbox"
-                         type="checkbox">
-                  <label class="§RANDOM_ID§-label"
-                         for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
+                  <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-min-distance-checkbox"
+                    type="checkbox">
+                  <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-min-distance-checkbox">Use minimum
+                    distance</label>
+                </div>
+                <div id="§RANDOM_ID§-many-body-force-min-distance-div">
+                  <span class="§RANDOM_ID§-slider-text-left">Min</span>
+                  <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-min-distance-text"></span>
+                  <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-min-distance-slider" type="range"
+                    min="0.01" max="10000.0" step="0.01">
                 </div>
               </div>
-            </div>
-            <!-- Sub-menu: Size -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Size
-              </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-image-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-image-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
+              <div style="margin-top: 6px;">
+                <div class="§RANDOM_ID§-labeled-input">
+                  <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-many-body-force-max-distance-checkbox"
+                    type="checkbox">
+                  <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-many-body-force-max-distance-checkbox">Use maximum
+                    distance</label>
+                </div>
+                <div id="§RANDOM_ID§-many-body-force-max-distance-div">
+                  <span class="§RANDOM_ID§-slider-text-left">Max</span>
+                  <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-many-body-force-max-distance-text"></span>
+                  <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-many-body-force-max-distance-slider" type="range"
+                    min="0.01" max="10000.0" step="0.01">
+                </div>
               </div>
             </div>
           </div>
         </div>
-        <!-- Menu: Node labels -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-label-head">
-          Node labels
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-label-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
+        <!-- Sub-menu: Links force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Links force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-links-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-links-force-checkbox">On</label>
+              </label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
+            <div id="§RANDOM_ID§-links-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Distance</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-links-force-distance-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-links-force-distance-slider" type="range" min="0.01"
+                  max="1000.0" step="0.01">
               </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-border-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-node-label-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-node-label-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Edges -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-edge-head">
-          Edges
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-edge-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-checkbox">Show edges</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Form -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Form
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-curvature-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-curvature-slider"
-                     type="range" min="-1.2" max="1.2" step="0.02">
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if provided)</label>
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-links-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-links-force-strength-slider" type="range" min="0.01"
+                  max="1.0" step="0.001">
               </div>
             </div>
           </div>
         </div>
-        <!-- Menu: Layout algorithm -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-layout-algorithm-head">
-          Layout algorithm
+        <!-- Sub-menu: x-positioning force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            x-positioning force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-x-positioning-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-x-positioning-force-checkbox">On</label>
+            </div>
+            <div id="§RANDOM_ID§-x-positioning-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-x-positioning-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-x-positioning-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-layout-algorithm-body">
-
-          <!-- Sub-menu: Simulation -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Simulation
+        <!-- Sub-menu: y-positioning force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            y-positioning force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-y-positioning-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-y-positioning-force-checkbox">On</label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-simulation-active-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
+            <div id="§RANDOM_ID§-y-positioning-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-y-positioning-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-y-positioning-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
               </div>
             </div>
           </div>
-          <!-- Sub-menu: Many-body force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Many-body force
+        </div>
+        <!-- Sub-menu: z-positioning force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            z-positioning force
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-z-positioning-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-z-positioning-force-checkbox">On</label>
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-many-body-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-many-body-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-many-body-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-many-body-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-many-body-force-strength-slider"
-                         type="range" min="-2000.0" max="200.0" step="0.01"
-                         style="direction:rtl;">
-                </div>
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Theta</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-many-body-force-theta-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-many-body-force-theta-slider"
-                         type="range" min="0.01" max="2.0" step="0.001">
-                </div>
-                <div style="margin-top: 6px;">
-                  <div class="§RANDOM_ID§-labeled-input">
-                    <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-many-body-force-min-distance-checkbox"
-                         type="checkbox">
-                    <label class="§RANDOM_ID§-label"
-                           for="§RANDOM_ID§-many-body-force-min-distance-checkbox">Use minimum distance</label>
-                  </div>
-                  <div id="§RANDOM_ID§-many-body-force-min-distance-div">
-                    <span class="§RANDOM_ID§-slider-text-left">Min</span>
-                    <span class="§RANDOM_ID§-slider-text-right"
-                          id="§RANDOM_ID§-many-body-force-min-distance-text"></span>
-                    <input class="§RANDOM_ID§-slider"
-                           id="§RANDOM_ID§-many-body-force-min-distance-slider"
-                           type="range" min="0.01" max="10000.0" step="0.01">
-                  </div>
-                </div>
-                <div style="margin-top: 6px;">
-                  <div class="§RANDOM_ID§-labeled-input">
-                    <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-many-body-force-max-distance-checkbox"
-                         type="checkbox">
-                    <label class="§RANDOM_ID§-label"
-                           for="§RANDOM_ID§-many-body-force-max-distance-checkbox">Use maximum distance</label>
-                  </div>
-                  <div id="§RANDOM_ID§-many-body-force-max-distance-div">
-                    <span class="§RANDOM_ID§-slider-text-left">Max</span>
-                    <span class="§RANDOM_ID§-slider-text-right"
-                          id="§RANDOM_ID§-many-body-force-max-distance-text"></span>
-                    <input class="§RANDOM_ID§-slider"
-                           id="§RANDOM_ID§-many-body-force-max-distance-slider"
-                           type="range" min="0.01" max="10000.0" step="0.01">
-                  </div>
-                </div>
+            <div id="§RANDOM_ID§-z-positioning-force-div">
+              <div>
+                <span class="§RANDOM_ID§-slider-text-left">Strength</span>
+                <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-z-positioning-force-strength-text"></span>
+                <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-z-positioning-force-strength-slider" type="range"
+                  min="0.01" max="1.0" step="0.001">
               </div>
             </div>
           </div>
-          <!-- Sub-menu: Links force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Links force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-links-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-links-force-checkbox">On</label>
-                </label>
-              </div>
-              <div id="§RANDOM_ID§-links-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Distance</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-links-force-distance-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-links-force-distance-slider"
-                         type="range" min="0.01" max="1000.0" step="0.01">
-                </div>
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-links-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-links-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
+        </div>
+        <!-- Sub-menu: Centering force -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Centering force
           </div>
-          <!-- Sub-menu: x-positioning force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              x-positioning force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-x-positioning-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-x-positioning-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-x-positioning-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-x-positioning-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-x-positioning-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: y-positioning force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              y-positioning force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-y-positioning-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-y-positioning-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-y-positioning-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-y-positioning-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-y-positioning-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: z-positioning force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              z-positioning force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-z-positioning-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-z-positioning-force-checkbox">On</label>
-              </div>
-              <div id="§RANDOM_ID§-z-positioning-force-div">
-                <div>
-                  <span class="§RANDOM_ID§-slider-text-left">Strength</span>
-                  <span class="§RANDOM_ID§-slider-text-right"
-                        id="§RANDOM_ID§-z-positioning-force-strength-text"></span>
-                  <input class="§RANDOM_ID§-slider"
-                         id="§RANDOM_ID§-z-positioning-force-strength-slider"
-                         type="range" min="0.01" max="1.0" step="0.001">
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Centering force -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Centering force
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-centering-force-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-centering-force-checkbox">On</label>
-              </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-centering-force-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-centering-force-checkbox">On</label>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+</div>
 
-  <script charset="utf-8" type="text/javascript">
-    if(typeof(require) === "undefined"){
+<script charset="utf-8" type="text/javascript">
+  if (typeof (require) === "undefined") {
       §LOAD_REQUIRE§
-    }
+  }
     §DEFINE_THREE§
     §DEFINE_3D_FORCE_GRAPH§
 
-    require(["gravis-3d-force-graph", "gravis-three"], function(ForceGraph3D, THREE){
-      // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
-      "use strict";
+  require(["gravis-3d-force-graph", "gravis-three"], function (ForceGraph3D, THREE) {
+    // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
+    "use strict";
 
-      const state = {
-        threeObjects:{
-          // Manual tracking and release of resources used by Three.js
-          // https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects
-          geometries: {},
-          materials: {},
-          textures: {},
-          renderers: {},
-          renderTargets: {},
-          trackGeometry(id, geometry){
-            if(typeof(this.geometries[id]) !== "undefined"){
-              this.removeGeometry(id);
-            }
-            this.geometries[id] = geometry;
-          },
-          removeGeometry(id){
-            this.geometries[id].dispose();
-            delete this.geometries[id];
-          },
-          trackMaterial(id, material){
-            if(typeof(this.materials[id]) !== "undefined"){
-              this.removeMaterial(id);
-            }
-            this.materials[id] = material;
-          },
-          removeMaterial(id){
-            this.materials[id].dispose();
-            delete this.materials[id];
-          },
-          trackTexture(id, texture){
-            if(typeof(this.textures[id]) !== "undefined"){
-              this.removeTexture(id);
-            }
-            this.textures[id] = texture;
-          },
-          removeTexture(id){
-            this.textures[id].dispose();
-            delete this.textures[id];
-          },
-          trackRenderer(id, renderer){
-            if(typeof(this.renderers[id]) !== "undefined"){
-              this.removeRenderer(id);
-            }
-            this.renderers[id] = renderer;
-          },
-          removeRenderer(id){
-            this.renderers[id].dispose();
-            delete this.renderers[id];
-          },
-          trackRenderTarget(id, renderTarget){
-            if(typeof(this.renderTargets[id]) !== "undefined"){
-              this.removeRenderTarget(id);
-            }
-            this.renderTargets[id] = renderTarget;
-          },
-          removeRenderTarget(id){
-            if(this.renderTargets[id] !== null){
-              this.renderTargets[id].dispose();
-            }
-            delete this.renderTargets[id];
-          },
-          disposeAll(){
-            const objects = [this.geometries, this.materials, this.textures, this.renderers, this.renderTargets];
-            for(let i=0; i<objects.length; i++){
-              const obj = objects[i];
-              for(let key in obj){
-                if(obj.hasOwnProperty(key)){
-                  if(obj[key] !== null){
-                    obj[key].dispose();
-                  }
-                }
-              }
-            }
-          },
+    const state = {
+      threeObjects: {
+        // Manual tracking and release of resources used by Three.js
+        // https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects
+        geometries: {},
+        materials: {},
+        textures: {},
+        renderers: {},
+        renderTargets: {},
+        trackGeometry(id, geometry) {
+          if (typeof (this.geometries[id]) !== "undefined") {
+            this.removeGeometry(id);
+          }
+          this.geometries[id] = geometry;
         },
-        manager:{
-          // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
-
-          // 1) Fetch state.rawData
-          fetchRawDataFromTemplating(){
-            state.rawData = §DATA§;
-            // Data selection and normalization
-            state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
-            state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
-            state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
-            state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
-            state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
-            state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
-            state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
-            state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
-            state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
-            state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
-            // Containers
-            state.graphContainerHeight = §GRAPH_HEIGHT§;
-            state.detailsContainerHeight = §DETAILS_HEIGHT§;
-            state.showDetails = §SHOW_DETAILS§,
-            state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
-            state.showMenu = §SHOW_MENU§,
-            state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
-            state.useDarkMode = §USE_DARK_MODE§,
-            // Nodes
-            state.showNodes = §SHOW_NODE§;
-            state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
-            state.nodeDragFix = §NODE_DRAG_FIX§;
-            state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
-            state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
-            state.showNodeImages = §SHOW_NODE_IMAGE§;
-            state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
-            state.showNodeLabels = §SHOW_NODE_LABEL§;
-            state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
-            state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
-            state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
-            state.nodeLabelFont = §NODE_LABEL_FONT§;
-            // Edges
-            state.showEdges = §SHOW_EDGE§;
-            state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
-            state.edgeCurvature = §EDGE_CURVATURE§;
-            state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
-            state.showEdgeLabels = §SHOW_EDGE_LABEL§;
-            state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
-            state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
-            state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
-            state.edgeLabelFont = §EDGE_LABEL_FONT§;
-            // Layout algorithm
-            state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
-            state.useManyBodyForce = §USE_MANY_BODY_FORCE§;
-            state.manyBodyForceStrength = §MANY_BODY_FORCE_STRENGTH§;
-            state.manyBodyForceTheta = §MANY_BODY_FORCE_THETA§;
-            state.useManyBodyForceMinDistance = §USE_MANY_BODY_FORCE_MIN_DISTANCE§;
-            state.manyBodyForceMinDistance = §MANY_BODY_FORCE_MIN_DISTANCE§;
-            state.useManyBodyForceMaxDistance = §USE_MANY_BODY_FORCE_MAX_DISTANCE§;
-            state.manyBodyForceMaxDistance = §MANY_BODY_FORCE_MAX_DISTANCE§;
-            state.useLinksForce = §USE_LINKS_FORCE§;
-            state.linksForceDistance = §LINKS_FORCE_DISTANCE§;
-            state.linksForceStrength = §LINKS_FORCE_STRENGTH§;
-            state.useXPositioningForce = §USE_X_POSITIONING_FORCE§;
-            state.xPositioningForceStrength = §X_POSITIONING_FORCE_STRENGTH§;
-            state.useYPositioningForce = §USE_Y_POSITIONING_FORCE§;
-            state.yPositioningForceStrength = §Y_POSITIONING_FORCE_STRENGTH§;
-            state.useZPositioningForce = §USE_Z_POSITIONING_FORCE§;
-            state.zPositioningForceStrength = §Z_POSITIONING_FORCE_STRENGTH§;
-            state.useCenteringForce = §USE_CENTERING_FORCE§;
-            // Other
-            state.initZoomFactor = §ZOOM_FACTOR§;
-            state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
-          },
-
-          // 2) Derive state.parsedData from state.givenData
-          rawDataParser:{
-            getBool(obj, prop, def){
-              try{
-                const value = obj[prop];
-                if(value == "true" || value == "True"){
-                  value = true;
-                } else if(value == "false" || value == "False"){
-                  value = false;
-                }
-                if(value !== true && value !== false){
-                  throw "Invalid value. Not a bool.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def
-            },
-
-            getString(obj, prop, def) {
-              try{
-                const value = String(obj[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def;
-            },
-
-            getArrayLengthOrZero(array){
-              try{
-                const value = parseInt(array.length);
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-
-            getObjectLengthOrZero(obj){
-              try{
-                const value = Object.keys(obj).length;
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-
-            createUniqueEdgeId(sourceId, targetId, knownEdgeIds){
-              let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
-                newEdgeId = newEdgeIdBase,
-                multiEdgeCounter = 1;
-              for(let i=1; knownEdgeIds.has(newEdgeId); i++){
-                newEdgeId = newEdgeIdBase + "_" + String(i);
-                multiEdgeCounter += 1;
-              }
-              knownEdgeIds.add(newEdgeId);
-              return {"id": newEdgeId, "count": multiEdgeCounter}
-            },
-          },
-
-          rawMetadataParser:{
-            getString(obj, prop, def){
-              try{
-                const value = String(obj.metadata[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getColor(obj, prop, def){
-              function isBodyidColor(strColor) {
-                const sty = new Option().style;
-                sty.color = strColor;
-                return sty.color !== "";
-              }
-              try{
-                const value = obj.metadata[prop];
-                if(!isBodyidColor(value)){
-                  throw "Invalid value. Not a color."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null){
-                  throw "Invalid value. Not a finite number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumberOrNull(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value)){  // Note: isFinite(null) gives true
-                  throw "Invalid value. Not a finite number or null."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFinitePositiveNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null || value < 0.0){
-                  throw "Invalid value. Not a finite positive number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            collectOtherMetadata(sourceObject, targetObject, definedMetadata){
-              if(typeof(sourceObject) !== "undefined" && typeof(sourceObject.metadata) !== "undefined"){
-                const properties = Object.keys(sourceObject.metadata);
-                for(let i=0; i<properties.length; i++){
-                  const property = properties[i];
-                  if(!definedMetadata.has(property)){
-                    targetObject[property] = sourceObject.metadata[property];
-                  }
-                }
-              }
-            },
-          },
-
-          propertyClassifier:{
-            numeric: null,
-            nonNumeric: null,
-            init(){
-              this.numeric = new Set(),
-              this.nonNumeric = new Set();
-            },
-            isNumeric(d){
-              return d === null || typeof(d) === "undefined" || String(parseFloat(d)) === String(d);
-            },
-            inspect(object, property){
-              const value = object[property];
-              if(!this.nonNumeric.has(property)){
-                if(this.isNumeric(value)){
-                  this.numeric.add(property);
-                } else{
-                  this.nonNumeric.add(property);
-                  this.numeric.delete(property);
-                }
-              }
-            }
-          },
-
-          replaceStringVariables(givenString, givenItem, variables){
-            let newString = givenString;
-            for(let i=0; i<variables.length; i++){
-              let variable = variables[i],
-                variableText = "$" + variable;
-              if(variable === "x"){
-                variable = "fx";
-              } else if (variable === "y"){
-                variable = "fy";
-              } else if (variable === "z"){
-                variable = "fz";
-              }
-              let insertedText = String(givenItem[variable]);
-              if(insertedText === "undefined"){
-                insertedText = "";
-              }
-              newString = newString.replace(variableText, insertedText);
-            }
-            return newString;
-          },
-
-          parseGeneral(givenData, parsedData){
-            const generalDefaults = state.useDarkMode ? {
-              background_color: "#1f1f25",
-              arrow_color: "#7ddba3",
-              node_color: "#7ddba3",
-              node_border_color: "#f0f0f5",
-              node_label_color: "#f0f0f5",
-              edge_color: "#b5b8c5",
-              edge_label_color: "#f0f0f5",
-            } : {
-              background_color: "white",
-              arrow_color: "black",
-              node_color: "black",
-              node_border_color: "black",
-              node_label_color: "black",
-              edge_color: "black",
-              edge_label_color: "black",
-            };
-            parsedData.general = {
-              // General
-              directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
-              label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
-              arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
-              // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
-              node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
-              node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
-              node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
-              node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
-              node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
-              node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
-              node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
-              node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
-              node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
-              node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
-              node_z: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_z", null),
-              contains_node_hover: false,
-              contains_node_click: false,
-              contains_node_image: false,
-              // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
-              edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
-              edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
-              edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
-              edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
-              edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
-              contains_edge_hover: false,
-              contains_edge_click: false,
-            };
-            if(!parsedData.general.directed){
-              parsedData.general.arrow_size = 0.0;
-            }
-          },
-
-          parseNodes(givenData, parsedData){
-            const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
-              nodeIdToObjectMap = new Map(),
-              nodeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "shape", "border_color", "border_size",
-                 "label_color", "label_size", "hover", "click", "image", "x", "y"]),
-              nodeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "shape", "border_color", "border_size",
-                "label_color", "label_size", "image", "x", "y"];
-            state.manager.propertyClassifier.init();
-            try {
-              Object.entries(givenData.nodes);
-            }
-            catch(e){
-               givenData.nodes = {};
-            }
-            for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
-              const parsedNode = {};
-              // data: id, label
-              parsedNode.id = String(givenNodeId);
-              parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
-              // defined metadata
-              parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
-              parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
-              parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
-              parsedNode.shape = state.manager.rawMetadataParser.getString(givenNode, "shape", parsedData.general.node_shape);
-              parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
-              parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
-              parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
-              parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
-              const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
-              if(image !== ""){
-                parsedNode.image = image;
-                parsedData.general.contains_node_image = true;
-              }
-              if(hover !== ""){
-                parsedNode.hover = hover;
-                parsedData.general.contains_node_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
-              if(click !== ""){
-                parsedNode.click = click;
-                parsedData.general.contains_node_click = true;
-              }
-              const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
-              const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
-              const z = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "z", parsedData.general.node_z);
-              if(x !== null){
-                parsedNode.fx = x;
-              }
-              if(y !== null){
-                parsedNode.fy = y;
-              }
-              if(z !== null){
-                parsedNode.fz = z;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
-              // feature classification
-              const parsedNodeProperties = Object.keys(parsedNode);
-              for(let i=0; i<parsedNodeProperties.length; i++){
-                const property = parsedNodeProperties[i],
-                  value = parsedNode[property];
-                state.manager.propertyClassifier.inspect(parsedNode, property);
-              }
-              // variable replacements
-              if(parsedNode.hover){
-                parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
-              }
-              if(parsedNode.click){
-                parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
-              }
-              // store the parsed node
-              parsedData.nodes.push(parsedNode);
-              // data structure for inserting node object references into edge data
-              nodeIdToObjectMap.set(parsedNode.id, parsedNode);
-            }
-            // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            for(let i=0; i<numNodes; i++){
-              const parsedNode = parsedData.nodes[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedNode[property]);
-                parsedNode[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.node_properties = {
-              "node_size_data_sources": numericProperties,
-              "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report empty graph
-            if(!(numNodes > 0)){
-              console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
-            }
-            return nodeIdToObjectMap;
-          },
-
-          parseEdges(givenData, parsedData, nodeIdToObjectMap){
-            let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
-            const knownEdgeIds = new Set(),
-              ignoredEdges = [],
-              edgeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
-              edgeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "label_color", "label_size"];
-            state.manager.propertyClassifier.init();
-            for(let i=0; i<numEdges; i++){
-              const givenEdge = givenData.edges[i],
-                parsedEdge = {},
-                sourceId = String(givenEdge.source),
-                targetId = String(givenEdge.target);
-              // data: source, target, id, multi_edge_counter, label
-              try{
-                const sourceObj = nodeIdToObjectMap.get(sourceId);
-                const targetObj = nodeIdToObjectMap.get(targetId);
-                if(typeof(sourceObj) === "undefined" || typeof(targetObj) === "undefined"){
-                  throw "Invalid node reference.";
-                }
-                parsedEdge.source = sourceObj;
-                parsedEdge.target = targetObj;
-              } catch(e){
-                const ignoredEdge = {
-                  index: i,
-                  source: sourceId,
-                  target: targetId,
-                }
-                ignoredEdges.push(ignoredEdge);
-                continue;
-              }
-              const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
-              parsedEdge.id = result.id;
-              parsedEdge.multi_edge_counter = result.count;
-              parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
-              // defined metadata
-              parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
-              parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
-              parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
-              parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
-              parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
-              if(hover !== ""){
-                parsedEdge.hover = hover;
-                parsedData.general.contains_edge_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
-              if(click !== ""){
-                parsedEdge.click = click;
-                parsedData.general.contains_edge_click = true;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
-              // feature classification
-              const parsedEdgeProperties = Object.keys(parsedEdge);
-              for(let i=0; i<parsedEdgeProperties.length; i++){
-                const property = parsedEdgeProperties[i],
-                  value = parsedEdge[property];
-                state.manager.propertyClassifier.inspect(parsedEdge, property);
-              }
-              // variable replacements
-              if(parsedEdge.hover){
-                parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
-              }
-              if(parsedEdge.click){
-                parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
-              }
-              // store it
-              parsedData.edges.push(parsedEdge);
-            }
-            // Ensure numeric properties are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges)
-            for(let i=0; i<numEdges; i++){
-              const parsedEdge = parsedData.edges[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedEdge[property]);
-                parsedEdge[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.edge_properties = {
-              "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
-              "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
-                item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report invalid edges
-            if(ignoredEdges.length > 0){
-              let message = undefined;
-              if(ignoredEdges.length == 1){
-                message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
-                  "refers to a node that is not part of the node list:\n";
-              } else{
-                message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
-                  "refer to a node that is not part of the node list:\n";
-              }
-              for(let i=0; i<ignoredEdges.length; i++){
-                const ignoredEdge = ignoredEdges[i];
-                message += '- Edge with index ' + ignoredEdge.index;
-                message += ', source "' + ignoredEdge.source;
-                message += '", target "' + ignoredEdge.target + '"\n';
-                if(i==9){
-                  message += '...';
-                  break;
-                }
-              }
-              console.log(message);
-            }
-          },
-
-          parseChosenData(chosenGraphNumber){
-            let givenData = state.rawData[chosenGraphNumber],
-              parsedData = {
-                general: {},
-                nodes: [],
-                edges: [],
-                adjacency: null,
-                incidence: null,
-              };
-            if(!givenData || givenData === null){
-              givenData = [];
-            }
-            // a) General
-            state.manager.parseGeneral(givenData, parsedData);
-            // b) Nodes
-            const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
-            // c) Edges
-            state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
-            // Update state
-            state.parsedData = parsedData;
-            state.currentGraphParts = {};
-            // Update UI: show or hide containers
-            ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
-            ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
-          },
-
-          // 3) Derive state.shownData from state.parsedData
-          createNodeToAdjacentNodesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(sourceNode, targetNode){
-                let adjacentNodes = this.map.get(sourceNode);
-                if(adjacentNodes){
-                  adjacentNodes.add(targetNode);
-                } else{
-                  adjacentNodes = new Set([targetNode]);
-                  this.map.set(sourceNode, adjacentNodes);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          createNodeToIncidentEdgesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(node, edge){
-                let incidentEdges = this.map.get(node);
-                if(incidentEdges){
-                  incidentEdges.add(edge);
-                } else{
-                  incidentEdges = new Set([edge]);
-                  this.map.set(node, incidentEdges);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          prepareShownData(){
-            const numNodes = state.parsedData.nodes.length,
-              numEdges = state.parsedData.edges.length;
-            state.shownData = {
-              "general": null,
-              "nodes": new Array(numNodes),
-              "edges": new Array(numEdges),
-            }
-            const nodeIdToObjectMap = new Map(),
-              nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            // a) General
-            state.shownData.general = {
-              "background_color": state.parsedData.general.background_color,
-              "arrow_size": state.parsedData.general.arrow_size,
-              "arrow_color": state.parsedData.general.arrow_color,
-              "directed": state.parsedData.general.directed,
-              "node_image_fetching_failed": false,
-            };
-            // b) Nodes
-            for(let i=0; i<numNodes; i++){
-              state.shownData.nodes[i] = {};
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.id = parsedNode.id;
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-              shownNode.color = parsedNode.color;
-              shownNode.opacity = parsedNode.opacity;
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              shownNode.shape = parsedNode.shape;
-              shownNode.border_color = parsedNode.border_color;
-              shownNode.border_size = parsedNode.border_size;
-              shownNode.label_color = parsedNode.label_color;
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-              if(typeof(parsedNode.image) !== "undefined"){
-                shownNode.image = parsedNode.image;
-              }
-              if(typeof(parsedNode.hover) !== "undefined"){
-                shownNode.hover = parsedNode.hover;
-              }
-              if(typeof(parsedNode.click) !== "undefined"){
-                shownNode.click = parsedNode.click;
-              }
-              if(typeof(parsedNode.fx) !== "undefined"){
-                shownNode.fx = parsedNode.fx;
-              }
-              if(typeof(parsedNode.fy) !== "undefined"){
-                shownNode.fy = parsedNode.fy;
-              }
-              if(typeof(parsedNode.fz) !== "undefined"){
-                shownNode.fz = parsedNode.fz;
-              }
-              nodeIdToObjectMap.set(shownNode.id, shownNode);
-              // Derived properties for performance improvement in updateNodePositions
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-              state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
-              state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
-            }
-            // c) Edges
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
-              nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
-              nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
-            for(let i=0; i<numEdges; i++){
-              state.shownData.edges[i] = {};
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
-              shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
-              shownEdge.id = parsedEdge.id;
-              shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
-              shownEdge.color = parsedEdge.color;
-              shownEdge.opacity = parsedEdge.opacity;
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-              shownEdge.label_color = parsedEdge.label_color;
-              shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
-              shownEdge.multi_edge_counter = parsedEdge.multi_edge_counter;
-              if(typeof(parsedEdge.hover) !== "undefined"){
-                shownEdge.hover = parsedEdge.hover;
-              }
-              if(typeof(parsedEdge.click) !== "undefined"){
-                shownEdge.click = parsedEdge.click;
-              }
-              // Derived properties for performance improvement in updateEdgePositions
-              shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-              // Data structure for highlighting adjacent nodes and incident edges to this node
-              nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
-              nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
-              nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
-              nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
-            }
-            state.shownData.adjacency = nodeToAdjacentNodesMap;
-            state.shownData.incidence = nodeToIncidentEdgesMap;
-          },
-
-          calcSingleNodeSize(parsedNode, nodeSizeNormalizer){
-            let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
-            if(!isFinite(nodeSize)){
-              nodeSize = state.parsedData.general.node_size;
-            }
-            return nodeSize * state.nodeSizeFactor;
-          },
-
-          calcSingleNodeLabelText(parsedNode){
-            return String(parsedNode[state.nodeLabelTextDataSource]);
-          },
-
-          calcSingleNodeLabelSize(parsedNode){
-            return parsedNode.label_size * state.nodeLabelSizeFactor;
-          },
-
-          calcSingleNodeLabelPlacement(node){
-            let baseSize = node.size_half;
-            if(state.showNodeImages && typeof(node.image) !== "undefined"){
-              baseSize = (node.size_half > node.image_size_half) ? node.size_half : node.image_size_half;
-            }
-            return baseSize + node.label_size * 0.77 + 2.0;
-          },
-
-          calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer){
-            let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
-            if(!isFinite(edgeSize)){
-              edgeSize = state.parsedData.general.edge_size;
-            }
-            return edgeSize * state.edgeSizeFactor;
-          },
-
-          calcSingleEdgeCurvatureFactor(parsedEdge){
-            const appearanceAdaptionFactor = 0.6;
-            return state.edgeCurvature * parsedEdge.multi_edge_counter * appearanceAdaptionFactor;
-          },
-
-          calcSingleEdgeLabelText(parsedEdge){
-            return String(parsedEdge[state.edgeLabelTextDataSource]);
-          },
-
-          calcSingleEdgeLabelSize(parsedEdge){
-            return parsedEdge.label_size * state.edgeLabelSizeFactor;
-          },
-
-          calcSingleNodeSizeDerivatives(shownNode){
-            shownNode.size_half = shownNode.size / 2.0;
-            const appearanceAdaptionFactor = 1.2;
-            shownNode.image_size = shownNode.size * state.nodeImageSizeFactor * appearanceAdaptionFactor;
-            shownNode.image_size_half = shownNode.image_size / 2.0;
-            shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
-          },
-
-          calcSingleNodeLabelSizeDerivatives(shownNode){
-            shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
-          },
-
-          calcSingleNodeBorderSizeDerivatives(shownNode){
-            shownNode.border_size_half = shownNode.border_size / 2.0;
-          },
-
-          createNodeSizeNormalizer(){
-            let normalizer;
-            if(state.useNodeSizeNormalization){
-              const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
-                dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
-                targetMin = state.nodeSizeNormalizationMin,
-                targetMax = state.nodeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor) || factor === null){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          createEdgeSizeNormalizer(){
-            let normalizer;
-            if(state.useEdgeSizeNormalization){
-              const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
-                dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
-                targetMin = state.edgeSizeNormalizationMin,
-                targetMax = state.edgeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor)){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          updateNodeSizes(){
-            // Data
-            const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeSizes();
-          },
-
-          updateNodeImageSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeImages();
-          },
-
-          updateNodeLabelTexts(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeLabels();
-          },
-
-          updateNodeLabelSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-              state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeLabels();
-          },
-
-          updateEdgeSizes(){
-            // Data
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-            }
-            // UI
-            ui.composites.graph.updateEdgeSizes();
-          },
-
-          updateEdgeCurvatures(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.updateEdgeCurvatures();
-          },
-        }
-      }
-
-      const ui = {
-        symbols:{
-          // Choice of symbols is influenced by their appearance in different browsers
-          // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
-          // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
-          detailsShown: "▾",
-          detailsHidden: "▴",
-          menuShown: "▸",
-          menuHidden: "◂",
-          menuItemActive: "▸",
-          menuItemInactive: "▾",
+        removeGeometry(id) {
+          this.geometries[id].dispose();
+          delete this.geometries[id];
         },
+        trackMaterial(id, material) {
+          if (typeof (this.materials[id]) !== "undefined") {
+            this.removeMaterial(id);
+          }
+          this.materials[id] = material;
+        },
+        removeMaterial(id) {
+          this.materials[id].dispose();
+          delete this.materials[id];
+        },
+        trackTexture(id, texture) {
+          if (typeof (this.textures[id]) !== "undefined") {
+            this.removeTexture(id);
+          }
+          this.textures[id] = texture;
+        },
+        removeTexture(id) {
+          this.textures[id].dispose();
+          delete this.textures[id];
+        },
+        trackRenderer(id, renderer) {
+          if (typeof (this.renderers[id]) !== "undefined") {
+            this.removeRenderer(id);
+          }
+          this.renderers[id] = renderer;
+        },
+        removeRenderer(id) {
+          this.renderers[id].dispose();
+          delete this.renderers[id];
+        },
+        trackRenderTarget(id, renderTarget) {
+          if (typeof (this.renderTargets[id]) !== "undefined") {
+            this.removeRenderTarget(id);
+          }
+          this.renderTargets[id] = renderTarget;
+        },
+        removeRenderTarget(id) {
+          if (this.renderTargets[id] !== null) {
+            this.renderTargets[id].dispose();
+          }
+          delete this.renderTargets[id];
+        },
+        disposeAll() {
+          const objects = [this.geometries, this.materials, this.textures, this.renderers, this.renderTargets];
+          for (let i = 0; i < objects.length; i++) {
+            const obj = objects[i];
+            for (let key in obj) {
+              if (obj.hasOwnProperty(key)) {
+                if (obj[key] !== null) {
+                  obj[key].dispose();
+                }
+              }
+            }
+          }
+        },
+      },
+      manager: {
+        // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
 
-        elements:{
+        // 1) Fetch state.rawData
+        fetchRawDataFromTemplating() {
+          state.rawData = §DATA§;
+          // Data selection and normalization
+          state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
+          state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
+          state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
+          state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
+          state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
+          state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
+          state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
+          state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
+          state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
+          state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
           // Containers
-          mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
-          tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
-          leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
-          rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
-          graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
-          detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
-          detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
-          detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
-          // Data sources
-          dataHead: document.getElementById("§RANDOM_ID§-data-head"),
-          dataBody: document.getElementById("§RANDOM_ID§-data-body"),
-          graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
-          graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
-          nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
-          nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
-          nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
-          nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
-          nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
-          nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
-          nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
-          edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
-          edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
-          edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
-          edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
-          edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
-          edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
-          edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
-          // General
-          generalHead: document.getElementById("§RANDOM_ID§-general-head"),
-          generalBody: document.getElementById("§RANDOM_ID§-general-body"),
-          resetButton: document.getElementById("§RANDOM_ID§-reset"),
-          fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
-          svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
-          pngExportButton: document.getElementById("§RANDOM_ID§-png"),
-          jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+          state.graphContainerHeight = §GRAPH_HEIGHT§;
+          state.detailsContainerHeight = §DETAILS_HEIGHT§;
+          state.showDetails = §SHOW_DETAILS§,
+          state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
+          state.showMenu = §SHOW_MENU§,
+          state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+          state.useDarkMode = §USE_DARK_MODE§,
           // Nodes
-          nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
-          nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
-          nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
-          nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
-          nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
-          nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
-          nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
-          nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
-          // Node images
-          nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
-          nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
-          nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
-          nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
-          nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
-          nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
-          // Node labels
-          nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
-          nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
-          nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
-          nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
-          nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
-          nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
-          nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
+          state.showNodes = §SHOW_NODE§;
+          state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
+          state.nodeDragFix = §NODE_DRAG_FIX§;
+          state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
+          state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
+          state.showNodeImages = §SHOW_NODE_IMAGE§;
+          state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
+          state.showNodeLabels = §SHOW_NODE_LABEL§;
+          state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
+          state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
+          state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
+          state.nodeLabelFont = §NODE_LABEL_FONT§;
           // Edges
-          edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
-          edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
-          edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
-          edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
-          edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
-          edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
-          edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
-          edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
+          state.showEdges = §SHOW_EDGE§;
+          state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
+          state.edgeCurvature = §EDGE_CURVATURE§;
+          state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
+          state.showEdgeLabels = §SHOW_EDGE_LABEL§;
+          state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
+          state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
+          state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
+          state.edgeLabelFont = §EDGE_LABEL_FONT§;
           // Layout algorithm
-          layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
-          layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
-          simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
-          manyBodyForceCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-checkbox"),
-          manyBodyForceContainer: document.getElementById("§RANDOM_ID§-many-body-force-div"),
-          manyBodyForceStrengthText: document.getElementById("§RANDOM_ID§-many-body-force-strength-text"),
-          manyBodyForceStrengthSlider: document.getElementById("§RANDOM_ID§-many-body-force-strength-slider"),
-          manyBodyForceThetaText: document.getElementById("§RANDOM_ID§-many-body-force-theta-text"),
-          manyBodyForceThetaSlider: document.getElementById("§RANDOM_ID§-many-body-force-theta-slider"),
-          manyBodyForceMinDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-checkbox"),
-          manyBodyForceMinDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-div"),
-          manyBodyForceMinDistText: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-text"),
-          manyBodyForceMinDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-slider"),
-          manyBodyForceMaxDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-checkbox"),
-          manyBodyForceMaxDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-div"),
-          manyBodyForceMaxDistText: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-text"),
-          manyBodyForceMaxDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-slider"),
-          linksForceCheckbox: document.getElementById("§RANDOM_ID§-links-force-checkbox"),
-          linksForceContainer: document.getElementById("§RANDOM_ID§-links-force-div"),
-          linksForceDistanceText: document.getElementById("§RANDOM_ID§-links-force-distance-text"),
-          linksForceDistanceSlider: document.getElementById("§RANDOM_ID§-links-force-distance-slider"),
-          linksForceStrengthText: document.getElementById("§RANDOM_ID§-links-force-strength-text"),
-          linksForceStrengthSlider: document.getElementById("§RANDOM_ID§-links-force-strength-slider"),
-          xPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-x-positioning-force-checkbox"),
-          xPositioningForceContainer: document.getElementById("§RANDOM_ID§-x-positioning-force-div"),
-          xPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-text"),
-          xPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-slider"),
-          yPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-y-positioning-force-checkbox"),
-          yPositioningForceContainer: document.getElementById("§RANDOM_ID§-y-positioning-force-div"),
-          yPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-text"),
-          yPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-slider"),
-          zPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-z-positioning-force-checkbox"),
-          zPositioningForceContainer: document.getElementById("§RANDOM_ID§-z-positioning-force-div"),
-          zPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-z-positioning-force-strength-text"),
-          zPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-z-positioning-force-strength-slider"),
-          centeringForceCheckbox: document.getElementById("§RANDOM_ID§-centering-force-checkbox"),
+          state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
+          state.useManyBodyForce = §USE_MANY_BODY_FORCE§;
+          state.manyBodyForceStrength = §MANY_BODY_FORCE_STRENGTH§;
+          state.manyBodyForceTheta = §MANY_BODY_FORCE_THETA§;
+          state.useManyBodyForceMinDistance = §USE_MANY_BODY_FORCE_MIN_DISTANCE§;
+          state.manyBodyForceMinDistance = §MANY_BODY_FORCE_MIN_DISTANCE§;
+          state.useManyBodyForceMaxDistance = §USE_MANY_BODY_FORCE_MAX_DISTANCE§;
+          state.manyBodyForceMaxDistance = §MANY_BODY_FORCE_MAX_DISTANCE§;
+          state.useLinksForce = §USE_LINKS_FORCE§;
+          state.linksForceDistance = §LINKS_FORCE_DISTANCE§;
+          state.linksForceStrength = §LINKS_FORCE_STRENGTH§;
+          state.useXPositioningForce = §USE_X_POSITIONING_FORCE§;
+          state.xPositioningForceStrength = §X_POSITIONING_FORCE_STRENGTH§;
+          state.useYPositioningForce = §USE_Y_POSITIONING_FORCE§;
+          state.yPositioningForceStrength = §Y_POSITIONING_FORCE_STRENGTH§;
+          state.useZPositioningForce = §USE_Z_POSITIONING_FORCE§;
+          state.zPositioningForceStrength = §Z_POSITIONING_FORCE_STRENGTH§;
+          state.useCenteringForce = §USE_CENTERING_FORCE§;
+          // Other
+          state.initZoomFactor = §ZOOM_FACTOR§;
+          state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
         },
 
-        composites:{
-          responsiveContainer:{
-            init(){
-              // Delete all contained items (relevant only for reset, not first creation)
-              ui.deleteChildElements(ui.elements.graphContainer);
-              ui.deleteChildElements(ui.elements.detailsBody);
-              // Menu
-              if(state.showMenu){
-                ui.composites.menu.show();
-              } else{
-                ui.composites.menu.hide();
+        // 2) Derive state.parsedData from state.givenData
+        rawDataParser: {
+          getBool(obj, prop, def) {
+            try {
+              const value = obj[prop];
+              if (value == "true" || value == "True") {
+                value = true;
+              } else if (value == "false" || value == "False") {
+                value = false;
               }
-              // Details
-              if(state.showDetails){
-                ui.composites.details.show(true);
-              } else{
-                ui.composites.details.hide(true);
+              if (value !== true && value !== false) {
+                throw "Invalid value. Not a bool.";
               }
-              // Divs
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-              ui.composites.responsiveContainer.getInnerWidths();
-            },
-
-            getInnerWidths(){
-              state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
-              state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
-            },
-
-            getInnerHeights(){
-              state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
-              if(state.showDetails){
-                state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-              }
-            },
-
-            setInnerHeights(){
-              ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
-              ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
-            },
-
-            setOuterHeights(){
-              ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
-            },
-
-            getSizes(){
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-            },
-
-            setSizes(){
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-            },
-
-            adaptToResize(){
-              ui.composites.responsiveContainer.getSizes();
-              ui.composites.responsiveContainer.setSizes();
-            },
-
-            adaptToFullscreen(){
-              ui.composites.responsiveContainer.getSizes();
-              if(document.fullscreenElement){
-                // On entering fullscreen, remember the current container heights
-                state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
-                state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
-                // and then adapt them to maximum height possible in full screen mode
-                function calculateFullscreenMaxGraphHeight(){
-                  let outerHeight = null;
-                  try{
-                    const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
-                      graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                      paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
-                      borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
-                      borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
-                      paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
-                    outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
-                    if(!isFinite(outerHeight) || outerHeight === null){
-                      throw "Invalid number";
-                    }
-                  } catch(e){
-                    // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
-                    outerHeight = 1 + 3 + 3 + 1;
-                  }
-                  let graphHeight = screen.height - outerHeight;
-                  if(state.showDetails){
-                    graphHeight -= ui.composites.details.calculateHeightDifference();
-                  }
-                  return graphHeight;
-                }
-                state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
-              } else{
-                // On leaving fullscreen, set container heights back to remembered values
-                state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
-                state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
-              }
-              ui.composites.responsiveContainer.setSizes();
-            },
-          },
-
-          menu:{
-            show(){
-              ui.elements.leftContainer.style.width = "80%";
-              ui.elements.rightContainer.style.width = "20%";
-              ui.elements.rightContainer.style.display = "block";
-            },
-
-            hide(){
-              ui.elements.leftContainer.style.width = "100%";
-              ui.elements.rightContainer.style.width = "0%";
-              ui.elements.rightContainer.style.display = "none";
-            },
-
-            toggle(){
-              // Update menu button
-              const div = ui.elements.menuToggleDiv;
-              state.showMenu = !state.showMenu;
-              if(state.showMenu){
-                div.innerText = ui.symbols.menuShown;
-                ui.composites.menu.show();
-              } else {
-                div.innerHTML = ui.symbols.menuHidden;
-                ui.composites.menu.hide();
-              }
-
-              // Update rest of UI
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-              ui.composites.graph.updateGraphDrawingArea();
-            },
-
-            setItem(keyElement, valElement, toActive){
-              const currentText = keyElement.innerHTML;
-              let sliceStart = 0;
-              if(currentText.startsWith(ui.symbols.menuItemActive)){
-                sliceStart = ui.symbols.menuItemActive.length;
-              } else if (currentText.startsWith(ui.symbols.menuItemInactive)){
-                sliceStart = ui.symbols.menuItemInactive.length;
-              }
-              if(toActive){
-                keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.classList.add("§RANDOM_ID§-active");
-                valElement.style.display = "block";
-              } else {
-                keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.classList.remove("§RANDOM_ID§-active");
-                valElement.style.display = "none";
-              }
-            },
-
-            toggleItem(keyElement, valElement){
-              const toActive = !(valElement.style.display !== "none");
-              ui.composites.menu.setItem(keyElement, valElement, toActive);
-            },
-          },
-
-          details:{
-            calculateHeightDifference(){
-              let outerHeight = null;
-              try{
-                const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                  detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
-                  border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
-                  margin = parseFloat(detailsContainerComputedStyle.marginTop),
-                  border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
-                outerHeight = border1 + margin + border2;
-                if(!isFinite(outerHeight) || outerHeight === null){
-                  throw "Invalid number";
-                }
-              } catch(e){
-                // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
-                outerHeight = 7.0;
-              }
-              return state.detailsContainerHeight + outerHeight
-            },
-
-            show(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "block";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight -= heightDiff;
-                if(state.graphContainerHeight < 70){
-                  state.graphContainerHeight = 70;
-                }
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            hide(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "none";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight += heightDiff;
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            toggle(){
-              // Update details button
-              const toggleDiv = ui.elements.detailsToggleDiv;
-              state.showDetails = !state.showDetails;
-              if(state.showDetails){
-                toggleDiv.innerText = ui.symbols.detailsShown;
-                ui.composites.details.show();
-              } else {
-                toggleDiv.innerHTML = ui.symbols.detailsHidden;
-                ui.composites.details.hide();
-              }
-            },
-          },
-
-          download:{
-            png(filename){
-              ui.composites.download._rasterImage(filename, "png");
-            },
-
-            jpg(filename){
-              ui.composites.download._rasterImage(filename, "jpeg");
-            },
-
-            _rasterImage(filename, format, resolutionFactor=4.0){
-              const renderer = state.webglGraph.renderer(),
-                scene = state.webglGraph.scene(),
-                camera = state.webglGraph.camera(),
-                mimeType = "image/" + format,
-                size = new THREE.Vector2(0, 0);
-
-              renderer.getSize(size);
-              const width = size.x,
-                height = size.y;
-
-              function upsize(){
-                renderer.setSize(width * resolutionFactor, height * resolutionFactor);
-                renderer.render(scene, camera);
-              }
-              function downsize(){
-                renderer.setSize(width, height);
-                renderer.render(scene, camera);
-              }
-              // Increase resolution
-              upsize();
-              // Create image and decrease solution to original value
-              function finishedBlobCallback(blob){
-                ui.composites.download._blobToFileDownload(blob, filename);
-                downsize();
-              }
-              renderer.domElement.toBlob(finishedBlobCallback, mimeType, 1.0);
-            },
-
-            _blobToFileDownload(blob, filename){
-              const url = URL.createObjectURL(blob),
-                a = document.createElement("a");
-              function handleClick(){
-                setTimeout(function(){
-                  // Long waiting time before removal for slow devices like mobile phones
-                  URL.revokeObjectURL(url);
-                  this.removeEventListener("click", handleClick);
-                }, 20000);
-              };
-              document.body.appendChild(a);
-              a.href = url;
-              a.download = filename;
-              a.addEventListener("click", handleClick, false);
-              a.click();
-              document.body.removeChild(a);
-            },
-          },
-
-          selection(element, optionList, valueList=undefined) {
-            while(element.hasChildNodes()){
-              element.removeChild(element.firstChild);
+              return value;
+            } catch (e) {
+              return def;
             }
-            for(let i=0; i<optionList.length; i++){
-              let text = optionList[i];
-              let value = text;
-              if(valueList){
-                value = valueList[i];
+            return def
+          },
+
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
               }
-              let opt = document.createElement("option");
-              opt.appendChild(document.createTextNode(text));
-              opt.value = value;
-              element.appendChild(opt);
+              return value;
+            } catch (e) {
+              return def;
+            }
+            return def;
+          },
+
+          getArrayLengthOrZero(array) {
+            try {
+              const value = parseInt(array.length);
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
+              }
+              return value;
+            } catch (e) {
+              return 0;
             }
           },
 
-          tooltip:{
-            show(xShift=null, yShift=null){
-              if(isFinite(xShift) && xShift !== null){
-                ui.elements.tooltipContainer.style.left =  parseInt(xShift) + "px";
+          getObjectLengthOrZero(obj) {
+            try {
+              const value = Object.keys(obj).length;
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
               }
-              if(isFinite(yShift) && yShift !== null){
-                ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
-              }
-              ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
-              ui.elements.tooltipContainer.style.visibility = "visible";
-              ui.elements.tooltipContainer.style.opacity = 1.0;
-            },
-
-            hide(){
-              ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
-              ui.elements.tooltipContainer.style.visibility = "hidden";
-              ui.elements.tooltipContainer.style.opacity = 0.0;
-            },
-          },
-
-          progressBar:{
-            create(){
-              // Main container
-              this.mainContainer = document.createElement("div");
-              this.mainContainer.id = "§RANDOM_ID§-progress-container";
-              this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
-              ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
-              // Text container
-              const numNodes = state.parsedData.nodes.length;
-              this.textContainer = document.createElement("div");
-              this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
-              this.textContainer.style.textAlign = "center";
-              // Bar container
-              this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
-              this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
-              this.innerBarContainer.style.width = "0%";
-              // Add them to DOM
-              this.outerBarContainer.appendChild(this.innerBarContainer);
-              this.mainContainer.appendChild(this.textContainer);
-              this.mainContainer.appendChild(this.outerBarContainer);
-              ui.elements.graphContainer.appendChild(this.mainContainer);
-            },
-
-            update(percentage){
-              this.innerBarContainer.style.width = percentage + "%";
-            },
-
-            remove(){
-              ui.elements.graphContainer.removeChild(this.mainContainer);
+              return value;
+            } catch (e) {
+              return 0;
             }
           },
 
-          graph:{
-            createGraph(){
-              // Remove existing elements
-              ui.deleteChildElements(ui.elements.graphContainer);
+          createUniqueEdgeId(sourceId, targetId, knownEdgeIds) {
+            let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
+              newEdgeId = newEdgeIdBase,
+              multiEdgeCounter = 1;
+            for (let i = 1; knownEdgeIds.has(newEdgeId); i++) {
+              newEdgeId = newEdgeIdBase + "_" + String(i);
+              multiEdgeCounter += 1;
+            }
+            knownEdgeIds.add(newEdgeId);
+            return { "id": newEdgeId, "count": multiEdgeCounter }
+          },
+        },
 
-              // Create new elements
-              // - Graph
-              state.webglGraph = ForceGraph3D()(ui.elements.graphContainer)
-                .showNavInfo(false)
-                .backgroundColor(state.shownData.general.background_color)
-                .width(state.graphContainerWidth)
-                .height(state.graphContainerHeight);
-              // Attempt to prevent some memory leaks
-              const renderer = state.webglGraph.renderer();
-              state.threeObjects.trackRenderer("currentGraph", renderer);
-              const renderTarget = renderer.getRenderTarget();
-              state.threeObjects.trackRenderTarget("currentRenderTarget", renderTarget);
-              // - Menu toggle button
-              if(state.showMenuToggleButton){
-                const menuDiv = document.createElement("div");
-                if(state.showMenu){
-                  menuDiv.innerText = ui.symbols.menuShown;
-                } else {
-                  menuDiv.innerText = ui.symbols.menuHidden;
-                }
-                menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
-                menuDiv.onclick = ui.composites.menu.toggle;
-                ui.elements.graphContainer.appendChild(menuDiv);
-                ui.elements.menuToggleDiv = menuDiv;
+        rawMetadataParser: {
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj.metadata[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
               }
-              // - Details toggle button
-              if(state.showDetailsToggleButton){
-                const detailsDiv = document.createElement("div");
-                if(state.showDetails){
-                  detailsDiv.innerText = ui.symbols.detailsShown;
-                } else {
-                  detailsDiv.innerText = ui.symbols.detailsHidden;
-                }
-                detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
-                detailsDiv.onclick = ui.composites.details.toggle;
-                ui.elements.graphContainer.appendChild(detailsDiv);
-                ui.elements.detailsToggleDiv = detailsDiv;
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getColor(obj, prop, def) {
+            function isBodyidColor(strColor) {
+              const sty = new Option().style;
+              sty.color = strColor;
+              return sty.color !== "";
+            }
+            try {
+              const value = obj.metadata[prop];
+              if (!isBodyidColor(value)) {
+                throw "Invalid value. Not a color."
               }
-              // Wait a bit to finish UI rendering, then start potentially slow layout computation
-              setTimeout(function(){
-                // - Layout algorithm
-                ui.composites.graph.setLayout();
-                // - Data
-                const data = {
-                  nodes: state.shownData.nodes,
-                  links: state.shownData.edges,
-                };
-                state.webglGraph
-                  .graphData(data);
-                // - Nodes
-                state.webglGraph
-                  .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
-                  .nodeVisibility(state.showNodes);
-                // - Edges
-                // Uses linkMaterial because linkOpacity can only be a single number, not function
-                state.webglGraph
-                  .linkVisibility(state.showEdges)
-                  .linkWidth(edge => edge.size)
-                  .linkCurvature(ui.composites.graph._calcEdgeCurvature)
-                  .linkMaterial(ui.composites.graph.createSingleEdgeMaterial);
-                if(state.shownData.general.directed){
-                  state.webglGraph
-                    .linkDirectionalArrowColor(edge => state.shownData.general.arrow_color)
-                    .linkDirectionalArrowLength(edge => state.shownData.general.arrow_size)
-                    .linkDirectionalArrowRelPos(ui.composites.graph._calcArrowPosition);
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null) {
+                throw "Invalid value. Not a finite number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumberOrNull(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value)) {  // Note: isFinite(null) gives true
+                throw "Invalid value. Not a finite number or null."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFinitePositiveNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null || value < 0.0) {
+                throw "Invalid value. Not a finite positive number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          collectOtherMetadata(sourceObject, targetObject, definedMetadata) {
+            if (typeof (sourceObject) !== "undefined" && typeof (sourceObject.metadata) !== "undefined") {
+              const properties = Object.keys(sourceObject.metadata);
+              for (let i = 0; i < properties.length; i++) {
+                const property = properties[i];
+                if (!definedMetadata.has(property)) {
+                  targetObject[property] = sourceObject.metadata[property];
                 }
-                // - Graph behavior
-                ui.composites.graph.setBehavior();
-              }, 250);
-            },
+              }
+            }
+          },
+        },
 
-            _calcArrowPosition(edge){
-              if(edge.source === edge.target){
-                // Case 1: Self loop
-                return 0.5;
-              } else{
-                // Case 2: Normal edge
-                const dx = edge.target.x - edge.source.x,
-                  dy = edge.target.y - edge.source.y,
-                  dz = edge.target.z - edge.source.z,
-                  len = Math.sqrt(dx**2 + dy**2 + dz**2);
-                return 0.99 - edge.target.size_half / len;
+        propertyClassifier: {
+          numeric: null,
+          nonNumeric: null,
+          init() {
+            this.numeric = new Set(),
+              this.nonNumeric = new Set();
+          },
+          isNumeric(d) {
+            return d === null || typeof (d) === "undefined" || String(parseFloat(d)) === String(d);
+          },
+          inspect(object, property) {
+            const value = object[property];
+            if (!this.nonNumeric.has(property)) {
+              if (this.isNumeric(value)) {
+                this.numeric.add(property);
+              } else {
+                this.nonNumeric.add(property);
+                this.numeric.delete(property);
               }
-            },
+            }
+          }
+        },
 
-            setLayout(){
-              // Store all forces provided by the library (for reuse when turning them off)
-              state.predefinedForces = {
-                "charge": state.webglGraph.d3Force("charge"),
-                "link": state.webglGraph.d3Force("link"),
-                "center": state.webglGraph.d3Force("center"),
-              }
-              ui.composites.graph.simulationManager.setAllForces();
-              state.webglGraph
-                .d3VelocityDecay(0.3);  // default 0.4, lower value means less friction
+        replaceStringVariables(givenString, givenItem, variables) {
+          let newString = givenString;
+          for (let i = 0; i < variables.length; i++) {
+            let variable = variables[i],
+              variableText = "$" + variable;
+            if (variable === "x") {
+              variable = "fx";
+            } else if (variable === "y") {
+              variable = "fy";
+            } else if (variable === "z") {
+              variable = "fz";
+            }
+            let insertedText = String(givenItem[variable]);
+            if (insertedText === "undefined") {
+              insertedText = "";
+            }
+            newString = newString.replace(variableText, insertedText);
+          }
+          return newString;
+        },
 
-              // - Progress bar: only if large graph, stops simulation to get initial static image
-              const numNodes = state.parsedData.nodes.length;
-              if(numNodes > state.largeGraphThreshold){
-                // Layout start
-                ui.composites.progressBar.create();
-                let numIterations = 40;
-                if(numNodes >= 25000){
-                  numIterations = 9;
-                } else if(numNodes >= 10000){
-                  numIterations = 13;
-                } else if(numNodes >= 5000){
-                  numIterations = 18;
-                } else if(numNodes >= 2000){
-                  numIterations = 25;
-                } else if(numNodes >= 1000){
-                  numIterations = 35;
-                }
-                // Layout update
-                state.webglGraph
-                  .warmupTicks(numIterations);
-                // Layout finished
-                state.webglGraph
-                  .onEngineTick(function(){
-                    // Freeze graph after warmup to get a static rendering
-                    state.webglGraph.cooldownTicks(0);
-                    // Remove progress message
-                    ui.composites.progressBar.remove();
-                  })
-                  .onEngineStop(function(){
-                    // Remove tick functions
-                    state.webglGraph.onEngineTick(function(){});
-                    state.webglGraph.onEngineStop(function(){});
-                    // Unfreeze graph for future user interaction
-                    state.webglGraph.cooldownTicks(Infinity);
-                  })
-              }
-            },
-
-            setBehavior(){
-              // - Node click behavior
-              function createNodeText(node){
-                let htmlText = "<div>Node: " + String(node.id) + "</div>";
-                if(typeof(node.click) !== "undefined" && node.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
-                }
-                return htmlText;
-              }
-              state.webglGraph
-                .onNodeClick(function(node){
-                  try {
-                    ui.elements.detailsBody.innerHTML = createNodeText(node);
-                  } catch(e) {
-                  };
-                });
-              // - Node drag behavior
-              state.webglGraph
-                .onNodeDragEnd(function(node){
-                  if(state.nodeDragFix){
-                    node.fx = node.x;
-                    node.fy = node.y;
-                    node.fz = node.z;
-                  } else{
-                    node.fx = null;
-                    node.fy = null;
-                    node.fz = null;
-                  }
-                });
-              // - Edge click behavior
-              function createEdgeText(edge){
-                let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
-                if(typeof(edge.click) !== "undefined" && edge.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
-                }
-                return htmlText;
-              }
-              state.webglGraph
-                .onLinkClick(function(edge){
-                  try {
-                    ui.elements.detailsBody.innerHTML = createEdgeText(edge);
-                  } catch(e){
-                  };
-                });
-              // - Hover behavior
-              document.addEventListener("mousemove", function(event){
-                // Hack to get mouse position in hover event handler
-                // https://stackoverflow.com/questions/2601097/how-to-get-the-mouse-position-without-events-without-moving-the-mouse
-                state.cursorX = event.clientX;
-                state.cursorY = event.clientY;
-              });
-              function calculateRelativePosition(){
-                const cont = ui.elements.mainContainer,
-                  contAbsX = cont.offsetLeft,
-                  contAbsY = cont.offsetTop,
-                  contBoundingRect = cont.getBoundingClientRect(),
-                  contClientX = contBoundingRect.left,
-                  contClientY = contBoundingRect.top,
-                  contWidth = contBoundingRect.width;
-                let deltaX = state.cursorX - contClientX,
-                  deltaY = state.cursorY - contClientY,
-                  deltaXMax = contWidth * 0.85;
-                if(deltaX > deltaXMax){
-                  deltaX = deltaXMax;
-                }
-                const xShift = contAbsX + deltaX + 7,
-                  yShift = contAbsY + deltaY + 14;
-                return {"xShift": xShift, "yShift": yShift};
-              }
-              // - Node hover behavior
-              state.webglGraph
-                .onNodeHover(function (node){
-                  if(node !== null){
-                    if(typeof(node.hover) !== "undefined"){
-                      if(state.nodeHoverTooltip){
-                        const relPos = calculateRelativePosition();
-                        ui.elements.tooltipContainer.innerHTML = node.hover;
-                        ui.composites.tooltip.show(relPos.xShift, relPos.yShift);
-                      }
-                    }
-                  } else{
-                    ui.composites.tooltip.hide();
-                  }
-                });
-              // - Edge hover behavior
-              state.webglGraph
-                .onLinkHover(function (edge){
-                  if(edge !== null){
-                    if(typeof(edge.hover) !== "undefined"){
-                      if(state.edgeHoverTooltip){
-                        const relPos = calculateRelativePosition();
-                        ui.elements.tooltipContainer.innerHTML = edge.hover;
-                        ui.composites.tooltip.show(relPos.xShift, relPos.yShift);
-                      }
-                    }
-                  } else{
-                    ui.composites.tooltip.hide();
-                  }
-                });
-            },
-
-            updateGraphDrawingArea(){
-              state.webglGraph
-                .width(state.graphContainerWidth)
-                .height(state.graphContainerHeight)
-            },
-
+        parseGeneral(givenData, parsedData) {
+          const generalDefaults = state.useDarkMode ? {
+            background_color: "#1f1f25",
+            arrow_color: "#7ddba3",
+            node_color: "#7ddba3",
+            node_border_color: "#f0f0f5",
+            node_label_color: "#f0f0f5",
+            edge_color: "#b5b8c5",
+            edge_label_color: "#f0f0f5",
+          } : {
+            background_color: "white",
+            arrow_color: "black",
+            node_color: "black",
+            node_border_color: "black",
+            node_label_color: "black",
+            edge_color: "black",
+            edge_label_color: "black",
+          };
+          parsedData.general = {
+            // General
+            directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
+            label: state.manager.rawDataParser.getString(givenData, "label", ""),
+            background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+            arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
+            arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
             // Nodes
-            createSingleNodeObject(node){
-              let obj = null;
-              // Object creator functions
-              function createGeometicObject(id, shape, size, sizeHalf, color, opacity){
-                const material = new THREE.MeshLambertMaterial({
-                  color: color,
-                  opacity: opacity,
-                  transparent: true,
-                  depthWrite: true,
-                });
-                state.threeObjects.trackMaterial(id, material);
-                let geometry = null;
-                if (shape == "rectangle") {
-                  geometry = new THREE.BoxGeometry(size, size, size);  // width, height, depth
-                } else if (shape == "hexagon") {
-                  geometry = new THREE.IcosahedronGeometry(sizeHalf);  // radius
-                } else {
-                  geometry = new THREE.SphereGeometry(sizeHalf, 16, 12);  // radius, widthSegments, heightSegments
-                }
-                state.threeObjects.trackGeometry(id, geometry);
-                obj = new THREE.Mesh(geometry, material);
-                return obj;
-              }
-              function createImageObject(id, image, size){
-                const material = new THREE.MeshBasicMaterial({
-                  transparent: true,
-                  depthWrite: false,
-                  opacity: 0.0,
-                });
-                const geometry = new THREE.SphereGeometry(size);
-                obj = new THREE.Mesh(geometry, material);
-                state.threeObjects.trackGeometry(id, geometry);
-                state.threeObjects.trackMaterial(id, material);
-                function onTextureLoad(texture){
-                  const width = texture.image.width,
-                    height = texture.image.height,
-                    factor1 = width / size,
-                    factor2 = height / size,
-                    largerFactor = (factor1 > factor2) ? factor1 : factor2;
-                  const imageMaterial = new THREE.SpriteMaterial({map: imageTexture});
-                  state.threeObjects.trackMaterial(id+"image", imageMaterial);
-                  const imageSprite = new THREE.Sprite(imageMaterial);
-                  imageSprite.scale.set(width / largerFactor, height / largerFactor, 1);
-                  obj.add(imageSprite);
-                }
-                const imageTexture = new THREE.TextureLoader().load(image, onTextureLoad);
-                state.threeObjects.trackTexture(id, imageTexture);
-                imageTexture.minFilter = THREE.LinearFilter;
-                return obj;
-              }
-              function createTextSpriteObject(id, text, fontSize, fontColor, fontBorderColor, fontName){
-                // Parameter processing
-                fontSize = fontSize * 10;
-                const fontStyle = fontSize + "px " + fontName;
-                // Canvas preparation: appropriate size for given text and text style
-                const canvas = document.createElement("canvas"),
-                  context = canvas.getContext("2d");
-                context.font = fontStyle;
-                const exactWidth = context.measureText(text).width,
-                  approxHeight = context.measureText("M").width * 2.0;
-                canvas.width = exactWidth;
-                canvas.height = approxHeight;
-                context.font = fontStyle;
-                // Text to canvas
-                if(state.showNodeLabelBorders){
-                  context.lineWidth = 6;
-                  context.strokeStyle = fontBorderColor;
-                  context.strokeText(text, 0, fontSize);
-                }
-                context.fillStyle = fontColor;
-                context.fillText(text, 0, fontSize);
-                // Canvas to sprite
-                const texture = new THREE.Texture(canvas);
-                state.threeObjects.trackTexture(id+"text", texture);
-                texture.minFilter = THREE.LinearFilter;
-                texture.needsUpdate = true;
-                const spriteMaterial = new THREE.SpriteMaterial({map: texture, depthWrite: false}),
-                  sprite = new THREE.Sprite(spriteMaterial),
-                  sizeCorrectionFactor = 0.1;
-                state.threeObjects.trackMaterial(id+"text", spriteMaterial);
-                sprite.scale.set(exactWidth * sizeCorrectionFactor, approxHeight * sizeCorrectionFactor, 1);
-                return sprite;
-              }
-              // Parent object: Image or geometric object
-              if(state.showNodeImages && typeof(node.image) !== "undefined"){
-                obj = createImageObject(node.id, node.image, node.image_size);
-              } else{
-                obj = createGeometicObject(node.id, node.shape, node.size, node.size_half, node.color, node.opacity);
-              }
-              // Child object: Text sprite (optional)
-              if(state.showNodeLabels && node.label !== ""){
-                const sprite = createTextSpriteObject(
-                  node.id, node.label, node.label_size, node.label_color,
-                  state.shownData.general.background_color, state.nodeLabelFont);
-                let dx = 0,
-                  dy = -node.relative_label_placement,
-                  dz = 0;
-                sprite.position.set(dx, dy, dz);
-                obj.add(sprite);
-              }
-              return obj;
-            },
-
-            updateNodeVisibilities(){
-              state.webglGraph
-                .nodeVisibility(state.showNodes);
-            },
-
-            updateNodeSizes(){
-              state.webglGraph
-                .nodeThreeObject(ui.composites.graph.createSingleNodeObject);
-            },
-
-            // Node images
-            updateNodeImages(){
-              state.webglGraph
-                .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
-            },
-
-            // Node labels
-            updateNodeLabels(){
-              state.webglGraph
-                .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
-            },
-
+            node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
+            node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
+            node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
+            node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
+            node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
+            node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
+            node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
+            node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
+            node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
+            node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
+            node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
+            node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
+            node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
+            node_z: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_z", null),
+            contains_node_hover: false,
+            contains_node_click: false,
+            contains_node_image: false,
             // Edges
-            createSingleEdgeMaterial(edge){
-              const material = new THREE.MeshLambertMaterial({
-                color: edge.color,
-                opacity: edge.opacity,
-                transparent: true,
-                depthWrite: true,
-              });
-              return material;
-            },
+            edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
+            edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
+            edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
+            edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
+            edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
+            edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
+            edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
+            contains_edge_hover: false,
+            contains_edge_click: false,
+          };
+          if (!parsedData.general.directed) {
+            parsedData.general.arrow_size = 0.0;
+          }
+        },
 
-            updateEdgeVisibilities(){
+        parseNodes(givenData, parsedData) {
+          const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
+            nodeIdToObjectMap = new Map(),
+            nodeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "shape", "border_color", "border_size",
+                "label_color", "label_size", "hover", "click", "image", "x", "y"]),
+            nodeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "shape", "border_color", "border_size",
+              "label_color", "label_size", "image", "x", "y"];
+          state.manager.propertyClassifier.init();
+          try {
+            Object.entries(givenData.nodes);
+          }
+          catch (e) {
+            givenData.nodes = {};
+          }
+          for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
+            const parsedNode = {};
+            // data: id, label
+            parsedNode.id = String(givenNodeId);
+            parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
+            // defined metadata
+            parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
+            parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
+            parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
+            parsedNode.shape = state.manager.rawMetadataParser.getString(givenNode, "shape", parsedData.general.node_shape);
+            parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
+            parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
+            parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
+            parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
+            const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
+            if (image !== "") {
+              parsedNode.image = image;
+              parsedData.general.contains_node_image = true;
+            }
+            if (hover !== "") {
+              parsedNode.hover = hover;
+              parsedData.general.contains_node_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
+            if (click !== "") {
+              parsedNode.click = click;
+              parsedData.general.contains_node_click = true;
+            }
+            const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
+            const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
+            const z = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "z", parsedData.general.node_z);
+            if (x !== null) {
+              parsedNode.fx = x;
+            }
+            if (y !== null) {
+              parsedNode.fy = y;
+            }
+            if (z !== null) {
+              parsedNode.fz = z;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
+            // feature classification
+            const parsedNodeProperties = Object.keys(parsedNode);
+            for (let i = 0; i < parsedNodeProperties.length; i++) {
+              const property = parsedNodeProperties[i],
+                value = parsedNode[property];
+              state.manager.propertyClassifier.inspect(parsedNode, property);
+            }
+            // variable replacements
+            if (parsedNode.hover) {
+              parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
+            }
+            if (parsedNode.click) {
+              parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
+            }
+            // store the parsed node
+            parsedData.nodes.push(parsedNode);
+            // data structure for inserting node object references into edge data
+            nodeIdToObjectMap.set(parsedNode.id, parsedNode);
+          }
+          // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          for (let i = 0; i < numNodes; i++) {
+            const parsedNode = parsedData.nodes[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedNode[property]);
+              parsedNode[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
+                }
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.node_properties = {
+            "node_size_data_sources": numericProperties,
+            "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report empty graph
+          if (!(numNodes > 0)) {
+            console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
+          }
+          return nodeIdToObjectMap;
+        },
+
+        parseEdges(givenData, parsedData, nodeIdToObjectMap) {
+          let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
+          const knownEdgeIds = new Set(),
+            ignoredEdges = [],
+            edgeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
+            edgeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "label_color", "label_size"];
+          state.manager.propertyClassifier.init();
+          for (let i = 0; i < numEdges; i++) {
+            const givenEdge = givenData.edges[i],
+              parsedEdge = {},
+              sourceId = String(givenEdge.source),
+              targetId = String(givenEdge.target);
+            // data: source, target, id, multi_edge_counter, label
+            try {
+              const sourceObj = nodeIdToObjectMap.get(sourceId);
+              const targetObj = nodeIdToObjectMap.get(targetId);
+              if (typeof (sourceObj) === "undefined" || typeof (targetObj) === "undefined") {
+                throw "Invalid node reference.";
+              }
+              parsedEdge.source = sourceObj;
+              parsedEdge.target = targetObj;
+            } catch (e) {
+              const ignoredEdge = {
+                index: i,
+                source: sourceId,
+                target: targetId,
+              }
+              ignoredEdges.push(ignoredEdge);
+              continue;
+            }
+            const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
+            parsedEdge.id = result.id;
+            parsedEdge.multi_edge_counter = result.count;
+            parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
+            // defined metadata
+            parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
+            parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
+            parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
+            parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
+            parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
+            if (hover !== "") {
+              parsedEdge.hover = hover;
+              parsedData.general.contains_edge_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
+            if (click !== "") {
+              parsedEdge.click = click;
+              parsedData.general.contains_edge_click = true;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
+            // feature classification
+            const parsedEdgeProperties = Object.keys(parsedEdge);
+            for (let i = 0; i < parsedEdgeProperties.length; i++) {
+              const property = parsedEdgeProperties[i],
+                value = parsedEdge[property];
+              state.manager.propertyClassifier.inspect(parsedEdge, property);
+            }
+            // variable replacements
+            if (parsedEdge.hover) {
+              parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
+            }
+            if (parsedEdge.click) {
+              parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
+            }
+            // store it
+            parsedData.edges.push(parsedEdge);
+          }
+          // Ensure numeric properties are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges)
+          for (let i = 0; i < numEdges; i++) {
+            const parsedEdge = parsedData.edges[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedEdge[property]);
+              parsedEdge[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
+                }
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.edge_properties = {
+            "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
+            "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
+              item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report invalid edges
+          if (ignoredEdges.length > 0) {
+            let message = undefined;
+            if (ignoredEdges.length == 1) {
+              message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
+                "refers to a node that is not part of the node list:\n";
+            } else {
+              message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
+                "refer to a node that is not part of the node list:\n";
+            }
+            for (let i = 0; i < ignoredEdges.length; i++) {
+              const ignoredEdge = ignoredEdges[i];
+              message += '- Edge with index ' + ignoredEdge.index;
+              message += ', source "' + ignoredEdge.source;
+              message += '", target "' + ignoredEdge.target + '"\n';
+              if (i == 9) {
+                message += '...';
+                break;
+              }
+            }
+            console.log(message);
+          }
+        },
+
+        parseChosenData(chosenGraphNumber) {
+          let givenData = state.rawData[chosenGraphNumber],
+            parsedData = {
+              general: {},
+              nodes: [],
+              edges: [],
+              adjacency: null,
+              incidence: null,
+            };
+          if (!givenData || givenData === null) {
+            givenData = [];
+          }
+          // a) General
+          state.manager.parseGeneral(givenData, parsedData);
+          // b) Nodes
+          const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
+          // c) Edges
+          state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
+          // Update state
+          state.parsedData = parsedData;
+          state.currentGraphParts = {};
+          // Update UI: show or hide containers
+          ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
+          ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
+        },
+
+        // 3) Derive state.shownData from state.parsedData
+        createNodeToAdjacentNodesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(sourceNode, targetNode) {
+              let adjacentNodes = this.map.get(sourceNode);
+              if (adjacentNodes) {
+                adjacentNodes.add(targetNode);
+              } else {
+                adjacentNodes = new Set([targetNode]);
+                this.map.set(sourceNode, adjacentNodes);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        createNodeToIncidentEdgesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(node, edge) {
+              let incidentEdges = this.map.get(node);
+              if (incidentEdges) {
+                incidentEdges.add(edge);
+              } else {
+                incidentEdges = new Set([edge]);
+                this.map.set(node, incidentEdges);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        prepareShownData() {
+          const numNodes = state.parsedData.nodes.length,
+            numEdges = state.parsedData.edges.length;
+          state.shownData = {
+            "general": null,
+            "nodes": new Array(numNodes),
+            "edges": new Array(numEdges),
+          }
+          const nodeIdToObjectMap = new Map(),
+            nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          // a) General
+          state.shownData.general = {
+            "background_color": state.parsedData.general.background_color,
+            "arrow_size": state.parsedData.general.arrow_size,
+            "arrow_color": state.parsedData.general.arrow_color,
+            "directed": state.parsedData.general.directed,
+            "node_image_fetching_failed": false,
+          };
+          // b) Nodes
+          for (let i = 0; i < numNodes; i++) {
+            state.shownData.nodes[i] = {};
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.id = parsedNode.id;
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+            shownNode.color = parsedNode.color;
+            shownNode.opacity = parsedNode.opacity;
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            shownNode.shape = parsedNode.shape;
+            shownNode.border_color = parsedNode.border_color;
+            shownNode.border_size = parsedNode.border_size;
+            shownNode.label_color = parsedNode.label_color;
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+            if (typeof (parsedNode.image) !== "undefined") {
+              shownNode.image = parsedNode.image;
+            }
+            if (typeof (parsedNode.hover) !== "undefined") {
+              shownNode.hover = parsedNode.hover;
+            }
+            if (typeof (parsedNode.click) !== "undefined") {
+              shownNode.click = parsedNode.click;
+            }
+            if (typeof (parsedNode.fx) !== "undefined") {
+              shownNode.fx = parsedNode.fx;
+            }
+            if (typeof (parsedNode.fy) !== "undefined") {
+              shownNode.fy = parsedNode.fy;
+            }
+            if (typeof (parsedNode.fz) !== "undefined") {
+              shownNode.fz = parsedNode.fz;
+            }
+            nodeIdToObjectMap.set(shownNode.id, shownNode);
+            // Derived properties for performance improvement in updateNodePositions
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+            state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
+            state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
+          }
+          // c) Edges
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
+            nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
+            nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
+          for (let i = 0; i < numEdges; i++) {
+            state.shownData.edges[i] = {};
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
+            shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
+            shownEdge.id = parsedEdge.id;
+            shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
+            shownEdge.color = parsedEdge.color;
+            shownEdge.opacity = parsedEdge.opacity;
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+            shownEdge.label_color = parsedEdge.label_color;
+            shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
+            shownEdge.multi_edge_counter = parsedEdge.multi_edge_counter;
+            if (typeof (parsedEdge.hover) !== "undefined") {
+              shownEdge.hover = parsedEdge.hover;
+            }
+            if (typeof (parsedEdge.click) !== "undefined") {
+              shownEdge.click = parsedEdge.click;
+            }
+            // Derived properties for performance improvement in updateEdgePositions
+            shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+            // Data structure for highlighting adjacent nodes and incident edges to this node
+            nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
+            nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
+            nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
+            nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
+          }
+          state.shownData.adjacency = nodeToAdjacentNodesMap;
+          state.shownData.incidence = nodeToIncidentEdgesMap;
+        },
+
+        calcSingleNodeSize(parsedNode, nodeSizeNormalizer) {
+          let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
+          if (!isFinite(nodeSize)) {
+            nodeSize = state.parsedData.general.node_size;
+          }
+          return nodeSize * state.nodeSizeFactor;
+        },
+
+        calcSingleNodeLabelText(parsedNode) {
+          return String(parsedNode[state.nodeLabelTextDataSource]);
+        },
+
+        calcSingleNodeLabelSize(parsedNode) {
+          return parsedNode.label_size * state.nodeLabelSizeFactor;
+        },
+
+        calcSingleNodeLabelPlacement(node) {
+          let baseSize = node.size_half;
+          if (state.showNodeImages && typeof (node.image) !== "undefined") {
+            baseSize = (node.size_half > node.image_size_half) ? node.size_half : node.image_size_half;
+          }
+          return baseSize + node.label_size * 0.77 + 2.0;
+        },
+
+        calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer) {
+          let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
+          if (!isFinite(edgeSize)) {
+            edgeSize = state.parsedData.general.edge_size;
+          }
+          return edgeSize * state.edgeSizeFactor;
+        },
+
+        calcSingleEdgeCurvatureFactor(parsedEdge) {
+          const appearanceAdaptionFactor = 0.6;
+          return state.edgeCurvature * parsedEdge.multi_edge_counter * appearanceAdaptionFactor;
+        },
+
+        calcSingleEdgeLabelText(parsedEdge) {
+          return String(parsedEdge[state.edgeLabelTextDataSource]);
+        },
+
+        calcSingleEdgeLabelSize(parsedEdge) {
+          return parsedEdge.label_size * state.edgeLabelSizeFactor;
+        },
+
+        calcSingleNodeSizeDerivatives(shownNode) {
+          shownNode.size_half = shownNode.size / 2.0;
+          const appearanceAdaptionFactor = 1.2;
+          shownNode.image_size = shownNode.size * state.nodeImageSizeFactor * appearanceAdaptionFactor;
+          shownNode.image_size_half = shownNode.image_size / 2.0;
+          shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
+        },
+
+        calcSingleNodeLabelSizeDerivatives(shownNode) {
+          shownNode.relative_label_placement = state.manager.calcSingleNodeLabelPlacement(shownNode);
+        },
+
+        calcSingleNodeBorderSizeDerivatives(shownNode) {
+          shownNode.border_size_half = shownNode.border_size / 2.0;
+        },
+
+        createNodeSizeNormalizer() {
+          let normalizer;
+          if (state.useNodeSizeNormalization) {
+            const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
+              dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
+              targetMin = state.nodeSizeNormalizationMin,
+              targetMax = state.nodeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor) || factor === null) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        createEdgeSizeNormalizer() {
+          let normalizer;
+          if (state.useEdgeSizeNormalization) {
+            const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
+              dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
+              targetMin = state.edgeSizeNormalizationMin,
+              targetMax = state.edgeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor)) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        updateNodeSizes() {
+          // Data
+          const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeSizes();
+        },
+
+        updateNodeImageSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeImages();
+        },
+
+        updateNodeLabelTexts() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeLabels();
+        },
+
+        updateNodeLabelSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+            state.manager.calcSingleNodeLabelSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeLabels();
+        },
+
+        updateEdgeSizes() {
+          // Data
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+          }
+          // UI
+          ui.composites.graph.updateEdgeSizes();
+        },
+
+        updateEdgeCurvatures() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.multi_edge_curvature_factor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.updateEdgeCurvatures();
+        },
+      }
+    }
+
+    const ui = {
+      symbols: {
+        // Choice of symbols is influenced by their appearance in different browsers
+        // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
+        // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
+        detailsShown: "▾",
+        detailsHidden: "▴",
+        menuShown: "▸",
+        menuHidden: "◂",
+        menuItemActive: "▸",
+        menuItemInactive: "▾",
+      },
+
+      elements: {
+        // Containers
+        mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
+        tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
+        leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
+        rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
+        graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
+        detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
+        detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
+        detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
+        // Data sources
+        dataHead: document.getElementById("§RANDOM_ID§-data-head"),
+        dataBody: document.getElementById("§RANDOM_ID§-data-body"),
+        graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
+        graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
+        nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
+        nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
+        nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
+        nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
+        nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
+        nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
+        nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
+        edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
+        edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
+        edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
+        edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
+        edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
+        edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
+        edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
+        // General
+        generalHead: document.getElementById("§RANDOM_ID§-general-head"),
+        generalBody: document.getElementById("§RANDOM_ID§-general-body"),
+        resetButton: document.getElementById("§RANDOM_ID§-reset"),
+        fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
+        svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
+        pngExportButton: document.getElementById("§RANDOM_ID§-png"),
+        jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+        // Nodes
+        nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
+        nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
+        nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
+        nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
+        nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
+        nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
+        nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
+        nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
+        // Node images
+        nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
+        nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
+        nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
+        nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
+        nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
+        nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
+        // Node labels
+        nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
+        nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
+        nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
+        nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
+        nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
+        nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
+        nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
+        // Edges
+        edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
+        edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
+        edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
+        edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
+        edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
+        edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
+        edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
+        edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
+        // Layout algorithm
+        layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
+        layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
+        simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
+        manyBodyForceCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-checkbox"),
+        manyBodyForceContainer: document.getElementById("§RANDOM_ID§-many-body-force-div"),
+        manyBodyForceStrengthText: document.getElementById("§RANDOM_ID§-many-body-force-strength-text"),
+        manyBodyForceStrengthSlider: document.getElementById("§RANDOM_ID§-many-body-force-strength-slider"),
+        manyBodyForceThetaText: document.getElementById("§RANDOM_ID§-many-body-force-theta-text"),
+        manyBodyForceThetaSlider: document.getElementById("§RANDOM_ID§-many-body-force-theta-slider"),
+        manyBodyForceMinDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-checkbox"),
+        manyBodyForceMinDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-div"),
+        manyBodyForceMinDistText: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-text"),
+        manyBodyForceMinDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-min-distance-slider"),
+        manyBodyForceMaxDistCheckbox: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-checkbox"),
+        manyBodyForceMaxDistContainer: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-div"),
+        manyBodyForceMaxDistText: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-text"),
+        manyBodyForceMaxDistSlider: document.getElementById("§RANDOM_ID§-many-body-force-max-distance-slider"),
+        linksForceCheckbox: document.getElementById("§RANDOM_ID§-links-force-checkbox"),
+        linksForceContainer: document.getElementById("§RANDOM_ID§-links-force-div"),
+        linksForceDistanceText: document.getElementById("§RANDOM_ID§-links-force-distance-text"),
+        linksForceDistanceSlider: document.getElementById("§RANDOM_ID§-links-force-distance-slider"),
+        linksForceStrengthText: document.getElementById("§RANDOM_ID§-links-force-strength-text"),
+        linksForceStrengthSlider: document.getElementById("§RANDOM_ID§-links-force-strength-slider"),
+        xPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-x-positioning-force-checkbox"),
+        xPositioningForceContainer: document.getElementById("§RANDOM_ID§-x-positioning-force-div"),
+        xPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-text"),
+        xPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-x-positioning-force-strength-slider"),
+        yPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-y-positioning-force-checkbox"),
+        yPositioningForceContainer: document.getElementById("§RANDOM_ID§-y-positioning-force-div"),
+        yPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-text"),
+        yPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-y-positioning-force-strength-slider"),
+        zPositioningForceCheckbox: document.getElementById("§RANDOM_ID§-z-positioning-force-checkbox"),
+        zPositioningForceContainer: document.getElementById("§RANDOM_ID§-z-positioning-force-div"),
+        zPositioningForceStrengthText: document.getElementById("§RANDOM_ID§-z-positioning-force-strength-text"),
+        zPositioningForceStrengthSlider: document.getElementById("§RANDOM_ID§-z-positioning-force-strength-slider"),
+        centeringForceCheckbox: document.getElementById("§RANDOM_ID§-centering-force-checkbox"),
+      },
+
+      composites: {
+        responsiveContainer: {
+          init() {
+            // Delete all contained items (relevant only for reset, not first creation)
+            ui.deleteChildElements(ui.elements.graphContainer);
+            ui.deleteChildElements(ui.elements.detailsBody);
+            // Menu
+            if (state.showMenu) {
+              ui.composites.menu.show();
+            } else {
+              ui.composites.menu.hide();
+            }
+            // Details
+            if (state.showDetails) {
+              ui.composites.details.show(true);
+            } else {
+              ui.composites.details.hide(true);
+            }
+            // Divs
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.responsiveContainer.getInnerWidths();
+          },
+
+          getInnerWidths() {
+            state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
+            state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
+          },
+
+          getInnerHeights() {
+            state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
+            if (state.showDetails) {
+              state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+            }
+          },
+
+          setInnerHeights() {
+            ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
+            ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
+          },
+
+          setOuterHeights() {
+            ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
+          },
+
+          getSizes() {
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+          },
+
+          setSizes() {
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+          },
+
+          adaptToResize() {
+            ui.composites.responsiveContainer.getSizes();
+            ui.composites.responsiveContainer.setSizes();
+          },
+
+          adaptToFullscreen() {
+            ui.composites.responsiveContainer.getSizes();
+            if (document.fullscreenElement) {
+              // On entering fullscreen, remember the current container heights
+              state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
+              state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
+              // and then adapt them to maximum height possible in full screen mode
+              function calculateFullscreenMaxGraphHeight() {
+                let outerHeight = null;
+                try {
+                  const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
+                    graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                    paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
+                    borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
+                    borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
+                    paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
+                  outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
+                  if (!isFinite(outerHeight) || outerHeight === null) {
+                    throw "Invalid number";
+                  }
+                } catch (e) {
+                  // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
+                  outerHeight = 1 + 3 + 3 + 1;
+                }
+                let graphHeight = screen.height - outerHeight;
+                if (state.showDetails) {
+                  graphHeight -= ui.composites.details.calculateHeightDifference();
+                }
+                return graphHeight;
+              }
+              state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
+            } else {
+              // On leaving fullscreen, set container heights back to remembered values
+              state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
+              state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
+            }
+            ui.composites.responsiveContainer.setSizes();
+          },
+        },
+
+        menu: {
+          show() {
+            ui.elements.leftContainer.style.width = "80%";
+            ui.elements.rightContainer.style.width = "20%";
+            ui.elements.rightContainer.style.display = "block";
+          },
+
+          hide() {
+            ui.elements.leftContainer.style.width = "100%";
+            ui.elements.rightContainer.style.width = "0%";
+            ui.elements.rightContainer.style.display = "none";
+          },
+
+          toggle() {
+            // Update menu button
+            const div = ui.elements.menuToggleDiv;
+            state.showMenu = !state.showMenu;
+            if (state.showMenu) {
+              div.innerText = ui.symbols.menuShown;
+              ui.composites.menu.show();
+            } else {
+              div.innerHTML = ui.symbols.menuHidden;
+              ui.composites.menu.hide();
+            }
+
+            // Update rest of UI
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.graph.updateGraphDrawingArea();
+          },
+
+          setItem(keyElement, valElement, toActive) {
+            const currentText = keyElement.innerHTML;
+            let sliceStart = 0;
+            if (currentText.startsWith(ui.symbols.menuItemActive)) {
+              sliceStart = ui.symbols.menuItemActive.length;
+            } else if (currentText.startsWith(ui.symbols.menuItemInactive)) {
+              sliceStart = ui.symbols.menuItemInactive.length;
+            }
+            if (toActive) {
+              keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
+              keyElement.classList.add("§RANDOM_ID§-active");
+              valElement.style.display = "block";
+            } else {
+              keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
+              keyElement.classList.remove("§RANDOM_ID§-active");
+              valElement.style.display = "none";
+            }
+          },
+
+          toggleItem(keyElement, valElement) {
+            const toActive = !(valElement.style.display !== "none");
+            ui.composites.menu.setItem(keyElement, valElement, toActive);
+          },
+        },
+
+        details: {
+          calculateHeightDifference() {
+            let outerHeight = null;
+            try {
+              const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
+                border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
+                margin = parseFloat(detailsContainerComputedStyle.marginTop),
+                border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
+              outerHeight = border1 + margin + border2;
+              if (!isFinite(outerHeight) || outerHeight === null) {
+                throw "Invalid number";
+              }
+            } catch (e) {
+              // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
+              outerHeight = 7.0;
+            }
+            return state.detailsContainerHeight + outerHeight
+          },
+
+          show(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "block";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight -= heightDiff;
+              if (state.graphContainerHeight < 70) {
+                state.graphContainerHeight = 70;
+              }
+              // Update rest of UI
+              ui.composites.responsiveContainer.setSizes();
+              ui.composites.graph.updateGraphDrawingArea();
+            }
+          },
+
+          hide(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "none";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight += heightDiff;
+              // Update rest of UI
+              ui.composites.responsiveContainer.setSizes();
+              ui.composites.graph.updateGraphDrawingArea();
+            }
+          },
+
+          toggle() {
+            // Update details button
+            const toggleDiv = ui.elements.detailsToggleDiv;
+            state.showDetails = !state.showDetails;
+            if (state.showDetails) {
+              toggleDiv.innerText = ui.symbols.detailsShown;
+              ui.composites.details.show();
+            } else {
+              toggleDiv.innerHTML = ui.symbols.detailsHidden;
+              ui.composites.details.hide();
+            }
+          },
+        },
+
+        download: {
+          png(filename) {
+            ui.composites.download._rasterImage(filename, "png");
+          },
+
+          jpg(filename) {
+            ui.composites.download._rasterImage(filename, "jpeg");
+          },
+
+          _rasterImage(filename, format, resolutionFactor = 4.0) {
+            const renderer = state.webglGraph.renderer(),
+              scene = state.webglGraph.scene(),
+              camera = state.webglGraph.camera(),
+              mimeType = "image/" + format,
+              size = new THREE.Vector2(0, 0);
+
+            renderer.getSize(size);
+            const width = size.x,
+              height = size.y;
+
+            function upsize() {
+              renderer.setSize(width * resolutionFactor, height * resolutionFactor);
+              renderer.render(scene, camera);
+            }
+            function downsize() {
+              renderer.setSize(width, height);
+              renderer.render(scene, camera);
+            }
+            // Increase resolution
+            upsize();
+            // Create image and decrease solution to original value
+            function finishedBlobCallback(blob) {
+              ui.composites.download._blobToFileDownload(blob, filename);
+              downsize();
+            }
+            renderer.domElement.toBlob(finishedBlobCallback, mimeType, 1.0);
+          },
+
+          _blobToFileDownload(blob, filename) {
+            const url = URL.createObjectURL(blob),
+              a = document.createElement("a");
+            function handleClick() {
+              setTimeout(function () {
+                // Long waiting time before removal for slow devices like mobile phones
+                URL.revokeObjectURL(url);
+                this.removeEventListener("click", handleClick);
+              }, 20000);
+            };
+            document.body.appendChild(a);
+            a.href = url;
+            a.download = filename;
+            a.addEventListener("click", handleClick, false);
+            a.click();
+            document.body.removeChild(a);
+          },
+        },
+
+        selection(element, optionList, valueList = undefined) {
+          while (element.hasChildNodes()) {
+            element.removeChild(element.firstChild);
+          }
+          for (let i = 0; i < optionList.length; i++) {
+            let text = optionList[i];
+            let value = text;
+            if (valueList) {
+              value = valueList[i];
+            }
+            let opt = document.createElement("option");
+            opt.appendChild(document.createTextNode(text));
+            opt.value = value;
+            element.appendChild(opt);
+          }
+        },
+
+        tooltip: {
+          show(xShift = null, yShift = null) {
+            if (isFinite(xShift) && xShift !== null) {
+              ui.elements.tooltipContainer.style.left = parseInt(xShift) + "px";
+            }
+            if (isFinite(yShift) && yShift !== null) {
+              ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
+            }
+            ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
+            ui.elements.tooltipContainer.style.visibility = "visible";
+            ui.elements.tooltipContainer.style.opacity = 1.0;
+          },
+
+          hide() {
+            ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
+            ui.elements.tooltipContainer.style.visibility = "hidden";
+            ui.elements.tooltipContainer.style.opacity = 0.0;
+          },
+        },
+
+        progressBar: {
+          create() {
+            // Main container
+            this.mainContainer = document.createElement("div");
+            this.mainContainer.id = "§RANDOM_ID§-progress-container";
+            this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
+            ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
+            // Text container
+            const numNodes = state.parsedData.nodes.length;
+            this.textContainer = document.createElement("div");
+            this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
+            this.textContainer.style.textAlign = "center";
+            // Bar container
+            this.outerBarContainer = document.createElement("div");
+            this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
+            this.innerBarContainer = document.createElement("div");
+            this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
+            this.innerBarContainer.style.width = "0%";
+            // Add them to DOM
+            this.outerBarContainer.appendChild(this.innerBarContainer);
+            this.mainContainer.appendChild(this.textContainer);
+            this.mainContainer.appendChild(this.outerBarContainer);
+            ui.elements.graphContainer.appendChild(this.mainContainer);
+          },
+
+          update(percentage) {
+            this.innerBarContainer.style.width = percentage + "%";
+          },
+
+          remove() {
+            ui.elements.graphContainer.removeChild(this.mainContainer);
+          }
+        },
+
+        graph: {
+          createGraph() {
+            // Remove existing elements
+            ui.deleteChildElements(ui.elements.graphContainer);
+
+            // Create new elements
+            // - Graph
+            state.webglGraph = ForceGraph3D()(ui.elements.graphContainer)
+              .showNavInfo(false)
+              .backgroundColor(state.shownData.general.background_color)
+              .width(state.graphContainerWidth)
+              .height(state.graphContainerHeight);
+            // Attempt to prevent some memory leaks
+            const renderer = state.webglGraph.renderer();
+            state.threeObjects.trackRenderer("currentGraph", renderer);
+            const renderTarget = renderer.getRenderTarget();
+            state.threeObjects.trackRenderTarget("currentRenderTarget", renderTarget);
+            // - Menu toggle button
+            if (state.showMenuToggleButton) {
+              const menuDiv = document.createElement("div");
+              if (state.showMenu) {
+                menuDiv.innerText = ui.symbols.menuShown;
+              } else {
+                menuDiv.innerText = ui.symbols.menuHidden;
+              }
+              menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
+              menuDiv.onclick = ui.composites.menu.toggle;
+              ui.elements.graphContainer.appendChild(menuDiv);
+              ui.elements.menuToggleDiv = menuDiv;
+            }
+            // - Details toggle button
+            if (state.showDetailsToggleButton) {
+              const detailsDiv = document.createElement("div");
+              if (state.showDetails) {
+                detailsDiv.innerText = ui.symbols.detailsShown;
+              } else {
+                detailsDiv.innerText = ui.symbols.detailsHidden;
+              }
+              detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
+              detailsDiv.onclick = ui.composites.details.toggle;
+              ui.elements.graphContainer.appendChild(detailsDiv);
+              ui.elements.detailsToggleDiv = detailsDiv;
+            }
+            // Wait a bit to finish UI rendering, then start potentially slow layout computation
+            setTimeout(function () {
+              // - Layout algorithm
+              ui.composites.graph.setLayout();
+              // - Data
+              const data = {
+                nodes: state.shownData.nodes,
+                links: state.shownData.edges,
+              };
+              state.webglGraph
+                .graphData(data);
+              // - Nodes
+              state.webglGraph
+                .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
+                .nodeVisibility(state.showNodes);
+              // - Edges
+              // Uses linkMaterial because linkOpacity can only be a single number, not function
               state.webglGraph
                 .linkVisibility(state.showEdges)
-            },
-
-            updateEdgeSizes(){
-              state.webglGraph
-                .linkWidth(edge => edge.size);
-            },
-
-            _calcEdgeCurvature(edge){
-              if(edge.source === edge.target){
-                return ui.composites.graph._calcSelfLoopCurvature(edge);
-              } else{
-                return ui.composites.graph._calcNormalEdgeCurvature(edge);
-              }
-            },
-
-            _calcNormalEdgeCurvature(edge){
-              return edge.multi_edge_curvature_factor;
-            },
-
-            _calcSelfLoopCurvature(edge){
-              return edge.source.size / 50.0 + edge.multi_edge_counter / 4.0 + Math.abs(edge.multi_edge_curvature_factor);
-            },
-
-            updateEdgeCurvatures(){
-              state.webglGraph
+                .linkWidth(edge => edge.size)
                 .linkCurvature(ui.composites.graph._calcEdgeCurvature)
-                .linkVisibility(state.showEdges);  // causes a redraw, relevant if graph has stabilized
-            },
+                .linkMaterial(ui.composites.graph.createSingleEdgeMaterial);
+              if (state.shownData.general.directed) {
+                state.webglGraph
+                  .linkDirectionalArrowColor(edge => state.shownData.general.arrow_color)
+                  .linkDirectionalArrowLength(edge => state.shownData.general.arrow_size)
+                  .linkDirectionalArrowRelPos(ui.composites.graph._calcArrowPosition);
+              }
+              // - Graph behavior
+              ui.composites.graph.setBehavior();
+            }, 250);
+          },
 
-            // Layout algorithm
-            simulationManager:{
-              move(){
-                if(state.layoutAlgorithmActive){
-                  state.webglGraph.d3ReheatSimulation();
-                }
-              },
-              restart(){
-                state.webglGraph.cooldownTicks(Infinity);
-                this.setAllForces();
-                this.move();
-              },
-              stop(){
-                state.webglGraph.cooldownTicks(0);
-                this.removeAllForces();
-              },
-              releaseFixedNodes(){
-                const nodes = state.shownData.nodes;
-                for(let i=0; i<nodes.length; i++){
-                  const node = nodes[i];
+          _calcArrowPosition(edge) {
+            if (edge.source === edge.target) {
+              // Case 1: Self loop
+              return 0.5;
+            } else {
+              // Case 2: Normal edge
+              const dx = edge.target.x - edge.source.x,
+                dy = edge.target.y - edge.source.y,
+                dz = edge.target.z - edge.source.z,
+                len = Math.sqrt(dx ** 2 + dy ** 2 + dz ** 2);
+              return 0.99 - edge.target.size_half / len;
+            }
+          },
+
+          setLayout() {
+            // Store all forces provided by the library (for reuse when turning them off)
+            state.predefinedForces = {
+              "charge": state.webglGraph.d3Force("charge"),
+              "link": state.webglGraph.d3Force("link"),
+              "center": state.webglGraph.d3Force("center"),
+            }
+            ui.composites.graph.simulationManager.setAllForces();
+            state.webglGraph
+              .d3VelocityDecay(0.3);  // default 0.4, lower value means less friction
+
+            // - Progress bar: only if large graph, stops simulation to get initial static image
+            const numNodes = state.parsedData.nodes.length;
+            if (numNodes > state.largeGraphThreshold) {
+              // Layout start
+              ui.composites.progressBar.create();
+              let numIterations = 40;
+              if (numNodes >= 25000) {
+                numIterations = 9;
+              } else if (numNodes >= 10000) {
+                numIterations = 13;
+              } else if (numNodes >= 5000) {
+                numIterations = 18;
+              } else if (numNodes >= 2000) {
+                numIterations = 25;
+              } else if (numNodes >= 1000) {
+                numIterations = 35;
+              }
+              // Layout update
+              state.webglGraph
+                .warmupTicks(numIterations);
+              // Layout finished
+              state.webglGraph
+                .onEngineTick(function () {
+                  // Freeze graph after warmup to get a static rendering
+                  state.webglGraph.cooldownTicks(0);
+                  // Remove progress message
+                  ui.composites.progressBar.remove();
+                })
+                .onEngineStop(function () {
+                  // Remove tick functions
+                  state.webglGraph.onEngineTick(function () { });
+                  state.webglGraph.onEngineStop(function () { });
+                  // Unfreeze graph for future user interaction
+                  state.webglGraph.cooldownTicks(Infinity);
+                })
+            }
+          },
+
+          setBehavior() {
+            // - Node click behavior
+            function createNodeText(node) {
+              let htmlText = "<div>Node: " + String(node.id) + "</div>";
+              if (typeof (node.click) !== "undefined" && node.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
+              }
+              return htmlText;
+            }
+            state.webglGraph
+              .onNodeClick(function (node) {
+                try {
+                  ui.elements.detailsBody.innerHTML = createNodeText(node);
+                } catch (e) {
+                };
+              });
+            // - Node drag behavior
+            state.webglGraph
+              .onNodeDragEnd(function (node) {
+                if (state.nodeDragFix) {
+                  node.fx = node.x;
+                  node.fy = node.y;
+                  node.fz = node.z;
+                } else {
                   node.fx = null;
                   node.fy = null;
                   node.fz = null;
                 }
-              },
-              setAllForces(){
-                this.setCenteringForce();
-                this.setLinksForce();
-                this.setManyBodyForce();
-                this.setXPositioningForce();
-                this.setYPositioningForce();
-                this.setZPositioningForce();
-              },
-              removeAllForces(){
-                state.webglGraph.d3Force("center", null);
-                state.webglGraph.d3Force("link", null);
-                state.webglGraph.d3Force("charge", null);
-                state.webglGraph.d3Force("x-positioning", null);
-                state.webglGraph.d3Force("y-positioning", null);
-                state.webglGraph.d3Force("z-positioning", null);
-              },
-              setCenteringForce(){
-                let centeringForce = null;
-                if(state.useCenteringForce && state.layoutAlgorithmActive){
-                  centeringForce = state.predefinedForces.center
-                    .x(0.0)
-                    .y(0.0);
-                }
-                state.webglGraph.d3Force("center", centeringForce);
-              },
-              setLinksForce(){
-                let linksForce = null;
-                if(state.useLinksForce && state.layoutAlgorithmActive){
-                  const nodes = state.shownData.nodes,
-                    edges = state.shownData.edges;
-                  if(!state.shownData.edgeCounts){
-                    const count = {};
-                    for(let i=0; i<edges.length; i++){
-                      const edge = edges[i];
-                      count[edge.source.id] = (count[edge.source.id] || 0) + 1;
-                      count[edge.target.id] = (count[edge.target.id] || 0) + 1;
-                    }
-                    state.shownData.edgeCounts = count;
-                  }
-                  const appearanceAdaptionFactor = 2.0;
-                  linksForce = state.predefinedForces.link
-                    .distance(state.linksForceDistance * appearanceAdaptionFactor)
-                    .strength(function(d){
-                      // Adapted from https://github.com/d3/d3-force/blob/master/src/link.js
-                      const fixedConnectivity = Math.min(
-                        state.shownData.edgeCounts[d.source.id],
-                        state.shownData.edgeCounts[d.target.id]
-                      );
-                      const adjustableStrength = 2.0 * state.linksForceStrength;
-                      return adjustableStrength / fixedConnectivity;
-                    });
-                }
-                state.webglGraph.d3Force("link", linksForce);
-              },
-              setManyBodyForce(){
-                let manyBodyForce = null;
-                if(state.useManyBodyForce && state.layoutAlgorithmActive){
-                  manyBodyForce = state.predefinedForces.charge
-                    .strength(state.manyBodyForceStrength)
-                    .theta(state.manyBodyForceTheta);
-                  if(state.useManyBodyForceMinDistance){
-                    manyBodyForce.distanceMin(state.manyBodyForceMinDistance);
-                  } else{
-                    manyBodyForce.distanceMin(0.0);
-                  }
-                  if(state.useManyBodyForceMaxDistance){
-                    manyBodyForce.distanceMax(state.manyBodyForceMaxDistance);
-                  } else{
-                    manyBodyForce.distanceMax(Infinity);
-                  }
-                }
-                state.webglGraph.d3Force("charge", manyBodyForce);
-              },
-              setXPositioningForce(){
-                let xPositioningForce = null;
-                if(state.useXPositioningForce && state.layoutAlgorithmActive){
-                  function userDefinedForce(alpha) {
-                    const nodes = state.shownData.nodes;
-                    for(let i=0; i<nodes.length; i++) {
-                      const node = nodes[i];
-                      node.vx += (0.0 - node.x) * alpha * state.xPositioningForceStrength;
+              });
+            // - Edge click behavior
+            function createEdgeText(edge) {
+              let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
+              if (typeof (edge.click) !== "undefined" && edge.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
+              }
+              return htmlText;
+            }
+            state.webglGraph
+              .onLinkClick(function (edge) {
+                try {
+                  ui.elements.detailsBody.innerHTML = createEdgeText(edge);
+                } catch (e) {
+                };
+              });
+            // - Hover behavior
+            document.addEventListener("mousemove", function (event) {
+              // Hack to get mouse position in hover event handler
+              // https://stackoverflow.com/questions/2601097/how-to-get-the-mouse-position-without-events-without-moving-the-mouse
+              state.cursorX = event.clientX;
+              state.cursorY = event.clientY;
+            });
+            function calculateRelativePosition() {
+              const cont = ui.elements.mainContainer,
+                contAbsX = cont.offsetLeft,
+                contAbsY = cont.offsetTop,
+                contBoundingRect = cont.getBoundingClientRect(),
+                contClientX = contBoundingRect.left,
+                contClientY = contBoundingRect.top,
+                contWidth = contBoundingRect.width;
+              let deltaX = state.cursorX - contClientX,
+                deltaY = state.cursorY - contClientY,
+                deltaXMax = contWidth * 0.85;
+              if (deltaX > deltaXMax) {
+                deltaX = deltaXMax;
+              }
+              const xShift = contAbsX + deltaX + 7,
+                yShift = contAbsY + deltaY + 14;
+              return { "xShift": xShift, "yShift": yShift };
+            }
+            // - Node hover behavior
+            state.webglGraph
+              .onNodeHover(function (node) {
+                if (node !== null) {
+                  if (typeof (node.hover) !== "undefined") {
+                    if (state.nodeHoverTooltip) {
+                      const relPos = calculateRelativePosition();
+                      ui.elements.tooltipContainer.innerHTML = node.hover;
+                      ui.composites.tooltip.show(relPos.xShift, relPos.yShift);
                     }
                   }
-                  xPositioningForce = userDefinedForce;
+                } else {
+                  ui.composites.tooltip.hide();
                 }
-                state.webglGraph.d3Force("x-positioning", xPositioningForce);
-              },
-              setYPositioningForce(){
-                let yPositioningForce = null;
-                if(state.useYPositioningForce && state.layoutAlgorithmActive){
-                  function userDefinedForce(alpha) {
-                    const nodes = state.shownData.nodes;
-                    for(let i=0; i<nodes.length; i++) {
-                      const node = nodes[i];
-                      node.vy += (0.0 - node.y) * alpha * state.yPositioningForceStrength;
+              });
+            // - Edge hover behavior
+            state.webglGraph
+              .onLinkHover(function (edge) {
+                if (edge !== null) {
+                  if (typeof (edge.hover) !== "undefined") {
+                    if (state.edgeHoverTooltip) {
+                      const relPos = calculateRelativePosition();
+                      ui.elements.tooltipContainer.innerHTML = edge.hover;
+                      ui.composites.tooltip.show(relPos.xShift, relPos.yShift);
                     }
                   }
-                  yPositioningForce = userDefinedForce;
+                } else {
+                  ui.composites.tooltip.hide();
                 }
-                state.webglGraph.d3Force("y-positioning", yPositioningForce);
-              },
-              setZPositioningForce(){
-                let zPositioningForce = null;
-                if(state.useZPositioningForce && state.layoutAlgorithmActive){
-                  function userDefinedForce(alpha) {
-                    const nodes = state.shownData.nodes;
-                    for(let i=0; i<nodes.length; i++) {
-                      const node = nodes[i];
-                      node.vz += (0.0 - node.z) * alpha * state.zPositioningForceStrength;
-                    }
+              });
+          },
+
+          updateGraphDrawingArea() {
+            state.webglGraph
+              .width(state.graphContainerWidth)
+              .height(state.graphContainerHeight)
+          },
+
+          // Nodes
+          createSingleNodeObject(node) {
+            let obj = null;
+            // Object creator functions
+            function createGeometicObject(id, shape, size, sizeHalf, color, opacity) {
+              const material = new THREE.MeshLambertMaterial({
+                color: color,
+                opacity: opacity,
+                transparent: true,
+                depthWrite: true,
+              });
+              state.threeObjects.trackMaterial(id, material);
+              let geometry = null;
+              if (shape == "rectangle") {
+                geometry = new THREE.BoxGeometry(size, size, size);  // width, height, depth
+              } else if (shape == "hexagon") {
+                geometry = new THREE.IcosahedronGeometry(sizeHalf);  // radius
+              } else {
+                geometry = new THREE.SphereGeometry(sizeHalf, 16, 12);  // radius, widthSegments, heightSegments
+              }
+              state.threeObjects.trackGeometry(id, geometry);
+              obj = new THREE.Mesh(geometry, material);
+              return obj;
+            }
+            function createImageObject(id, image, size) {
+              const material = new THREE.MeshBasicMaterial({
+                transparent: true,
+                depthWrite: false,
+                opacity: 0.0,
+              });
+              const geometry = new THREE.SphereGeometry(size);
+              obj = new THREE.Mesh(geometry, material);
+              state.threeObjects.trackGeometry(id, geometry);
+              state.threeObjects.trackMaterial(id, material);
+              function onTextureLoad(texture) {
+                const width = texture.image.width,
+                  height = texture.image.height,
+                  factor1 = width / size,
+                  factor2 = height / size,
+                  largerFactor = (factor1 > factor2) ? factor1 : factor2;
+                const imageMaterial = new THREE.SpriteMaterial({ map: imageTexture });
+                state.threeObjects.trackMaterial(id + "image", imageMaterial);
+                const imageSprite = new THREE.Sprite(imageMaterial);
+                imageSprite.scale.set(width / largerFactor, height / largerFactor, 1);
+                obj.add(imageSprite);
+              }
+              const imageTexture = new THREE.TextureLoader().load(image, onTextureLoad);
+              state.threeObjects.trackTexture(id, imageTexture);
+              imageTexture.minFilter = THREE.LinearFilter;
+              return obj;
+            }
+            function createTextSpriteObject(id, text, fontSize, fontColor, fontBorderColor, fontName) {
+              // Parameter processing
+              fontSize = fontSize * 10;
+              const fontStyle = fontSize + "px " + fontName;
+              // Canvas preparation: appropriate size for given text and text style
+              const canvas = document.createElement("canvas"),
+                context = canvas.getContext("2d");
+              context.font = fontStyle;
+              const exactWidth = context.measureText(text).width,
+                approxHeight = context.measureText("M").width * 2.0;
+              canvas.width = exactWidth;
+              canvas.height = approxHeight;
+              context.font = fontStyle;
+              // Text to canvas
+              if (state.showNodeLabelBorders) {
+                context.lineWidth = 6;
+                context.strokeStyle = fontBorderColor;
+                context.strokeText(text, 0, fontSize);
+              }
+              context.fillStyle = fontColor;
+              context.fillText(text, 0, fontSize);
+              // Canvas to sprite
+              const texture = new THREE.Texture(canvas);
+              state.threeObjects.trackTexture(id + "text", texture);
+              texture.minFilter = THREE.LinearFilter;
+              texture.needsUpdate = true;
+              const spriteMaterial = new THREE.SpriteMaterial({ map: texture, depthWrite: false }),
+                sprite = new THREE.Sprite(spriteMaterial),
+                sizeCorrectionFactor = 0.1;
+              state.threeObjects.trackMaterial(id + "text", spriteMaterial);
+              sprite.scale.set(exactWidth * sizeCorrectionFactor, approxHeight * sizeCorrectionFactor, 1);
+              return sprite;
+            }
+            // Parent object: Image or geometric object
+            if (state.showNodeImages && typeof (node.image) !== "undefined") {
+              obj = createImageObject(node.id, node.image, node.image_size);
+            } else {
+              obj = createGeometicObject(node.id, node.shape, node.size, node.size_half, node.color, node.opacity);
+            }
+            // Child object: Text sprite (optional)
+            if (state.showNodeLabels && node.label !== "") {
+              const sprite = createTextSpriteObject(
+                node.id, node.label, node.label_size, node.label_color,
+                state.shownData.general.background_color, state.nodeLabelFont);
+              let dx = 0,
+                dy = -node.relative_label_placement,
+                dz = 0;
+              sprite.position.set(dx, dy, dz);
+              obj.add(sprite);
+            }
+            return obj;
+          },
+
+          updateNodeVisibilities() {
+            state.webglGraph
+              .nodeVisibility(state.showNodes);
+          },
+
+          updateNodeSizes() {
+            state.webglGraph
+              .nodeThreeObject(ui.composites.graph.createSingleNodeObject);
+          },
+
+          // Node images
+          updateNodeImages() {
+            state.webglGraph
+              .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
+          },
+
+          // Node labels
+          updateNodeLabels() {
+            state.webglGraph
+              .nodeThreeObject(ui.composites.graph.createSingleNodeObject)
+          },
+
+          // Edges
+          createSingleEdgeMaterial(edge) {
+            const material = new THREE.MeshLambertMaterial({
+              color: edge.color,
+              opacity: edge.opacity,
+              transparent: true,
+              depthWrite: true,
+            });
+            return material;
+          },
+
+          updateEdgeVisibilities() {
+            state.webglGraph
+              .linkVisibility(state.showEdges)
+          },
+
+          updateEdgeSizes() {
+            state.webglGraph
+              .linkWidth(edge => edge.size);
+          },
+
+          _calcEdgeCurvature(edge) {
+            if (edge.source === edge.target) {
+              return ui.composites.graph._calcSelfLoopCurvature(edge);
+            } else {
+              return ui.composites.graph._calcNormalEdgeCurvature(edge);
+            }
+          },
+
+          _calcNormalEdgeCurvature(edge) {
+            return edge.multi_edge_curvature_factor;
+          },
+
+          _calcSelfLoopCurvature(edge) {
+            return edge.source.size / 50.0 + edge.multi_edge_counter / 4.0 + Math.abs(edge.multi_edge_curvature_factor);
+          },
+
+          updateEdgeCurvatures() {
+            state.webglGraph
+              .linkCurvature(ui.composites.graph._calcEdgeCurvature)
+              .linkVisibility(state.showEdges);  // causes a redraw, relevant if graph has stabilized
+          },
+
+          // Layout algorithm
+          simulationManager: {
+            move() {
+              if (state.layoutAlgorithmActive) {
+                state.webglGraph.d3ReheatSimulation();
+              }
+            },
+            restart() {
+              state.webglGraph.cooldownTicks(Infinity);
+              this.setAllForces();
+              this.move();
+            },
+            stop() {
+              state.webglGraph.cooldownTicks(0);
+              this.removeAllForces();
+            },
+            releaseFixedNodes() {
+              const nodes = state.shownData.nodes;
+              for (let i = 0; i < nodes.length; i++) {
+                const node = nodes[i];
+                node.fx = null;
+                node.fy = null;
+                node.fz = null;
+              }
+            },
+            setAllForces() {
+              this.setCenteringForce();
+              this.setLinksForce();
+              this.setManyBodyForce();
+              this.setXPositioningForce();
+              this.setYPositioningForce();
+              this.setZPositioningForce();
+            },
+            removeAllForces() {
+              state.webglGraph.d3Force("center", null);
+              state.webglGraph.d3Force("link", null);
+              state.webglGraph.d3Force("charge", null);
+              state.webglGraph.d3Force("x-positioning", null);
+              state.webglGraph.d3Force("y-positioning", null);
+              state.webglGraph.d3Force("z-positioning", null);
+            },
+            setCenteringForce() {
+              let centeringForce = null;
+              if (state.useCenteringForce && state.layoutAlgorithmActive) {
+                centeringForce = state.predefinedForces.center
+                  .x(0.0)
+                  .y(0.0);
+              }
+              state.webglGraph.d3Force("center", centeringForce);
+            },
+            setLinksForce() {
+              let linksForce = null;
+              if (state.useLinksForce && state.layoutAlgorithmActive) {
+                const nodes = state.shownData.nodes,
+                  edges = state.shownData.edges;
+                if (!state.shownData.edgeCounts) {
+                  const count = {};
+                  for (let i = 0; i < edges.length; i++) {
+                    const edge = edges[i];
+                    count[edge.source.id] = (count[edge.source.id] || 0) + 1;
+                    count[edge.target.id] = (count[edge.target.id] || 0) + 1;
                   }
-                  zPositioningForce = userDefinedForce;
+                  state.shownData.edgeCounts = count;
                 }
-                state.webglGraph.d3Force("z-positioning", zPositioningForce);
-              },
+                const appearanceAdaptionFactor = 2.0;
+                linksForce = state.predefinedForces.link
+                  .distance(state.linksForceDistance * appearanceAdaptionFactor)
+                  .strength(function (d) {
+                    // Adapted from https://github.com/d3/d3-force/blob/master/src/link.js
+                    const fixedConnectivity = Math.min(
+                      state.shownData.edgeCounts[d.source.id],
+                      state.shownData.edgeCounts[d.target.id]
+                    );
+                    const adjustableStrength = 2.0 * state.linksForceStrength;
+                    return adjustableStrength / fixedConnectivity;
+                  });
+              }
+              state.webglGraph.d3Force("link", linksForce);
+            },
+            setManyBodyForce() {
+              let manyBodyForce = null;
+              if (state.useManyBodyForce && state.layoutAlgorithmActive) {
+                manyBodyForce = state.predefinedForces.charge
+                  .strength(state.manyBodyForceStrength)
+                  .theta(state.manyBodyForceTheta);
+                if (state.useManyBodyForceMinDistance) {
+                  manyBodyForce.distanceMin(state.manyBodyForceMinDistance);
+                } else {
+                  manyBodyForce.distanceMin(0.0);
+                }
+                if (state.useManyBodyForceMaxDistance) {
+                  manyBodyForce.distanceMax(state.manyBodyForceMaxDistance);
+                } else {
+                  manyBodyForce.distanceMax(Infinity);
+                }
+              }
+              state.webglGraph.d3Force("charge", manyBodyForce);
+            },
+            setXPositioningForce() {
+              let xPositioningForce = null;
+              if (state.useXPositioningForce && state.layoutAlgorithmActive) {
+                function userDefinedForce(alpha) {
+                  const nodes = state.shownData.nodes;
+                  for (let i = 0; i < nodes.length; i++) {
+                    const node = nodes[i];
+                    node.vx += (0.0 - node.x) * alpha * state.xPositioningForceStrength;
+                  }
+                }
+                xPositioningForce = userDefinedForce;
+              }
+              state.webglGraph.d3Force("x-positioning", xPositioningForce);
+            },
+            setYPositioningForce() {
+              let yPositioningForce = null;
+              if (state.useYPositioningForce && state.layoutAlgorithmActive) {
+                function userDefinedForce(alpha) {
+                  const nodes = state.shownData.nodes;
+                  for (let i = 0; i < nodes.length; i++) {
+                    const node = nodes[i];
+                    node.vy += (0.0 - node.y) * alpha * state.yPositioningForceStrength;
+                  }
+                }
+                yPositioningForce = userDefinedForce;
+              }
+              state.webglGraph.d3Force("y-positioning", yPositioningForce);
+            },
+            setZPositioningForce() {
+              let zPositioningForce = null;
+              if (state.useZPositioningForce && state.layoutAlgorithmActive) {
+                function userDefinedForce(alpha) {
+                  const nodes = state.shownData.nodes;
+                  for (let i = 0; i < nodes.length; i++) {
+                    const node = nodes[i];
+                    node.vz += (0.0 - node.z) * alpha * state.zPositioningForceStrength;
+                  }
+                }
+                zPositioningForce = userDefinedForce;
+              }
+              state.webglGraph.d3Force("z-positioning", zPositioningForce);
             },
           },
         },
+      },
 
-        init(){
-          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
-          // Containers
-          ui.composites.responsiveContainer.init();
-          // Graph selection (only visible if multiple graphs in data)
-          if(state.rawData.length > 1){
-            ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            const optionList = [],
-              valueList = [];
-            let label;
-            for(let i=0; i<state.rawData.length; i++){
-              const graph = state.rawData[i];
-              try{
-                label = String(graph.label);
-                if(label === "undefined" || label === ""){
-                  throw "Invalid label";
-                }
-              } catch(e){
-                label = "Unnamed graph";
+      init() {
+        ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
+        // Containers
+        ui.composites.responsiveContainer.init();
+        // Graph selection (only visible if multiple graphs in data)
+        if (state.rawData.length > 1) {
+          ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          const optionList = [],
+            valueList = [];
+          let label;
+          for (let i = 0; i < state.rawData.length; i++) {
+            const graph = state.rawData[i];
+            try {
+              label = String(graph.label);
+              if (label === "undefined" || label === "") {
+                throw "Invalid label";
               }
-              const name = String(i+1) + ": " + label;
-              optionList.push(name);
-              valueList.push(String(i));
+            } catch (e) {
+              label = "Unnamed graph";
             }
-            ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
+            const name = String(i + 1) + ": " + label;
+            optionList.push(name);
+            valueList.push(String(i));
           }
-          // General (menu item)
-          ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
-          // Data selection (menu item)
-          ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
-          // - Node size
-          ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
-          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-          ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-          ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-          // - Edge size
-          ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
-          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-          ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-          ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
-          // Nodes
-          ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
-          ui.elements.nodeCheckbox.checked = state.showNodes;
-          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
-          ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
-          ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
-          ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
-          // Node images
-          ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
-          ui.elements.nodeImageMetaControl.style.display = false;
-          ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
-          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
-          ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
-          // Node labels
-          ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
-          ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
-          ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
-          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
-          ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
-          // Edges
-          ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
-          ui.elements.edgeCheckbox.checked = state.showEdges;
-          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
-          ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
-          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
-          ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
-          ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
-          // Layout algorithm
-          ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
-          ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
-          ui.elements.manyBodyForceCheckbox.checked = state.useManyBodyForce;
-          ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
-          ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(state.manyBodyForceStrength);
-          ui.elements.manyBodyForceStrengthSlider.value = state.manyBodyForceStrength;
-          ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(state.manyBodyForceTheta);
-          ui.elements.manyBodyForceThetaSlider.value = state.manyBodyForceTheta;
-          ui.elements.manyBodyForceMinDistCheckbox.checked = state.useManyBodyForceMinDistance;
-          ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
-          ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
-          ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
-          ui.elements.manyBodyForceMaxDistCheckbox.checked = state.useManyBodyForceMaxDistance;
-          ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
-          ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
-          ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
-          ui.elements.linksForceCheckbox.checked = state.useLinksForce;
-          ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
-          ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(state.linksForceDistance);
-          ui.elements.linksForceDistanceSlider.value = state.linksForceDistance;
-          ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(state.linksForceStrength);
-          ui.elements.linksForceStrengthSlider.value = state.linksForceStrength;
-          ui.elements.xPositioningForceCheckbox.checked = state.useXPositioningForce;
-          ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
-          ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.xPositioningForceStrength);
-          ui.elements.xPositioningForceStrengthSlider.value = state.xPositioningForceStrength;
-          ui.elements.yPositioningForceCheckbox.checked = state.useYPositioningForce;
-          ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
-          ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.yPositioningForceStrength);
-          ui.elements.yPositioningForceStrengthSlider.value = state.yPositioningForceStrength;
-          ui.elements.zPositioningForceCheckbox.checked = state.useZPositioningForce;
-          ui.elements.zPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useZPositioningForce);
-          ui.elements.zPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.zPositioningForceStrength);
-          ui.elements.zPositioningForceStrengthSlider.value = state.zPositioningForceStrength;
-          ui.elements.centeringForceCheckbox.checked = state.useCenteringForce;
+          ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
+        }
+        // General (menu item)
+        ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
+        // Data selection (menu item)
+        ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
+        // - Node size
+        ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
+        ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+        ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+        ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+        ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
+        ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+        // - Edge size
+        ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
+        ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+        ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+        ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+        ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+        ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+        // Nodes
+        ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
+        ui.elements.nodeCheckbox.checked = state.showNodes;
+        ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
+        ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
+        ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
+        ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
+        // Node images
+        ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
+        ui.elements.nodeImageMetaControl.style.display = false;
+        ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
+        ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
+        ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
+        // Node labels
+        ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
+        ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
+        ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
+        ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
+        ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
+        // Edges
+        ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
+        ui.elements.edgeCheckbox.checked = state.showEdges;
+        ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
+        ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
+        ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
+        ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
+        ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
+        // Layout algorithm
+        ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
+        ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
+        ui.elements.manyBodyForceCheckbox.checked = state.useManyBodyForce;
+        ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
+        ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(state.manyBodyForceStrength);
+        ui.elements.manyBodyForceStrengthSlider.value = state.manyBodyForceStrength;
+        ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(state.manyBodyForceTheta);
+        ui.elements.manyBodyForceThetaSlider.value = state.manyBodyForceTheta;
+        ui.elements.manyBodyForceMinDistCheckbox.checked = state.useManyBodyForceMinDistance;
+        ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
+        ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
+        ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
+        ui.elements.manyBodyForceMaxDistCheckbox.checked = state.useManyBodyForceMaxDistance;
+        ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
+        ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
+        ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
+        ui.elements.linksForceCheckbox.checked = state.useLinksForce;
+        ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
+        ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(state.linksForceDistance);
+        ui.elements.linksForceDistanceSlider.value = state.linksForceDistance;
+        ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(state.linksForceStrength);
+        ui.elements.linksForceStrengthSlider.value = state.linksForceStrength;
+        ui.elements.xPositioningForceCheckbox.checked = state.useXPositioningForce;
+        ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
+        ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.xPositioningForceStrength);
+        ui.elements.xPositioningForceStrengthSlider.value = state.xPositioningForceStrength;
+        ui.elements.yPositioningForceCheckbox.checked = state.useYPositioningForce;
+        ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
+        ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.yPositioningForceStrength);
+        ui.elements.yPositioningForceStrengthSlider.value = state.yPositioningForceStrength;
+        ui.elements.zPositioningForceCheckbox.checked = state.useZPositioningForce;
+        ui.elements.zPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useZPositioningForce);
+        ui.elements.zPositioningForceStrengthText.innerHTML = ui.convert.numberToText(state.zPositioningForceStrength);
+        ui.elements.zPositioningForceStrengthSlider.value = state.zPositioningForceStrength;
+        ui.elements.centeringForceCheckbox.checked = state.useCenteringForce;
 
-          ui.initSelectionValues();
-        },
+        ui.initSelectionValues();
+      },
 
-        initSelectionValues(){
-          function setSelectionOptionsAndValue(element, options, value){
-            if(!options.includes(value)){
-              value = options[0];
-            }
-            ui.composites.selection(element, options);
-            element.value = value;
+      initSelectionValues() {
+        function setSelectionOptionsAndValue(element, options, value) {
+          if (!options.includes(value)) {
+            value = options[0];
           }
-          // Node label text data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeLabelTextDataSourceSelect,
-            state.parsedData.general.node_properties.node_label_text_data_sources,
-            state.nodeLabelTextDataSource,
-          );
-          // Node size data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeSizeDataSourceSelect,
-            state.parsedData.general.node_properties.node_size_data_sources,
-            state.nodeSizeDataSource,
-          );
-          // Edge size data source
-          setSelectionOptionsAndValue(
-            ui.elements.edgeSizeDataSourceSelect,
-            state.parsedData.general.edge_properties.edge_size_data_sources,
-            state.edgeSizeDataSource,
-          );
+          ui.composites.selection(element, options);
+          element.value = value;
+        }
+        // Node label text data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeLabelTextDataSourceSelect,
+          state.parsedData.general.node_properties.node_label_text_data_sources,
+          state.nodeLabelTextDataSource,
+        );
+        // Node size data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeSizeDataSourceSelect,
+          state.parsedData.general.node_properties.node_size_data_sources,
+          state.nodeSizeDataSource,
+        );
+        // Edge size data source
+        setSelectionOptionsAndValue(
+          ui.elements.edgeSizeDataSourceSelect,
+          state.parsedData.general.edge_properties.edge_size_data_sources,
+          state.edgeSizeDataSource,
+        );
+      },
+
+      deleteChildElements(element) {
+        while (element.firstChild) {
+          element.removeChild(element.firstChild);
+        }
+      },
+
+      convert: {
+        numberToText(number, numDigits = 2) {
+          return String(Number(number).toFixed(numDigits));
         },
 
-        deleteChildElements(element){
-          while(element.firstChild){
-            element.removeChild(element.firstChild);
+        boolToDisplayStyle(isVisible) {
+          if (isVisible) {
+            return "block";
           }
+          return "none";
         },
 
-        convert:{
-          numberToText(number, numDigits=2) {
-            return String(Number(number).toFixed(numDigits));
-          },
-
-          boolToDisplayStyle(isVisible){
-            if(isVisible){
-              return "block";
-            }
-            return "none";
-          },
-
-          boolToOpacity(isActive){
-            if(isActive){
-              return 1.0;
-            }
-            return 0.25;
-          },
+        boolToOpacity(isActive) {
+          if (isActive) {
+            return 1.0;
+          }
+          return 0.25;
         },
+      },
 
-        setBehavior(){
-          // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
-          window.onresize = function(){
+      setBehavior() {
+        // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
+        window.onresize = function () {
+          ui.composites.responsiveContainer.adaptToResize();
+          ui.composites.graph.updateGraphDrawingArea();
+        }
+        // Container resize
+        ui.elements.graphContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
+          if (currentHeight != state.graphContainerHeight) {
             ui.composites.responsiveContainer.adaptToResize();
             ui.composites.graph.updateGraphDrawingArea();
           }
-          // Container resize
-          ui.elements.graphContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
-            if(currentHeight != state.graphContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
-          };
-          ui.elements.detailsContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-            if(currentHeight != state.detailsContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-            }
-          };
-          // Tooltip
-          ui.elements.tooltipContainer.onmouseover = function(){
-            ui.composites.tooltip.show();
+        };
+        ui.elements.detailsContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+          if (currentHeight != state.detailsContainerHeight) {
+            ui.composites.responsiveContainer.adaptToResize();
           }
-          ui.elements.tooltipContainer.onmouseout = function(){
-            ui.composites.tooltip.hide();
+        };
+        // Tooltip
+        ui.elements.tooltipContainer.onmouseover = function () {
+          ui.composites.tooltip.show();
+        }
+        ui.elements.tooltipContainer.onmouseout = function () {
+          ui.composites.tooltip.hide();
+        }
+        // General menu
+        ui.elements.generalHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
+        };
+        ui.elements.resetButton.onclick = function () {
+          app.restart();
+        };
+        ui.elements.fullscreenButton.onclick = function () {
+          if (document.fullscreenElement) {
+            document.exitFullscreen();
+          } else {
+            ui.elements.mainContainer.requestFullscreen()
+              .catch(function (err) {
+                alert("Error attempting to enable full-screen mode: " + err.message);
+              });
           }
-          // General menu
-          ui.elements.generalHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
-          };
-          ui.elements.resetButton.onclick = function(){
-            app.restart();
-          };
-          ui.elements.fullscreenButton.onclick = function(){
-            if(document.fullscreenElement){
-              document.exitFullscreen();
-            } else{
-              ui.elements.mainContainer.requestFullscreen()
-                .catch(function(err){
-                  alert("Error attempting to enable full-screen mode: " + err.message);
-                });
-            }
-          };
-          ui.elements.mainContainer.onfullscreenchange = function(){
-            if(document.fullscreenElement){
-              ui.elements.fullscreenButton.innerText = "Exit full screen";
-            } else{
-              ui.elements.fullscreenButton.innerText = "Enter full screen";
-            }
-            // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
-            setTimeout(function(){
-              ui.composites.responsiveContainer.adaptToFullscreen();
-              ui.composites.graph.updateGraphDrawingArea();
-            }, 250);
-          };
-          ui.elements.pngExportButton.onclick = function(){
-            ui.composites.download.png("graph.png");
-          };
-          ui.elements.jpgExportButton.onclick = function(){
-            ui.composites.download.jpg("graph.jpg");
-          };
-          // Data menu
-          ui.elements.dataHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
-          };
-          // - Graph selection
-          ui.elements.graphSelection.onchange = function(){
-            const chosenGraphIndex = parseInt(this.value);
-            state.manager.parseChosenData(chosenGraphIndex);
-            state.manager.prepareShownData();
-            ui.initSelectionValues();
-            ui.composites.graph.createGraph();
-          };
-          // - Node label text
-          ui.elements.nodeLabelTextDataSourceSelect.onchange = function(){
-            state.nodeLabelTextDataSource = this.value;
-            state.manager.updateNodeLabelTexts();
-          };
-          // - Node size
-          ui.elements.nodeSizeDataSourceSelect.onchange = function(){
-            state.nodeSizeDataSource = this.value;
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationCheckbox.onchange = function(){
-            state.useNodeSizeNormalization = this.checked;
-            ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.onchange = function(){
-            state.nodeSizeNormalizationMin = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax){
-              state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-            }
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.onchange = function(){
-            state.nodeSizeNormalizationMax = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin){
-              state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-            }
-            state.manager.updateNodeSizes();
-          };
-          // - Edge size
-          ui.elements.edgeSizeDataSourceSelect.onchange = function(){
-            state.edgeSizeDataSource = this.value;
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationCheckbox.onchange = function(){
-            state.useEdgeSizeNormalization = this.checked;
-            ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.onchange = function(){
-            state.edgeSizeNormalizationMin = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax){
-              state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.onchange = function(){
-            state.edgeSizeNormalizationMax = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin){
-              state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          // Nodes menu
-          ui.elements.nodeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
-          };
-          ui.elements.nodeCheckbox.onchange = function(){
-            state.showNodes = this.checked;
-            ui.composites.graph.updateNodeVisibilities();
-          };
-          ui.elements.nodeSizeFactorSlider.oninput = function(){
-            ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeFactorSlider.onchange = function(){
-            state.nodeSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeDragFixCheckbox.onchange = function(){
-            state.nodeDragFix = this.checked;
-          };
-          ui.elements.nodeHoverTooltipCheckbox.onchange = function(){
-            state.nodeHoverTooltip = this.checked;
-          };
-          ui.elements.nodeReleaseButton.onclick = function(){
-            ui.composites.graph.simulationManager.releaseFixedNodes();
-            ui.composites.graph.simulationManager.move();
-          };
-          // Node images menu
-          ui.elements.nodeImageHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
-          };
-          ui.elements.nodeImageCheckbox.onchange = function(){
-            state.showNodeImages = this.checked;
-            ui.composites.graph.updateNodeImages();
-          };
-          ui.elements.nodeImageSizeFactorSlider.oninput = function(){
-            ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeImageSizeFactorSlider.onchange = function(){
-            state.nodeImageSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeImageSizes();
-          };
-          // Node labels menu
-          ui.elements.nodeLabelHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
-          };
-          ui.elements.nodeLabelCheckbox.onchange = function(){
-            state.showNodeLabels = this.checked;
-            ui.composites.graph.updateNodeLabels();
-          };
-          ui.elements.nodeLabelBorderCheckbox.onchange = function(){
-            state.showNodeLabelBorders = this.checked;
-            ui.composites.graph.updateNodeLabels();
-          };
-          ui.elements.nodeLabelSizeFactorSlider.oninput = function(){
-            ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeLabelSizeFactorSlider.onchange = function(){
-            state.nodeLabelSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeLabelSizes();
-          };
-          // Edges menu
-          ui.elements.edgeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
-          };
-          ui.elements.edgeCheckbox.onchange = function(){
-            state.showEdges = this.checked;
-            ui.composites.graph.updateEdgeVisibilities();
-          };
-          ui.elements.edgeSizeFactorSlider.oninput = function(){
-            ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeFactorSlider.onchange = function(){
-            state.edgeSizeFactor = parseFloat(this.value);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeCurvatureSlider.oninput = function(){
-            ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeCurvatureSlider.onchange = function(){
-            state.edgeCurvature = parseFloat(this.value);
-            state.manager.updateEdgeCurvatures();
-          };
-          ui.elements.edgeHoverTooltipCheckbox.onchange = function(){
-            state.edgeHoverTooltip = this.checked;
-          };
-          // Layout algorithm menu
-          ui.elements.layoutAlgorithmHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
-          };
-          ui.elements.simulationCheckbox.onchange = function(){
-            state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
-            if(state.layoutAlgorithmActive){
-              ui.composites.graph.simulationManager.restart();
-            } else {
-              ui.composites.graph.simulationManager.stop();
-            }
+        };
+        ui.elements.mainContainer.onfullscreenchange = function () {
+          if (document.fullscreenElement) {
+            ui.elements.fullscreenButton.innerText = "Exit full screen";
+          } else {
+            ui.elements.fullscreenButton.innerText = "Enter full screen";
           }
-          ui.elements.manyBodyForceCheckbox.onchange = function(){
-            state.useManyBodyForce = this.checked;
-            ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.manyBodyForceStrengthSlider.oninput = function(){
-            ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceStrengthSlider.onchange = function(){
-            state.manyBodyForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceThetaSlider.oninput = function(){
-            ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceThetaSlider.onchange = function(){
-            state.manyBodyForceTheta = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceMinDistCheckbox.onchange = function(){
-            state.useManyBodyForceMinDistance = this.checked;
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
-          }
-          ui.elements.manyBodyForceMinDistSlider.oninput = function(){
-            ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceMinDistSlider.onchange = function(){
-            state.manyBodyForceMinDistance = parseFloat(this.value);
-            if(state.manyBodyForceMinDistance > state.manyBodyForceMaxDistance){
-              state.manyBodyForceMaxDistance = state.manyBodyForceMinDistance;
-              ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
-              ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
-            }
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.manyBodyForceMaxDistCheckbox.onchange = function(){
-            state.useManyBodyForceMaxDistance = this.checked;
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
-          }
-          ui.elements.manyBodyForceMaxDistSlider.oninput = function(){
-            ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.manyBodyForceMaxDistSlider.onchange = function(){
-            state.manyBodyForceMaxDistance = parseFloat(this.value);
-            if(state.manyBodyForceMaxDistance < state.manyBodyForceMinDistance){
-              state.manyBodyForceMinDistance = state.manyBodyForceMaxDistance;
-              ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
-              ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
-            }
-            ui.composites.graph.simulationManager.setManyBodyForce();
-            if(state.useManyBodyForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.linksForceCheckbox.onchange = function(){
-            state.useLinksForce = this.checked;
-            ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
-            ui.composites.graph.simulationManager.setLinksForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.linksForceDistanceSlider.oninput = function(){
-            ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.linksForceDistanceSlider.onchange = function(){
-            state.linksForceDistance = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setLinksForce();
-            if(state.useLinksForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.linksForceStrengthSlider.oninput = function(){
-            ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.linksForceStrengthSlider.onchange = function(){
-            state.linksForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setLinksForce();
-            if(state.useLinksForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.xPositioningForceCheckbox.onchange = function(){
-            state.useXPositioningForce = this.checked;
-            ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
-            ui.composites.graph.simulationManager.setXPositioningForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.xPositioningForceStrengthSlider.oninput = function(){
-            ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.xPositioningForceStrengthSlider.onchange = function(){
-            state.xPositioningForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setXPositioningForce();
-            if(state.useXPositioningForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.yPositioningForceCheckbox.onchange = function(){
-            state.useYPositioningForce = this.checked;
-            ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
-            ui.composites.graph.simulationManager.setYPositioningForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.yPositioningForceStrengthSlider.oninput = function(){
-            ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.yPositioningForceStrengthSlider.onchange = function(){
-            state.yPositioningForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setYPositioningForce();
-            if(state.useYPositioningForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.zPositioningForceCheckbox.onchange = function(){
-            state.useZPositioningForce = this.checked;
-            ui.elements.zPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useZPositioningForce);
-            ui.composites.graph.simulationManager.setZPositioningForce();
-            ui.composites.graph.simulationManager.move();
-          };
-          ui.elements.zPositioningForceStrengthSlider.oninput = function(){
-            ui.elements.zPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.zPositioningForceStrengthSlider.onchange = function(){
-            state.yPositioningForceStrength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setZPositioningForce();
-            if(state.useZPositioningForce){
-              ui.composites.graph.simulationManager.move();
-            }
-          };
-          ui.elements.centeringForceCheckbox.onchange = function(){
-            state.useCenteringForce = this.checked;
-            ui.composites.graph.simulationManager.setCenteringForce();
-            ui.composites.graph.simulationManager.move();
-          };
-        },
-      }
-
-      const app = {
-        start(){
-          state.manager.fetchRawDataFromTemplating();
-          state.manager.parseChosenData(0);
+          // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
+          setTimeout(function () {
+            ui.composites.responsiveContainer.adaptToFullscreen();
+            ui.composites.graph.updateGraphDrawingArea();
+          }, 250);
+        };
+        ui.elements.pngExportButton.onclick = function () {
+          ui.composites.download.png("graph.png");
+        };
+        ui.elements.jpgExportButton.onclick = function () {
+          ui.composites.download.jpg("graph.jpg");
+        };
+        // Data menu
+        ui.elements.dataHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
+        };
+        // - Graph selection
+        ui.elements.graphSelection.onchange = function () {
+          const chosenGraphIndex = parseInt(this.value);
+          state.manager.parseChosenData(chosenGraphIndex);
           state.manager.prepareShownData();
-          ui.init();
-          // Wait a bit to finish UI rendering, then start potentially slow layout computation
-          setTimeout(function(){
-            ui.composites.graph.createGraph();
-            ui.setBehavior();
-          }, 800);
-          // Reduce risk of getting stuck with a wrong drawing area size
-          function checkIfSizeUpdateRequired(){
-            if(ui.elements.graphContainer.clientWidth != state.graphContainerWidth){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
+          ui.initSelectionValues();
+          ui.composites.graph.createGraph();
+        };
+        // - Node label text
+        ui.elements.nodeLabelTextDataSourceSelect.onchange = function () {
+          state.nodeLabelTextDataSource = this.value;
+          state.manager.updateNodeLabelTexts();
+        };
+        // - Node size
+        ui.elements.nodeSizeDataSourceSelect.onchange = function () {
+          state.nodeSizeDataSource = this.value;
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationCheckbox.onchange = function () {
+          state.useNodeSizeNormalization = this.checked;
+          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.onchange = function () {
+          state.nodeSizeNormalizationMin = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax) {
+            state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
           }
-          [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function(delay){
-            setTimeout(checkIfSizeUpdateRequired, delay*1000);
-          })
-        },
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.onchange = function () {
+          state.nodeSizeNormalizationMax = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin) {
+            state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+          }
+          state.manager.updateNodeSizes();
+        };
+        // - Edge size
+        ui.elements.edgeSizeDataSourceSelect.onchange = function () {
+          state.edgeSizeDataSource = this.value;
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationCheckbox.onchange = function () {
+          state.useEdgeSizeNormalization = this.checked;
+          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.onchange = function () {
+          state.edgeSizeNormalizationMin = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax) {
+            state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.onchange = function () {
+          state.edgeSizeNormalizationMax = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin) {
+            state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        // Nodes menu
+        ui.elements.nodeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
+        };
+        ui.elements.nodeCheckbox.onchange = function () {
+          state.showNodes = this.checked;
+          ui.composites.graph.updateNodeVisibilities();
+        };
+        ui.elements.nodeSizeFactorSlider.oninput = function () {
+          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeFactorSlider.onchange = function () {
+          state.nodeSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeDragFixCheckbox.onchange = function () {
+          state.nodeDragFix = this.checked;
+        };
+        ui.elements.nodeHoverTooltipCheckbox.onchange = function () {
+          state.nodeHoverTooltip = this.checked;
+        };
+        ui.elements.nodeReleaseButton.onclick = function () {
+          ui.composites.graph.simulationManager.releaseFixedNodes();
+          ui.composites.graph.simulationManager.move();
+        };
+        // Node images menu
+        ui.elements.nodeImageHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
+        };
+        ui.elements.nodeImageCheckbox.onchange = function () {
+          state.showNodeImages = this.checked;
+          ui.composites.graph.updateNodeImages();
+        };
+        ui.elements.nodeImageSizeFactorSlider.oninput = function () {
+          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeImageSizeFactorSlider.onchange = function () {
+          state.nodeImageSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeImageSizes();
+        };
+        // Node labels menu
+        ui.elements.nodeLabelHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
+        };
+        ui.elements.nodeLabelCheckbox.onchange = function () {
+          state.showNodeLabels = this.checked;
+          ui.composites.graph.updateNodeLabels();
+        };
+        ui.elements.nodeLabelBorderCheckbox.onchange = function () {
+          state.showNodeLabelBorders = this.checked;
+          ui.composites.graph.updateNodeLabels();
+        };
+        ui.elements.nodeLabelSizeFactorSlider.oninput = function () {
+          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeLabelSizeFactorSlider.onchange = function () {
+          state.nodeLabelSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeLabelSizes();
+        };
+        // Edges menu
+        ui.elements.edgeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
+        };
+        ui.elements.edgeCheckbox.onchange = function () {
+          state.showEdges = this.checked;
+          ui.composites.graph.updateEdgeVisibilities();
+        };
+        ui.elements.edgeSizeFactorSlider.oninput = function () {
+          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeFactorSlider.onchange = function () {
+          state.edgeSizeFactor = parseFloat(this.value);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeCurvatureSlider.oninput = function () {
+          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeCurvatureSlider.onchange = function () {
+          state.edgeCurvature = parseFloat(this.value);
+          state.manager.updateEdgeCurvatures();
+        };
+        ui.elements.edgeHoverTooltipCheckbox.onchange = function () {
+          state.edgeHoverTooltip = this.checked;
+        };
+        // Layout algorithm menu
+        ui.elements.layoutAlgorithmHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
+        };
+        ui.elements.simulationCheckbox.onchange = function () {
+          state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
+          if (state.layoutAlgorithmActive) {
+            ui.composites.graph.simulationManager.restart();
+          } else {
+            ui.composites.graph.simulationManager.stop();
+          }
+        }
+        ui.elements.manyBodyForceCheckbox.onchange = function () {
+          state.useManyBodyForce = this.checked;
+          ui.elements.manyBodyForceContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForce);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.manyBodyForceStrengthSlider.oninput = function () {
+          ui.elements.manyBodyForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceStrengthSlider.onchange = function () {
+          state.manyBodyForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceThetaSlider.oninput = function () {
+          ui.elements.manyBodyForceThetaText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceThetaSlider.onchange = function () {
+          state.manyBodyForceTheta = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceMinDistCheckbox.onchange = function () {
+          state.useManyBodyForceMinDistance = this.checked;
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.elements.manyBodyForceMinDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMinDistance);
+        }
+        ui.elements.manyBodyForceMinDistSlider.oninput = function () {
+          ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceMinDistSlider.onchange = function () {
+          state.manyBodyForceMinDistance = parseFloat(this.value);
+          if (state.manyBodyForceMinDistance > state.manyBodyForceMaxDistance) {
+            state.manyBodyForceMaxDistance = state.manyBodyForceMinDistance;
+            ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMaxDistance);
+            ui.elements.manyBodyForceMaxDistSlider.value = state.manyBodyForceMaxDistance;
+          }
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.manyBodyForceMaxDistCheckbox.onchange = function () {
+          state.useManyBodyForceMaxDistance = this.checked;
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          ui.elements.manyBodyForceMaxDistContainer.style.opacity = ui.convert.boolToOpacity(state.useManyBodyForceMaxDistance);
+        }
+        ui.elements.manyBodyForceMaxDistSlider.oninput = function () {
+          ui.elements.manyBodyForceMaxDistText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.manyBodyForceMaxDistSlider.onchange = function () {
+          state.manyBodyForceMaxDistance = parseFloat(this.value);
+          if (state.manyBodyForceMaxDistance < state.manyBodyForceMinDistance) {
+            state.manyBodyForceMinDistance = state.manyBodyForceMaxDistance;
+            ui.elements.manyBodyForceMinDistText.innerHTML = ui.convert.numberToText(state.manyBodyForceMinDistance);
+            ui.elements.manyBodyForceMinDistSlider.value = state.manyBodyForceMinDistance;
+          }
+          ui.composites.graph.simulationManager.setManyBodyForce();
+          if (state.useManyBodyForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.linksForceCheckbox.onchange = function () {
+          state.useLinksForce = this.checked;
+          ui.elements.linksForceContainer.style.opacity = ui.convert.boolToOpacity(state.useLinksForce);
+          ui.composites.graph.simulationManager.setLinksForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.linksForceDistanceSlider.oninput = function () {
+          ui.elements.linksForceDistanceText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.linksForceDistanceSlider.onchange = function () {
+          state.linksForceDistance = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setLinksForce();
+          if (state.useLinksForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.linksForceStrengthSlider.oninput = function () {
+          ui.elements.linksForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.linksForceStrengthSlider.onchange = function () {
+          state.linksForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setLinksForce();
+          if (state.useLinksForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.xPositioningForceCheckbox.onchange = function () {
+          state.useXPositioningForce = this.checked;
+          ui.elements.xPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useXPositioningForce);
+          ui.composites.graph.simulationManager.setXPositioningForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.xPositioningForceStrengthSlider.oninput = function () {
+          ui.elements.xPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.xPositioningForceStrengthSlider.onchange = function () {
+          state.xPositioningForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setXPositioningForce();
+          if (state.useXPositioningForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.yPositioningForceCheckbox.onchange = function () {
+          state.useYPositioningForce = this.checked;
+          ui.elements.yPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useYPositioningForce);
+          ui.composites.graph.simulationManager.setYPositioningForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.yPositioningForceStrengthSlider.oninput = function () {
+          ui.elements.yPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.yPositioningForceStrengthSlider.onchange = function () {
+          state.yPositioningForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setYPositioningForce();
+          if (state.useYPositioningForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.zPositioningForceCheckbox.onchange = function () {
+          state.useZPositioningForce = this.checked;
+          ui.elements.zPositioningForceContainer.style.opacity = ui.convert.boolToOpacity(state.useZPositioningForce);
+          ui.composites.graph.simulationManager.setZPositioningForce();
+          ui.composites.graph.simulationManager.move();
+        };
+        ui.elements.zPositioningForceStrengthSlider.oninput = function () {
+          ui.elements.zPositioningForceStrengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.zPositioningForceStrengthSlider.onchange = function () {
+          state.yPositioningForceStrength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setZPositioningForce();
+          if (state.useZPositioningForce) {
+            ui.composites.graph.simulationManager.move();
+          }
+        };
+        ui.elements.centeringForceCheckbox.onchange = function () {
+          state.useCenteringForce = this.checked;
+          ui.composites.graph.simulationManager.setCenteringForce();
+          ui.composites.graph.simulationManager.move();
+        };
+      },
+    }
 
-        restart(){
-          ui.composites.graph.simulationManager.stop();
-          app.start();
-        },
-      }
+    const app = {
+      start() {
+        state.manager.fetchRawDataFromTemplating();
+        state.manager.parseChosenData(0);
+        state.manager.prepareShownData();
+        ui.init();
+        // Wait a bit to finish UI rendering, then start potentially slow layout computation
+        setTimeout(function () {
+          ui.composites.graph.createGraph();
+          ui.setBehavior();
+        }, 800);
+        // Reduce risk of getting stuck with a wrong drawing area size
+        function checkIfSizeUpdateRequired() {
+          if (ui.elements.graphContainer.clientWidth != state.graphContainerWidth) {
+            ui.composites.responsiveContainer.adaptToResize();
+            ui.composites.graph.updateGraphDrawingArea();
+          }
+        }
+        [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function (delay) {
+          setTimeout(checkIfSizeUpdateRequired, delay * 1000);
+        })
+      },
 
-      // Start website dynamics
-      window.addEventListener("unload", function(){
-        state.threeObjects.disposeAll();
-      });
-      app.start();
+      restart() {
+        ui.composites.graph.simulationManager.stop();
+        app.start();
+      },
+    }
+
+    // Start website dynamics
+    window.addEventListener("unload", function () {
+      state.threeObjects.disposeAll();
     });
-  </script>
+    app.start();
+  });
+</script>
 §SUFFIX§

--- a/gravis/_internal/plotting/templates/three.html
+++ b/gravis/_internal/plotting/templates/three.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -1031,6 +1090,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1267,21 +1327,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1293,10 +1370,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2146,17 +2223,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2338,19 +2409,14 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
-              // this.mainContainer.appendChild(this.outerBarContainer);  // Hide bar (not updated)
+              this.mainContainer.appendChild(this.outerBarContainer);
               ui.elements.graphContainer.appendChild(this.mainContainer);
             },
 
@@ -2923,6 +2989,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/three.html
+++ b/gravis/_internal/plotting/templates/three.html
@@ -413,8 +413,8 @@
 
   #legend {
     position: absolute;
-    top: 10px;
-    left: 10px;
+    top: 20px;
+    left: 20px;
     z-index: 1000;
   }
 </style>

--- a/gravis/_internal/plotting/templates/vis.html
+++ b/gravis/_internal/plotting/templates/vis.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -309,32 +368,6 @@
     #§RANDOM_ID§-details-user-provided ul {
       list-style-position: inside;
       padding-left: 6px;
-    }
-
-    /* Unavailable in vis.js and therefore hidden */
-    #§RANDOM_ID§-svg,
-    #§RANDOM_ID§-node-label-rotation,
-    #§RANDOM_ID§-edge-label-rotation {
-      display: none;
-    }
-    /* Specific to vis.js */
-    div.vis-tooltip {
-      position: absolute;
-      visibility: hidden;
-      pointer-events: none;
-      z-index: 5;
-      max-width: 40%;
-      white-space: pre-wrap;
-      word-break: break-word;
-      font-size: 10px;
-      padding: 5px;
-      color: black;
-      background-color: white;
-      -moz-border-radius: 3px;
-      -webkit-border-radius: 3px;
-      border-radius: 3px;
-      border: 0.5px solid black;
-      box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
     }
   </style>
 
@@ -942,6 +975,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -2052,17 +2086,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2235,15 +2263,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -2953,6 +2976,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/vis.html
+++ b/gravis/_internal/plotting/templates/vis.html
@@ -1,2789 +1,2273 @@
 §PREFIX§
-  <style>
-    /* Main divisions */
-    #§RANDOM_ID§-main-div {
-      line-height: normal;
-      box-sizing: content-box;
-      padding: 3px;
-      background-color: var(--§RANDOM_ID§-background-color);
-      color: var(--§RANDOM_ID§-text-color);
-      --§RANDOM_ID§-background-color: #ffffff;
-      --§RANDOM_ID§-text-color: #222222;
-      --§RANDOM_ID§-text-color-subtle: #666666;
-      --§RANDOM_ID§-accent-color: #006429;
-      --§RANDOM_ID§-surface-color: #f5f5f5;
-      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
-      --§RANDOM_ID§-surface-color-strong: #dddddd;
-      --§RANDOM_ID§-surface-color-overlay: #ffffff;
-      --§RANDOM_ID§-border-color: #cccccc;
-      --§RANDOM_ID§-border-color-strong: #bbbbbb;
-      --§RANDOM_ID§-border-color-hover: #999999;
-      --§RANDOM_ID§-tooltip-background: #ffffff;
-      --§RANDOM_ID§-tooltip-text: #111111;
-      --§RANDOM_ID§-details-separator: #333333;
-      --§RANDOM_ID§-progress-border: #000000;
-      --§RANDOM_ID§-progress-fill: #000000;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
-    }
-    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
-      --§RANDOM_ID§-background-color: #1f1f25;
-      --§RANDOM_ID§-text-color: #f0f0f5;
-      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
-      --§RANDOM_ID§-accent-color: #7ddba3;
-      --§RANDOM_ID§-surface-color: #2d303c;
-      --§RANDOM_ID§-surface-color-muted: #343746;
-      --§RANDOM_ID§-surface-color-strong: #3d4050;
-      --§RANDOM_ID§-surface-color-overlay: #282a36;
-      --§RANDOM_ID§-border-color: #43465a;
-      --§RANDOM_ID§-border-color-strong: #50546a;
-      --§RANDOM_ID§-border-color-hover: #5e637c;
-      --§RANDOM_ID§-tooltip-background: #2f3241;
-      --§RANDOM_ID§-tooltip-text: #f0f2ff;
-      --§RANDOM_ID§-details-separator: #5e637c;
-      --§RANDOM_ID§-progress-border: #f0f2ff;
-      --§RANDOM_ID§-progress-fill: #7ddba3;
-      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
-    }
-    #§RANDOM_ID§-left-div {
-      float: left;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-div {
-      float: left;
-      height: 100%;
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-right-inner-div {
-      padding-left: 5px;
-      padding-right: 2px;
-      overflow-x: hidden;
-      overflow-y: auto;
-      height: 100%;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+<style>
+  /* Main divisions */
+  #§RANDOM_ID§-main-div {
+    line-height: normal;
+    box-sizing: content-box;
+    padding: 3px;
+    background-color: var(--§RANDOM_ID§-background-color);
+    color: var(--§RANDOM_ID§-text-color);
+    --§RANDOM_ID§-background-color: #ffffff;
+    --§RANDOM_ID§-text-color: #222222;
+    --§RANDOM_ID§-text-color-subtle: #666666;
+    --§RANDOM_ID§-accent-color: #006429;
+    --§RANDOM_ID§-surface-color: #f5f5f5;
+    --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+    --§RANDOM_ID§-surface-color-strong: #dddddd;
+    --§RANDOM_ID§-surface-color-overlay: #ffffff;
+    --§RANDOM_ID§-border-color: #cccccc;
+    --§RANDOM_ID§-border-color-strong: #bbbbbb;
+    --§RANDOM_ID§-border-color-hover: #999999;
+    --§RANDOM_ID§-tooltip-background: #ffffff;
+    --§RANDOM_ID§-tooltip-text: #111111;
+    --§RANDOM_ID§-details-separator: #333333;
+    --§RANDOM_ID§-progress-border: #000000;
+    --§RANDOM_ID§-progress-fill: #000000;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+  }
 
-    /* Graph and details (contained in left-inner-div) */
-    #§RANDOM_ID§-graph-div {
-      overflow: hidden;
-      resize: vertical;
-      position: relative;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-div {
-      overflow: auto;
-      resize: vertical;
-      margin-top: 5px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      border-radius: 4px;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
-      display: none;
-      line-height: normal;
-      box-sizing: content-box;
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-    }
-    #§RANDOM_ID§-details-head {
-      user-select: none;
-      padding-left: 4px !important;
-      padding-top: 4px !important;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color-subtle);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-details-body {
-      padding: 10px;
-      padding-top: 6px;
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      line-height: normal;
-      box-sizing: content-box;
-    }
+  #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+    --§RANDOM_ID§-background-color: #1f1f25;
+    --§RANDOM_ID§-text-color: #f0f0f5;
+    --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+    --§RANDOM_ID§-accent-color: #7ddba3;
+    --§RANDOM_ID§-surface-color: #2d303c;
+    --§RANDOM_ID§-surface-color-muted: #343746;
+    --§RANDOM_ID§-surface-color-strong: #3d4050;
+    --§RANDOM_ID§-surface-color-overlay: #282a36;
+    --§RANDOM_ID§-border-color: #43465a;
+    --§RANDOM_ID§-border-color-strong: #50546a;
+    --§RANDOM_ID§-border-color-hover: #5e637c;
+    --§RANDOM_ID§-tooltip-background: #2f3241;
+    --§RANDOM_ID§-tooltip-text: #f0f2ff;
+    --§RANDOM_ID§-details-separator: #5e637c;
+    --§RANDOM_ID§-progress-border: #f0f2ff;
+    --§RANDOM_ID§-progress-fill: #7ddba3;
+    --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
+  }
 
-    /* Control menu (contained in right-inner-div) */
-    .§RANDOM_ID§-menu-item-head {
-      font-size: 11px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      cursor: pointer;
-      padding-left: 5px;
-      padding-right: 0px;
-      padding-top: 5px;
-      padding-bottom: 5px;
-      margin-bottom: 5px;
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
-      background-color: var(--§RANDOM_ID§-surface-color);
-      border-color: var(--§RANDOM_ID§-border-color-hover);
-      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
-    }
-    .§RANDOM_ID§-menu-item-body {
-      margin-left: 5px;
-      margin-bottom: 10px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-head {
-      font-size: 9px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-weight: 600;
-      color: var(--§RANDOM_ID§-accent-color);
-      cursor: default;
-      margin-bottom: 2px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-menu-subitem-body {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      margin-left: 7px;
-      margin-bottom: 5px;
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    .§RANDOM_ID§-labeled-input {
-      all: initial;
-      display: flex;
-      align-items: center;
-      margin-top: 1px;
-      margin-bottom: 1px;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-label {
-      all: initial;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      cursor: pointer;
-      color: var(--§RANDOM_ID§-text-color);
-    }
-    .§RANDOM_ID§-slider {
-      width: 100%;
-      margin-bottom: 2px;
-    }
-    .§RANDOM_ID§-slider::-moz-focus-outer {
-      border: 0;
-    }
-    .§RANDOM_ID§-slider-text-left {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      font-style: italic;
-      color: var(--§RANDOM_ID§-text-color);
-      float: left;
-      margin-top: 2px;
-    }
-    .§RANDOM_ID§-slider-text-right {
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      float: right;
-    }
-    .§RANDOM_ID§-checkbox {
-      margin-left: 0px !important;
-      margin-right: 4px !important;
-      margin-top: 2px !important;
-      margin-bottom: 2px !important;
-      padding: 0px !important;
-    }
+  #§RANDOM_ID§-left-div {
+    float: left;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-div {
+    float: left;
+    height: 100%;
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-right-inner-div {
+    padding-left: 5px;
+    padding-right: 2px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100%;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Graph and details (contained in left-inner-div) */
+  #§RANDOM_ID§-graph-div {
+    overflow: hidden;
+    resize: vertical;
+    position: relative;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-div {
+    overflow: auto;
+    resize: vertical;
+    margin-top: 5px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    border-radius: 4px;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    line-height: normal;
+    box-sizing: content-box;
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+  }
+
+  #§RANDOM_ID§-details-head {
+    user-select: none;
+    padding-left: 4px !important;
+    padding-top: 4px !important;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color-subtle);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-details-body {
+    padding: 10px;
+    padding-top: 6px;
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  /* Control menu (contained in right-inner-div) */
+  .§RANDOM_ID§-menu-item-head {
+    font-size: 11px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    cursor: pointer;
+    padding-left: 5px;
+    padding-right: 0px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-bottom: 5px;
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+    background-color: var(--§RANDOM_ID§-surface-color);
+    border-color: var(--§RANDOM_ID§-border-color-hover);
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
+  }
+
+  .§RANDOM_ID§-menu-item-body {
+    margin-left: 5px;
+    margin-bottom: 10px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-head {
+    font-size: 9px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-weight: 600;
+    color: var(--§RANDOM_ID§-accent-color);
+    cursor: default;
+    margin-bottom: 2px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-menu-subitem-body {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    margin-left: 7px;
+    margin-bottom: 5px;
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  .§RANDOM_ID§-labeled-input {
+    all: initial;
+    display: flex;
+    align-items: center;
+    margin-top: 1px;
+    margin-bottom: 1px;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-label {
+    all: initial;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    cursor: pointer;
+    color: var(--§RANDOM_ID§-text-color);
+  }
+
+  .§RANDOM_ID§-slider {
+    width: 100%;
+    margin-bottom: 2px;
+  }
+
+  .§RANDOM_ID§-slider::-moz-focus-outer {
+    border: 0;
+  }
+
+  .§RANDOM_ID§-slider-text-left {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    font-style: italic;
+    color: var(--§RANDOM_ID§-text-color);
+    float: left;
+    margin-top: 2px;
+  }
+
+  .§RANDOM_ID§-slider-text-right {
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    float: right;
+  }
+
+  .§RANDOM_ID§-checkbox {
+    margin-left: 0px !important;
+    margin-right: 4px !important;
+    margin-top: 2px !important;
+    margin-bottom: 2px !important;
+    padding: 0px !important;
+  }
+
+  .§RANDOM_ID§-select {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color);
+    width: 100%;
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 5px;
+    padding-right: 10px;
+    margin-right: 5px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: var(--§RANDOM_ID§-select-arrow);
+    background-repeat: no-repeat;
+    background-position: right 4px top 50%;
+    background-size: 6px;
+  }
+
+  @-moz-document url-prefix() {
+
+    /* Dirty hack to remove dotted border on focus */
     .§RANDOM_ID§-select {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color);
-      width: 100%;
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 5px;
-      padding-right: 10px;
-      margin-right: 5px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+      color: transparent !important;
+      text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
+    }
+  }
 
-      -moz-appearance: none;
-      -webkit-appearance: none;
-      appearance: none;
-      background-image: var(--§RANDOM_ID§-select-arrow);
-      background-repeat: no-repeat;
-      background-position: right 4px top 50%;
-      background-size: 6px;
-    }
-    @-moz-document url-prefix() {
-      /* Dirty hack to remove dotted border on focus */
-      .§RANDOM_ID§-select {
-        color: transparent !important;
-        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
-      }
-    }
-    .§RANDOM_ID§-select:after {
-      cursor: pointer;
-    }
-    .§RANDOM_ID§-button {
-      cursor: pointer;
-      outline: none;
-      font-size: 8px;
-      font-family: "Lucida Console", Monaco, monospace;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-muted);
-      padding-top: 4px !important;
-      padding-bottom: 4px !important;
-      padding-left: 10px;
-      padding-right: 10px;
-      margin-top: 2px;
-      margin-bottom: 2px;
-      border-radius: 4px;
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
-      box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
-    }
-    .§RANDOM_ID§-button:hover {
-      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
-      background-color: var(--§RANDOM_ID§-surface-color);
-    }
-    .§RANDOM_ID§-button:active {
-      background-color: var(--§RANDOM_ID§-surface-color-strong);
-    }
-    .§RANDOM_ID§-button::-moz-focus-inner {
-      border: 0;
-    }
-    /* Hidden menu items */
-    #§RANDOM_ID§-graph-select-div {
-      display: none;
-    }
-    #§RANDOM_ID§-node-size-norm-div {
-      display: none;
-    }
-    #§RANDOM_ID§-edge-size-norm-div {
-      display: none;
-    }
+  .§RANDOM_ID§-select:after {
+    cursor: pointer;
+  }
 
-    /* Graph */
-    #§RANDOM_ID§-tooltip-div {
-      font-size: 10px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42001;
-      opacity: 0;
-      visibility: hidden;
-      position: absolute !important;
-      max-width: 40%;
-      padding: 5px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: var(--§RANDOM_ID§-tooltip-text);
-      background-color: var(--§RANDOM_ID§-tooltip-background);
-      border-radius: 4px;
-      border: 1px solid var(--§RANDOM_ID§-border-color);
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button, #§RANDOM_ID§-details-toggle-button, #§RANDOM_ID§-progress-container {
-      font-size: 14px;
-      font-family: "Lucida Console", Monaco, monospace;
-      z-index: 42000;
-      cursor: pointer;
-      position: absolute;
-      color: var(--§RANDOM_ID§-text-color);
-      background-color: var(--§RANDOM_ID§-surface-color-overlay);
-      border-radius: 4px;
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
-      line-height: normal;
-      box-sizing: content-box;
-    }
-    #§RANDOM_ID§-menu-toggle-button {
-      top: 0;
-      right: 0;
-      padding-left: 6px;
-      padding-right: 6px;
-      padding-top: 12px;
-      padding-bottom: 12px;
-      border-top: 0px;
-      border-right: 0px;
-      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
-      border-left: 1px solid var(--§RANDOM_ID§-border-color);
-    }
-    #§RANDOM_ID§-details-toggle-button {
-      bottom: 0;
-      left: 0;
-      padding-left: 19px;
-      padding-right: 19px;
-      padding-top: 0.5px;
-      padding-bottom: 2px;
-      border-top: 1px solid var(--§RANDOM_ID§-border-color);
-      border-right: 1px solid var(--§RANDOM_ID§-border-color);
-      border-bottom: 0px;
-      border-left: 0px;
-    }
-    #§RANDOM_ID§-progress-container {
-      font-size: 10px;
-      text-align: center;
-      top: 46%;
-      left: 15%;
-      width: 70%;
-      padding: 8px;
-      border: none;
-      box-shadow: none;
-    }
+  .§RANDOM_ID§-button {
+    cursor: pointer;
+    outline: none;
+    font-size: 8px;
+    font-family: "Lucida Console", Monaco, monospace;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-muted);
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-radius: 4px;
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
+    box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
+  }
 
-    .§RANDOM_ID§-progress-bar-outer {
-      border: 1px solid var(--§RANDOM_ID§-progress-border);
-      border-radius: 4px;
-      margin-top: 1ex;
-      padding: 1px;
-    }
-    .§RANDOM_ID§-progress-bar-inner {
-      background-color: var(--§RANDOM_ID§-progress-fill);
-      width: 0%;
-      height: 8px;
-      border-radius: 3px;
-    }
+  .§RANDOM_ID§-button:hover {
+    border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+    background-color: var(--§RANDOM_ID§-surface-color);
+  }
 
-    /* Details */
-    #§RANDOM_ID§-details-user-provided {
-      margin-top: 3px;
-      padding-top: 3.5px;
-      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
-      line-height: normal;
-      box-sizing: content-box;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    #§RANDOM_ID§-details-user-provided ul {
-      list-style-position: inside;
-      padding-left: 6px;
-    }
-  </style>
+  .§RANDOM_ID§-button:active {
+    background-color: var(--§RANDOM_ID§-surface-color-strong);
+  }
 
-  <div id="§RANDOM_ID§-main-div">
-    <div id="§RANDOM_ID§-tooltip-div"></div>
+  .§RANDOM_ID§-button::-moz-focus-inner {
+    border: 0;
+  }
 
-    <div id="§RANDOM_ID§-left-div">
-      <div id="§RANDOM_ID§-left-inner-div">
-        <div id="§RANDOM_ID§-graph-div"></div>
-        <div id="§RANDOM_ID§-details-div">
-          <div id="§RANDOM_ID§-details-head">
-            Details for selected element
-          </div>
-          <div id="§RANDOM_ID§-details-body">
-          </div>
+  /* Hidden menu items */
+  #§RANDOM_ID§-graph-select-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-node-size-norm-div {
+    display: none;
+  }
+
+  #§RANDOM_ID§-edge-size-norm-div {
+    display: none;
+  }
+
+  /* Graph */
+  #§RANDOM_ID§-tooltip-div {
+    font-size: 10px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42001;
+    opacity: 0;
+    visibility: hidden;
+    position: absolute !important;
+    max-width: 40%;
+    padding: 5px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--§RANDOM_ID§-tooltip-text);
+    background-color: var(--§RANDOM_ID§-tooltip-background);
+    border-radius: 4px;
+    border: 1px solid var(--§RANDOM_ID§-border-color);
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button,
+  #§RANDOM_ID§-details-toggle-button,
+  #§RANDOM_ID§-progress-container {
+    font-size: 14px;
+    font-family: "Lucida Console", Monaco, monospace;
+    z-index: 42000;
+    cursor: pointer;
+    position: absolute;
+    color: var(--§RANDOM_ID§-text-color);
+    background-color: var(--§RANDOM_ID§-surface-color-overlay);
+    border-radius: 4px;
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
+    line-height: normal;
+    box-sizing: content-box;
+  }
+
+  #§RANDOM_ID§-menu-toggle-button {
+    top: 0;
+    right: 0;
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-top: 0px;
+    border-right: 0px;
+    border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+    border-left: 1px solid var(--§RANDOM_ID§-border-color);
+  }
+
+  #§RANDOM_ID§-details-toggle-button {
+    bottom: 0;
+    left: 0;
+    padding-left: 19px;
+    padding-right: 19px;
+    padding-top: 0.5px;
+    padding-bottom: 2px;
+    border-top: 1px solid var(--§RANDOM_ID§-border-color);
+    border-right: 1px solid var(--§RANDOM_ID§-border-color);
+    border-bottom: 0px;
+    border-left: 0px;
+  }
+
+  #§RANDOM_ID§-progress-container {
+    font-size: 10px;
+    text-align: center;
+    top: 46%;
+    left: 15%;
+    width: 70%;
+    padding: 8px;
+    border: none;
+    box-shadow: none;
+  }
+
+  .§RANDOM_ID§-progress-bar-outer {
+    border: 1px solid var(--§RANDOM_ID§-progress-border);
+    border-radius: 4px;
+    margin-top: 1ex;
+    padding: 1px;
+  }
+
+  .§RANDOM_ID§-progress-bar-inner {
+    background-color: var(--§RANDOM_ID§-progress-fill);
+    width: 0%;
+    height: 8px;
+    border-radius: 3px;
+  }
+
+  /* Details */
+  #§RANDOM_ID§-details-user-provided {
+    margin-top: 3px;
+    padding-top: 3.5px;
+    border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
+    line-height: normal;
+    box-sizing: content-box;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  #§RANDOM_ID§-details-user-provided ul {
+    list-style-position: inside;
+    padding-left: 6px;
+  }
+
+  /* Legend */
+
+  #legend {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+  }
+</style>
+
+<div id="§RANDOM_ID§-main-div">
+  <div id="legend">§LEGEND-CODE§</div>
+  <div id="§RANDOM_ID§-tooltip-div"></div>
+
+  <div id="§RANDOM_ID§-left-div">
+    <div id="§RANDOM_ID§-left-inner-div">
+      <div id="§RANDOM_ID§-graph-div"></div>
+      <div id="§RANDOM_ID§-details-div">
+        <div id="§RANDOM_ID§-details-head">
+          Details for selected element
+        </div>
+        <div id="§RANDOM_ID§-details-body">
         </div>
       </div>
     </div>
+  </div>
 
-    <div id="§RANDOM_ID§-right-div">
-      <div id="§RANDOM_ID§-right-inner-div">
-        <!-- Menu: General -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-general-head">
-          General
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-general-body">
-          <!-- Sub-menu: State -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              App state
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-reset"
-                      type="button">Reset</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Display mode (fullscreen or not) -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Display mode
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-fullscreen-button"
-                      type="button">Enter full screen</button>
-            </div>
-          </div>
-          <!-- Sub-menu: Export -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Export
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-svg"
-                      type="button">SVG</button>
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-png"
-                      type="button">PNG</button>
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-jpg"
-                      type="button">JPG</button>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Data -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-data-head">
-          Data selection
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-data-body">
-          <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
-          <div id="§RANDOM_ID§-graph-select-div">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Graph
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-graph-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node label text -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Node label text
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-label-data-source-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Edge label text -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Edge label text
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-edge-label-data-source-select"></select>
-            </div>
-          </div>
-          <!-- Sub-menu: Node size -->
+  <div id="§RANDOM_ID§-right-div">
+    <div id="§RANDOM_ID§-right-inner-div">
+      <!-- Menu: General -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-general-head">
+        General
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-general-body">
+        <!-- Sub-menu: State -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Node size
+            App state
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-reset" type="button">Reset</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Display mode (fullscreen or not) -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Display mode
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-fullscreen-button" type="button">Enter full
+              screen</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Export -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Export
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-svg" type="button">SVG</button>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-png" type="button">PNG</button>
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-jpg" type="button">JPG</button>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Data -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-data-head">
+        Data selection
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-data-body">
+        <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
+        <div id="§RANDOM_ID§-graph-select-div">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Graph
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-graph-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node label text -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Node label text
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-label-data-source-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Edge label text -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Edge label text
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-edge-label-data-source-select"></select>
+          </div>
+        </div>
+        <!-- Sub-menu: Node size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Node size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-node-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-node-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-min-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-normalization-max-slider" type="range"
+                min="0.01" max="300.0" step="0.01">
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Edge size -->
+        <div class="§RANDOM_ID§-menu-subitem-head">
+          Edge size
+        </div>
+        <div class="§RANDOM_ID§-menu-subitem-body">
+          <div>
+            <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-edge-size-data-source-select"></select>
+          </div>
+          <div class="§RANDOM_ID§-labeled-input">
+            <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-size-normalization-checkbox" type="checkbox">
+            <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
+          </div>
+          <div id="§RANDOM_ID§-edge-size-norm-div">
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-min-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+            <div>
+              <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-normalization-max-slider" type="range"
+                min="0.01" max="50.0" step="0.01">
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Nodes -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-head">
+        Nodes
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-checkbox">Show nodes</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
             <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-node-size-data-source-select"></select>
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Position -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Position
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <button class="§RANDOM_ID§-button" id="§RANDOM_ID§-node-release-button" type="button">Release fixed
+              nodes</button>
+          </div>
+        </div>
+        <!-- Sub-menu: Drag behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Drag behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-drag-fix-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-hover-neighborhood-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-hover-neighborhood-checkbox">Show
+                neighborhood</label>
             </div>
             <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-node-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-node-size-normalization-checkbox">Normalize</label>
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
             </div>
-            <div id="§RANDOM_ID§-node-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-min-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-normalization-max-slider"
-                       type="range" min="0.01" max="300.0" step="0.01">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Node images -->
+      <div id="§RANDOM_ID§-node-image-meta-control">
+        <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-image-head">
+          Node images
+        </div>
+        <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-image-body">
+          <!-- Sub-menu: Visibility -->
+          <div>
+            <div class="§RANDOM_ID§-menu-subitem-head">
+              Visibility
+            </div>
+            <div class="§RANDOM_ID§-menu-subitem-body">
+              <div class="§RANDOM_ID§-labeled-input">
+                <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-image-checkbox" type="checkbox">
+                <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
               </div>
             </div>
           </div>
-          <!-- Sub-menu: Edge size -->
+          <!-- Sub-menu: Size -->
+          <div>
+            <div class="§RANDOM_ID§-menu-subitem-head">
+              Size
+            </div>
+            <div class="§RANDOM_ID§-menu-subitem-body">
+              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-image-size-factor-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-image-size-factor-slider" type="range" min="0.01"
+                max="5.0" step="0.01">
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Node labels -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-node-label-head">
+        Node labels
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-node-label-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
           <div class="§RANDOM_ID§-menu-subitem-head">
-            Edge size
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-node-label-border-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-label-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-label-size-factor-slider" type="range" min="0.01"
+              max="5.0" step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Rotation -->
+        <div id="§RANDOM_ID§-node-label-rotation">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Rotation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Angle</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-node-label-rotation-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-node-label-rotation-slider" type="range" min="0.0"
+              max="359.0" step="1.0">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Edges -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-edge-head">
+        Edges
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-edge-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-checkbox">Show edges</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-size-factor-slider" type="range" min="0.01" max="5.0"
+              step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Form -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Form
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-curvature-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-curvature-slider" type="range" min="-1.2" max="1.2"
+              step="0.02">
+          </div>
+        </div>
+        <!-- Sub-menu: Hover behavior -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Hover behavior
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-hover-tooltip-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if
+                provided)</label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Edge labels -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-edge-label-head">
+        Edge labels
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-edge-label-body">
+        <!-- Sub-menu: Visibility -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Visibility
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-label-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-label-checkbox">Show edge labels</label>
+            </div>
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-edge-label-border-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-edge-label-border-checkbox">Show borders</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Size -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Size
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-label-size-factor-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-label-size-factor-slider" type="range" min="0.01"
+              max="5.0" step="0.01">
+          </div>
+        </div>
+        <!-- Sub-menu: Rotation -->
+        <div id="§RANDOM_ID§-edge-label-rotation">
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Rotation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <span class="§RANDOM_ID§-slider-text-left">Angle</span>
+            <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-edge-label-rotation-text"></span>
+            <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-edge-label-rotation-slider" type="range" min="0.0"
+              max="359.0" step="1.0">
+          </div>
+        </div>
+      </div>
+      <!-- Menu: Layout algorithm -->
+      <div class="§RANDOM_ID§-menu-item-head" id="§RANDOM_ID§-layout-algorithm-head">
+        Layout algorithm
+      </div>
+      <div class="§RANDOM_ID§-menu-item-body" id="§RANDOM_ID§-layout-algorithm-body">
+        <!-- Sub-menu: Simulation -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Simulation
+          </div>
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div class="§RANDOM_ID§-labeled-input">
+              <input class="§RANDOM_ID§-checkbox" id="§RANDOM_ID§-simulation-active-checkbox" type="checkbox">
+              <label class="§RANDOM_ID§-label" for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
+            </div>
+          </div>
+        </div>
+        <!-- Sub-menu: Algorithm -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Algorithm
           </div>
           <div class="§RANDOM_ID§-menu-subitem-body">
             <div>
-              <select class="§RANDOM_ID§-select"
-                      id="§RANDOM_ID§-edge-size-data-source-select"></select>
-            </div>
-            <div class="§RANDOM_ID§-labeled-input">
-              <input class="§RANDOM_ID§-checkbox"
-                     id="§RANDOM_ID§-edge-size-normalization-checkbox"
-                     type="checkbox">
-              <label class="§RANDOM_ID§-label"
-                     for="§RANDOM_ID§-edge-size-normalization-checkbox">Normalize</label>
-            </div>
-            <div id="§RANDOM_ID§-edge-size-norm-div">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Minimum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-min-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-min-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Maximum</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-size-normalization-max-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-edge-size-normalization-max-slider"
-                       type="range" min="0.01" max="50.0" step="0.01">
-              </div>
+              <select class="§RANDOM_ID§-select" id="§RANDOM_ID§-layout-algorithm-select"></select>
             </div>
           </div>
         </div>
-        <!-- Menu: Nodes -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-head">
-          Nodes
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-checkbox">Show nodes</label>
-              </div>
-            </div>
+        <!-- Sub-menu: Parameters -->
+        <div>
+          <div class="§RANDOM_ID§-menu-subitem-head">
+            Parameters
           </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
+          <div class="§RANDOM_ID§-menu-subitem-body">
+            <div id="§RANDOM_ID§-gravitational-constant-div">
+              <span class="§RANDOM_ID§-slider-text-left">Gravitational constant</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-gravitational-constant-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-gravitational-constant-slider" type="range" min="-50000"
+                max="0" step="1" style="direction:rtl;">
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div>
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
-              </div>
+            <div id="§RANDOM_ID§-spring-length-div">
+              <span class="§RANDOM_ID§-slider-text-left">Spring length</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-spring-length-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-spring-length-slider" type="range" min="0.0" max="500"
+                step="0.1">
             </div>
-          </div>
-          <!-- Sub-menu: Position -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Position
+            <div id="§RANDOM_ID§-spring-constant-div">
+              <span class="§RANDOM_ID§-slider-text-left">Spring constant</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-spring-constant-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-spring-constant-slider" type="range" min="0.0" max="1.0"
+                step="0.01">
             </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <button class="§RANDOM_ID§-button"
-                      id="§RANDOM_ID§-node-release-button"
-                      type="button">Release fixed nodes</button>
+            <div id="§RANDOM_ID§-avoid-overlap-div">
+              <span class="§RANDOM_ID§-slider-text-left">Avoid overlap</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-avoid-overlap-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-avoid-overlap-slider" type="range" min="0.0" max="1.0"
+                step="0.01">
             </div>
-          </div>
-          <!-- Sub-menu: Drag behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Drag behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-drag-fix-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-drag-fix-checkbox">Fix node position</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-hover-neighborhood-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-hover-neighborhood-checkbox">Show neighborhood</label>
-              </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-hover-tooltip-checkbox">Show tooltips (if provided)</label>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Node images -->
-        <div id="§RANDOM_ID§-node-image-meta-control">
-          <div class="§RANDOM_ID§-menu-item-head"
-               id="§RANDOM_ID§-node-image-head">
-            Node images
-          </div>
-          <div class="§RANDOM_ID§-menu-item-body"
-               id="§RANDOM_ID§-node-image-body">
-            <!-- Sub-menu: Visibility -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Visibility
-              </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
-                <div class="§RANDOM_ID§-labeled-input">
-                  <input class="§RANDOM_ID§-checkbox"
-                         id="§RANDOM_ID§-node-image-checkbox"
-                         type="checkbox">
-                  <label class="§RANDOM_ID§-label"
-                         for="§RANDOM_ID§-node-image-checkbox">Show node images</label>
-                </div>
-              </div>
-            </div>
-            <!-- Sub-menu: Size -->
-            <div>
-              <div class="§RANDOM_ID§-menu-subitem-head">
-                Size
-              </div>
-              <div class="§RANDOM_ID§-menu-subitem-body">
-                <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-node-image-size-factor-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-node-image-size-factor-slider"
-                       type="range" min="0.01" max="5.0" step="0.01">
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Node labels -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-node-label-head">
-          Node labels
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-node-label-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-checkbox">Show node labels</label>
-              </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-node-label-border-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-node-label-border-checkbox">Show borders</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-node-label-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-node-label-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Rotation -->
-          <div id="§RANDOM_ID§-node-label-rotation">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Rotation
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Angle</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-node-label-rotation-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-node-label-rotation-slider"
-                     type="range" min="0.0" max="359.0" step="1.0">
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Edges -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-edge-head">
-          Edges
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-edge-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-checkbox">Show edges</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Form -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Form
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Curvature</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-curvature-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-curvature-slider"
-                     type="range" min="-1.2" max="1.2" step="0.02">
-            </div>
-          </div>
-          <!-- Sub-menu: Hover behavior -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Hover behavior
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-hover-tooltip-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-hover-tooltip-checkbox">Show tooltips (if provided)</label>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Edge labels -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-edge-label-head">
-          Edge labels
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-edge-label-body">
-          <!-- Sub-menu: Visibility -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Visibility
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-label-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-label-checkbox">Show edge labels</label>
-              </div>
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-edge-label-border-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-edge-label-border-checkbox">Show borders</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Size -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Size
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Scaling factor</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                    id="§RANDOM_ID§-edge-label-size-factor-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-label-size-factor-slider"
-                     type="range" min="0.01" max="5.0" step="0.01">
-            </div>
-          </div>
-          <!-- Sub-menu: Rotation -->
-          <div id="§RANDOM_ID§-edge-label-rotation">
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Rotation
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <span class="§RANDOM_ID§-slider-text-left">Angle</span>
-              <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-edge-label-rotation-text"></span>
-              <input class="§RANDOM_ID§-slider"
-                     id="§RANDOM_ID§-edge-label-rotation-slider"
-                     type="range" min="0.0" max="359.0" step="1.0">
-            </div>
-          </div>
-        </div>
-        <!-- Menu: Layout algorithm -->
-        <div class="§RANDOM_ID§-menu-item-head"
-             id="§RANDOM_ID§-layout-algorithm-head">
-          Layout algorithm
-        </div>
-        <div class="§RANDOM_ID§-menu-item-body"
-             id="§RANDOM_ID§-layout-algorithm-body">
-          <!-- Sub-menu: Simulation -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Simulation
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div class="§RANDOM_ID§-labeled-input">
-                <input class="§RANDOM_ID§-checkbox"
-                       id="§RANDOM_ID§-simulation-active-checkbox"
-                       type="checkbox">
-                <label class="§RANDOM_ID§-label"
-                       for="§RANDOM_ID§-simulation-active-checkbox">Active</label>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Algorithm -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Algorithm
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div>
-                <select class="§RANDOM_ID§-select"
-                        id="§RANDOM_ID§-layout-algorithm-select"></select>
-              </div>
-            </div>
-          </div>
-          <!-- Sub-menu: Parameters -->
-          <div>
-            <div class="§RANDOM_ID§-menu-subitem-head">
-              Parameters
-            </div>
-            <div class="§RANDOM_ID§-menu-subitem-body">
-              <div id="§RANDOM_ID§-gravitational-constant-div">
-                <span class="§RANDOM_ID§-slider-text-left">Gravitational constant</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-gravitational-constant-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-gravitational-constant-slider"
-                       type="range" min="-50000" max="0" step="1"
-                       style="direction:rtl;">
-              </div>
-              <div id="§RANDOM_ID§-spring-length-div">
-                <span class="§RANDOM_ID§-slider-text-left">Spring length</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-spring-length-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-spring-length-slider"
-                       type="range" min="0.0" max="500" step="0.1">
-              </div>
-              <div id="§RANDOM_ID§-spring-constant-div">
-                <span class="§RANDOM_ID§-slider-text-left">Spring constant</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-spring-constant-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-spring-constant-slider"
-                       type="range" min="0.0" max="1.0" step="0.01">
-              </div>
-              <div id="§RANDOM_ID§-avoid-overlap-div">
-                <span class="§RANDOM_ID§-slider-text-left">Avoid overlap</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-avoid-overlap-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-avoid-overlap-slider"
-                       type="range" min="0.0" max="1.0" step="0.01">
-              </div>
-              <div id="§RANDOM_ID§-central-gravity-div">
-                <span class="§RANDOM_ID§-slider-text-left">Central gravity</span>
-                <span class="§RANDOM_ID§-slider-text-right"
-                      id="§RANDOM_ID§-central-gravity-text"></span>
-                <input class="§RANDOM_ID§-slider"
-                       id="§RANDOM_ID§-central-gravity-slider"
-                       type="range" min="0.0" max="10.0" step="0.001">
-              </div>
+            <div id="§RANDOM_ID§-central-gravity-div">
+              <span class="§RANDOM_ID§-slider-text-left">Central gravity</span>
+              <span class="§RANDOM_ID§-slider-text-right" id="§RANDOM_ID§-central-gravity-text"></span>
+              <input class="§RANDOM_ID§-slider" id="§RANDOM_ID§-central-gravity-slider" type="range" min="0.0"
+                max="10.0" step="0.001">
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+</div>
 
-  <script charset="utf-8" type="text/javascript">
-    if(typeof(require) === "undefined"){
+<script charset="utf-8" type="text/javascript">
+  if (typeof (require) === "undefined") {
       §LOAD_REQUIRE§
-    }
+  }
     §DEFINE_VIS§
 
-    require(["gravis-vis-network"], function(vis){
-      // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
-      "use strict";
+  require(["gravis-vis-network"], function (vis) {
+    // Strict mode: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode
+    "use strict";
 
-      const state = {
-        manager:{
-          // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
+    const state = {
+      manager: {
+        // Data generation process: 1) Fetch state.rawData, 2) derive state.parsedData, 3) derive state.shownData
 
-          // 1) Fetch state.rawData
-          fetchRawDataFromTemplating(){
-            state.rawData = §DATA§;
-            // Data selection and normalization
-            state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
-            state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
-            state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
-            state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
-            state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
-            state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
-            state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
-            state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
-            state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
-            state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
-            // Containers
-            state.graphContainerHeight = §GRAPH_HEIGHT§;
-            state.detailsContainerHeight = §DETAILS_HEIGHT§;
-            state.showDetails = §SHOW_DETAILS§,
-            state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
-            state.showMenu = §SHOW_MENU§,
-            state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
-            state.useDarkMode = §USE_DARK_MODE§,
-            // Nodes
-            state.showNodes = §SHOW_NODE§;
-            state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
-            state.nodeDragFix = §NODE_DRAG_FIX§;
-            state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
-            state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
-            state.showNodeImages = §SHOW_NODE_IMAGE§;
-            state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
-            state.showNodeLabels = §SHOW_NODE_LABEL§;
-            state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
-            state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
-            state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
-            state.nodeLabelFont = §NODE_LABEL_FONT§;
-            // Edges
-            state.showEdges = §SHOW_EDGE§;
-            state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
-            state.edgeCurvature = §EDGE_CURVATURE§;
-            state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
-            state.showEdgeLabels = §SHOW_EDGE_LABEL§;
-            state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
-            state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
-            state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
-            state.edgeLabelFont = §EDGE_LABEL_FONT§;
-            // Layout algorithm
-            state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
-            state.layoutAlgorithm = §LAYOUT_ALGORITHM§;
-            state.gravitationalConstant = §GRAVITATIONLAL_CONSTANT§;
-            state.centralGravity = §CENTRAL_GRAVITY§;
-            state.springLength = §SPRING_LENGTH§;
-            state.springConstant = §SPRING_CONSTANT§;
-            state.avoidOverlap = §AVOID_OVERLAP§;
-            // Other
-            state.initZoomFactor = §ZOOM_FACTOR§;
-            state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
-          },
-
-          // 2) Derive state.parsedData from state.givenData
-          rawDataParser:{
-            getBool(obj, prop, def){
-              try{
-                const value = obj[prop];
-                if(value == "true" || value == "True"){
-                  value = true;
-                } else if(value == "false" || value == "False"){
-                  value = false;
-                }
-                if(value !== true && value !== false){
-                  throw "Invalid value. Not a bool.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def
-            },
-
-            getString(obj, prop, def) {
-              try{
-                const value = String(obj[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-              return def;
-            },
-
-            getArrayLengthOrZero(array){
-              try{
-                const value = parseInt(array.length);
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-
-            getObjectLengthOrZero(obj){
-              try{
-                const value = Object.keys(obj).length;
-                if(!((value + 1) > 0)){
-                  throw "Invalid value. Not a proper length.";
-                }
-                return value;
-              } catch(e){
-                return 0;
-              }
-            },
-
-            createUniqueEdgeId(sourceId, targetId, knownEdgeIds){
-              let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
-                newEdgeId = newEdgeIdBase,
-                multiEdgeCounter = 1;
-              for(let i=1; knownEdgeIds.has(newEdgeId); i++){
-                newEdgeId = newEdgeIdBase + "_" + String(i);
-                multiEdgeCounter += 1;
-              }
-              knownEdgeIds.add(newEdgeId);
-              return {"id": newEdgeId, "count": multiEdgeCounter}
-            },
-          },
-
-          rawMetadataParser:{
-            getString(obj, prop, def){
-              try{
-                const value = String(obj.metadata[prop]);
-                if(value === "undefined"){
-                  throw "Invalid value. Not a proper string.";
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getShape(obj, prop, def){
-              const givenShape = state.manager.rawMetadataParser.getString(obj, prop, def);
-              let visShape = def;
-              if(givenShape === "circle"){
-                visShape = "dot";
-              } else if(givenShape === "rectangle"){
-                visShape = "square";
-              } else if(givenShape === "hexagon"){
-                visShape = "hexagon";
-              }
-              return visShape;
-            },
-            getColor(obj, prop, def){
-              function isBodyidColor(strColor) {
-                const sty = new Option().style;
-                sty.color = strColor;
-                return sty.color !== "";
-              }
-              try{
-                const value = obj.metadata[prop];
-                if(!isBodyidColor(value)){
-                  throw "Invalid value. Not a color."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null){
-                  throw "Invalid value. Not a finite number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFiniteNumberOrNull(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value)){  // Note: isFinite(null) gives true
-                  throw "Invalid value. Not a finite number or null."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            getFinitePositiveNumber(obj, prop, def){
-              try{
-                const value = parseFloat(obj.metadata[prop]);
-                if(!isFinite(value) || value === null || value < 0.0){
-                  throw "Invalid value. Not a finite positive number."
-                }
-                return value;
-              } catch(e){
-                return def;
-              }
-            },
-            collectOtherMetadata(sourceObject, targetObject, definedMetadata){
-              if(typeof(sourceObject) !== "undefined" && typeof(sourceObject.metadata) !== "undefined"){
-                const properties = Object.keys(sourceObject.metadata);
-                for(let i=0; i<properties.length; i++){
-                  const property = properties[i];
-                  if(!definedMetadata.has(property)){
-                    targetObject[property] = sourceObject.metadata[property];
-                  }
-                }
-              }
-            },
-          },
-
-          propertyClassifier:{
-            numeric: null,
-            nonNumeric: null,
-            init(){
-              this.numeric = new Set(),
-              this.nonNumeric = new Set();
-            },
-            isNumeric(d){
-              return d === null || typeof(d) === "undefined" || String(parseFloat(d)) === String(d);
-            },
-            inspect(object, property){
-              const value = object[property];
-              if(!this.nonNumeric.has(property)){
-                if(this.isNumeric(value)){
-                  this.numeric.add(property);
-                } else{
-                  this.nonNumeric.add(property);
-                  this.numeric.delete(property);
-                }
-              }
-            }
-          },
-
-          replaceStringVariables(givenString, givenItem, variables){
-            let newString = givenString;
-            for(let i=0; i<variables.length; i++){
-              let variable = variables[i],
-                variableText = "$" + variable;
-              if(variable === "x"){
-                variable = "fx";
-              } else if (variable === "y"){
-                variable = "fy";
-              }
-              let insertedText = String(givenItem[variable]);
-              if(insertedText === "undefined"){
-                insertedText = "";
-              }
-              newString = newString.replace(variableText, insertedText);
-            }
-            return newString;
-          },
-
-          parseGeneral(givenData, parsedData){
-            const generalDefaults = state.useDarkMode ? {
-              background_color: "#1f1f25",
-              arrow_color: "#7ddba3",
-              node_color: "#7ddba3",
-              node_border_color: "#f0f0f5",
-              node_label_color: "#f0f0f5",
-              edge_color: "#b5b8c5",
-              edge_label_color: "#f0f0f5",
-            } : {
-              background_color: "white",
-              arrow_color: "black",
-              node_color: "black",
-              node_border_color: "black",
-              node_label_color: "black",
-              edge_color: "black",
-              edge_label_color: "black",
-            };
-            parsedData.general = {
-              // General
-              directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
-              label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
-              arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
-              // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
-              node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
-              node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
-              node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
-              node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
-              node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
-              node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
-              node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
-              node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
-              node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
-              node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
-              contains_node_hover: false,
-              contains_node_click: false,
-              contains_node_image: false,
-              // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
-              edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
-              edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
-              edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
-              edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
-              edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
-              contains_edge_hover: false,
-              contains_edge_click: false,
-            };
-            if(!parsedData.general.directed){
-              parsedData.general.arrow_size = 0.0;
-            }
-          },
-
-          parseNodes(givenData, parsedData){
-            const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
-              nodeIdToObjectMap = new Map(),
-              nodeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "shape", "border_color", "border_size",
-                 "label_color", "label_size", "hover", "click", "image", "x", "y"]),
-              nodeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "shape", "border_color", "border_size",
-                "label_color", "label_size", "image", "x", "y"];
-            state.manager.propertyClassifier.init();
-            try {
-              Object.entries(givenData.nodes);
-            }
-            catch(e){
-               givenData.nodes = {};
-            }
-            for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
-              const parsedNode = {};
-              // data: id, label
-              parsedNode.id = String(givenNodeId);
-              parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
-              // defined metadata
-              parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
-              parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
-              parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
-              parsedNode.shape = state.manager.rawMetadataParser.getShape(givenNode, "shape", parsedData.general.node_shape);
-              parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
-              parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
-              parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
-              parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
-              const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
-              if(image !== ""){
-                parsedNode.image = image;
-                parsedData.general.contains_node_image = true;
-              }
-              if(hover !== ""){
-                parsedNode.hover = hover;
-                parsedData.general.contains_node_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
-              if(click !== ""){
-                parsedNode.click = click;
-                parsedData.general.contains_node_click = true;
-              }
-              const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
-              const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
-              if(x !== null){
-                parsedNode.fx = x;
-              }
-              if(y !== null){
-                parsedNode.fy = y;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
-              // feature classification
-              const parsedNodeProperties = Object.keys(parsedNode);
-              for(let i=0; i<parsedNodeProperties.length; i++){
-                const property = parsedNodeProperties[i],
-                  value = parsedNode[property];
-                state.manager.propertyClassifier.inspect(parsedNode, property);
-              }
-              // variable replacements
-              if(parsedNode.hover){
-                parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
-              }
-              if(parsedNode.click){
-                parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
-              }
-              // store the parsed node
-              parsedData.nodes.push(parsedNode);
-              // data structure for inserting node object references into edge data
-              nodeIdToObjectMap.set(parsedNode.id, parsedNode);
-            }
-            // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            for(let i=0; i<numNodes; i++){
-              const parsedNode = parsedData.nodes[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedNode[property]);
-                parsedNode[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.node_properties = {
-              "node_size_data_sources": numericProperties,
-              "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report empty graph
-            if(!(numNodes > 0)){
-              console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
-            }
-            return nodeIdToObjectMap;
-          },
-
-          parseEdges(givenData, parsedData, nodeIdToObjectMap){
-            let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
-            const knownEdgeIds = new Set(),
-              ignoredEdges = [],
-              edgeDefinedMetadata = new Set(
-                ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
-              edgeReplacementVariables = [
-                "id", "label",
-                "color", "opacity", "size", "label_color", "label_size"];
-            state.manager.propertyClassifier.init();
-            for(let i=0; i<numEdges; i++){
-              const givenEdge = givenData.edges[i],
-                parsedEdge = {},
-                sourceId = String(givenEdge.source),
-                targetId = String(givenEdge.target);
-              // data: source, target, id, multi_edge_counter, label
-              try{
-                const sourceObj = nodeIdToObjectMap.get(sourceId);
-                const targetObj = nodeIdToObjectMap.get(targetId);
-                if(typeof(sourceObj) === "undefined" || typeof(targetObj) === "undefined"){
-                  throw "Invalid node reference.";
-                }
-                parsedEdge.source = sourceObj;
-                parsedEdge.target = targetObj;
-              } catch(e){
-                const ignoredEdge = {
-                  index: i,
-                  source: sourceId,
-                  target: targetId,
-                }
-                ignoredEdges.push(ignoredEdge);
-                continue;
-              }
-              const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
-              parsedEdge.id = result.id;
-              parsedEdge.multi_edge_counter = result.count;
-              parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
-              // defined metadata
-              parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
-              parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
-              parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
-              parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
-              parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
-              const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
-              if(hover !== ""){
-                parsedEdge.hover = hover;
-                parsedData.general.contains_edge_hover = true;
-              }
-              const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
-              if(click !== ""){
-                parsedEdge.click = click;
-                parsedData.general.contains_edge_click = true;
-              }
-              // other metadata
-              const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
-              // feature classification
-              const parsedEdgeProperties = Object.keys(parsedEdge);
-              for(let i=0; i<parsedEdgeProperties.length; i++){
-                const property = parsedEdgeProperties[i],
-                  value = parsedEdge[property];
-                state.manager.propertyClassifier.inspect(parsedEdge, property);
-              }
-              // variable replacements
-              if(parsedEdge.hover){
-                parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
-              }
-              if(parsedEdge.click){
-                parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
-              }
-              // store it
-              parsedData.edges.push(parsedEdge);
-            }
-            // Ensure numeric properties are stored as numbers and remember their extrema
-            const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
-              nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
-              minima = {},
-              maxima = {};
-            numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges);
-            for(let i=0; i<numEdges; i++){
-              const parsedEdge = parsedData.edges[i];
-              for(let p=0; p<numericProperties.length; p++){
-                const property = numericProperties[p],
-                  numericValue = parseFloat(parsedEdge[property]);
-                parsedEdge[property] = numericValue;
-                if(isFinite(numericValue)){
-                  if(typeof(minima[property]) === "undefined" || numericValue < minima[property]){
-                    minima[property] = numericValue;
-                  }
-                  if(typeof(maxima[property]) === "undefined" || numericValue > maxima[property]){
-                    maxima[property] = numericValue;
-                  }
-                }
-              }
-            }
-            // Store feature classification and extrema
-            parsedData.general.edge_properties = {
-              "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
-              "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
-                item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
-              "minima": minima,
-              "maxima": maxima,
-            }
-            // Report invalid edges
-            if(ignoredEdges.length > 0){
-              let message = undefined;
-              if(ignoredEdges.length == 1){
-                message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
-                  "refers to a node that is not part of the node list:\n";
-              } else{
-                message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
-                  "refer to a node that is not part of the node list:\n";
-              }
-              for(let i=0; i<ignoredEdges.length; i++){
-                const ignoredEdge = ignoredEdges[i];
-                message += '- Edge with index ' + ignoredEdge.index;
-                message += ', source "' + ignoredEdge.source;
-                message += '", target "' + ignoredEdge.target + '"\n';
-                if(i==9){
-                  message += '...';
-                  break;
-                }
-              }
-              console.log(message);
-            }
-          },
-
-          parseChosenData(chosenGraphNumber){
-            let givenData = state.rawData[chosenGraphNumber],
-              parsedData = {
-                general: {},
-                nodes: [],
-                edges: [],
-                adjacency: null,
-                incidence: null,
-              };
-            if(!givenData || givenData === null){
-              givenData = [];
-            }
-            // a) General
-            state.manager.parseGeneral(givenData, parsedData);
-            // b) Nodes
-            const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
-            // c) Edges
-            state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
-            // Update state
-            state.parsedData = parsedData;
-            state.currentGraphParts = {};
-            // Update UI: show or hide containers
-            ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
-            ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
-          },
-
-          // 3) Derive state.shownData from state.parsedData
-          createNodeToAdjacentNodesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(sourceNode, targetNode){
-                let adjacentNodes = this.map.get(sourceNode);
-                if(adjacentNodes){
-                  adjacentNodes.add(targetNode);
-                } else{
-                  adjacentNodes = new Set([targetNode]);
-                  this.map.set(sourceNode, adjacentNodes);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          createNodeToIncidentEdgesMap(){
-            const dataStructure = {
-              map: new Map(),
-              add(node, edge){
-                let incidentEdges = this.map.get(node);
-                if(incidentEdges){
-                  incidentEdges.add(edge);
-                } else{
-                  incidentEdges = new Set([edge]);
-                  this.map.set(node, incidentEdges);
-                }
-              },
-            }
-            return dataStructure;
-          },
-
-          hoverTextToHtml(text) {
-            // https://visjs.github.io/vis-network/examples/network/other/html-in-titles.html
-            const div = document.createElement("div");
-            div.innerHTML = text;
-            return div;
-          },
-
-          prepareShownData(){
-            const numNodes = state.parsedData.nodes.length,
-              numEdges = state.parsedData.edges.length;
-            state.shownData = {
-              "general": null,
-              "nodes": new Array(numNodes),
-              "edges": new Array(numEdges),
-            }
-            const nodeIdToObjectMap = new Map(),
-              nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            // a) General
-            state.shownData.general = {
-              "background_color": state.parsedData.general.background_color,
-              "arrow_size": state.parsedData.general.arrow_size,
-              "arrow_color": state.parsedData.general.arrow_color,
-              "directed": state.parsedData.general.directed,
-            };
-            // b) Nodes
-            for(let i=0; i<numNodes; i++){
-              state.shownData.nodes[i] = {};
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.id = parsedNode.id;
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-              shownNode.color = parsedNode.color;
-              shownNode.opacity = parsedNode.opacity;
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              shownNode.shape = parsedNode.shape;
-              shownNode.border_color = parsedNode.border_color;
-              shownNode.border_size = parsedNode.border_size;
-              shownNode.label_color = parsedNode.label_color;
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-              if(typeof(parsedNode.image) !== "undefined"){
-                shownNode.image = parsedNode.image;
-              }
-              if(typeof(parsedNode.hover) !== "undefined"){
-                shownNode.hover = state.manager.hoverTextToHtml(parsedNode.hover);
-              }
-              if(typeof(parsedNode.click) !== "undefined"){
-                shownNode.click = parsedNode.click;
-              }
-              if(typeof(parsedNode.fx) !== "undefined"){
-                shownNode.fx = parsedNode.fx;
-              }
-              if(typeof(parsedNode.fy) !== "undefined"){
-                shownNode.fy = parsedNode.fy;
-              }
-              nodeIdToObjectMap.set(shownNode.id, shownNode);
-              // Derived properties for performance improvement in updateNodePositions
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-              state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
-            }
-            // c) Edges
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
-              nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
-              nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
-            for(let i=0; i<numEdges; i++){
-              state.shownData.edges[i] = {};
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
-              shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
-              shownEdge.id = parsedEdge.id;
-              shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
-              shownEdge.color = parsedEdge.color;
-              shownEdge.opacity = parsedEdge.opacity;
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-              shownEdge.label_color = parsedEdge.label_color;
-              shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
-              if(typeof(parsedEdge.hover) !== "undefined"){
-                shownEdge.hover = state.manager.hoverTextToHtml(parsedEdge.hover);
-              }
-              if(typeof(parsedEdge.click) !== "undefined"){
-                shownEdge.click = parsedEdge.click;
-              }
-              // Derived properties for performance improvement in updateEdgePositions
-              shownEdge.multiEdgeCurvatureFactor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-              // Data structure for highlighting adjacent nodes and incident edges to this node
-              nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
-              nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
-              nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
-              nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
-            }
-            state.shownData.adjacency = nodeToAdjacentNodesMap;
-            state.shownData.incidence = nodeToIncidentEdgesMap;
-          },
-
-          calcSingleNodeSize(parsedNode, nodeSizeNormalizer){
-            const appearanceAdaptionFactor = 0.5;
-            let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
-            if(!isFinite(nodeSize)){
-              nodeSize = state.parsedData.general.node_size;
-            }
-            return nodeSize * state.nodeSizeFactor * appearanceAdaptionFactor;
-          },
-
-          calcSingleNodeSizeDerivatives(shownNode){
-            shownNode.image_size = shownNode.size / 1.42 * state.nodeImageSizeFactor;
-          },
-
-          calcSingleNodeLabelText(parsedNode){
-            return String(parsedNode[state.nodeLabelTextDataSource]);
-          },
-
-          calcSingleNodeLabelSize(parsedNode){
-            return parsedNode.label_size * state.nodeLabelSizeFactor;
-          },
-
-          calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer){
-            let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
-            if(!isFinite(edgeSize)){
-              edgeSize = state.parsedData.general.edge_size;
-            }
-            return edgeSize * state.edgeSizeFactor;
-          },
-
-          calcSingleEdgeCurvatureFactor(parsedEdge){
-            // Caution: Currently a single value is used for all edges instead of these here
-            const appearanceAdaptionFactor = 0.5;
-            return state.edgeCurvature * parsedEdge.multiEdgeCounter * appearanceAdaptionFactor;
-          },
-
-          calcSingleEdgeLabelText(parsedEdge){
-            return String(parsedEdge[state.edgeLabelTextDataSource]);
-          },
-
-          calcSingleEdgeLabelSize(parsedEdge){
-            return parsedEdge.label_size * state.edgeLabelSizeFactor;
-          },
-
-          calcSingleNodeBorderSizeDerivatives(shownNode){
-            shownNode.border_size_half = shownNode.border_size / 2.0;
-          },
-
-          createNodeSizeNormalizer(){
-            let normalizer;
-            if(state.useNodeSizeNormalization){
-              const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
-                dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
-                targetMin = state.nodeSizeNormalizationMin,
-                targetMax = state.nodeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor) || factor === null){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          createEdgeSizeNormalizer(){
-            let normalizer;
-            if(state.useEdgeSizeNormalization){
-              const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
-                dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
-                targetMin = state.edgeSizeNormalizationMin,
-                targetMax = state.edgeSizeNormalizationMax,
-                dataDiff = dataMax - dataMin,
-                targetDiff = targetMax - targetMin;
-              let factor = targetDiff / dataDiff;
-              if(!isFinite(factor)){
-                factor = 0.0;
-              }
-              normalizer = function(val){
-                return (val - dataMin) * factor + targetMin;
-              }
-            } else{
-              normalizer = function(val){
-                return val;
-              }
-            }
-            return normalizer;
-          },
-
-          updateNodeSizes(){
-            // Data
-            const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeSizes();
-          },
-
-          updateNodeLabelTexts(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeLabels();
-          },
-
-          updateNodeLabelSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeLabels();
-          },
-
-          updateNodeImages(){
-            // Data
-            for(let i=0; i<state.parsedData.nodes.length; i++){
-              const parsedNode = state.parsedData.nodes[i],
-                shownNode = state.shownData.nodes[i];
-              state.manager.calcSingleNodeSizeDerivatives(shownNode);
-            }
-            // UI
-            ui.composites.graph.updateNodeImages();
-          },
-
-          updateEdgeSizes(){
-            // Data
-            const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
-            }
-            // UI
-            ui.composites.graph.updateEdgeSizes();
-          },
-
-          updateEdgeCurvatures(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.multiEdgeCurvatureFactor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.updateEdgeCurvatures();
-          },
-
-          updateEdgeLabelTexts(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.updateEdgeLabels();
-          },
-
-          updateEdgeLabelSizes(){
-            // Data
-            for(let i=0; i<state.parsedData.edges.length; i++){
-              const parsedEdge = state.parsedData.edges[i],
-                shownEdge = state.shownData.edges[i];
-              shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
-            }
-            // UI
-            ui.composites.graph.updateEdgeLabels();
-          },
-        }
-      }
-
-      const ui = {
-        symbols:{
-          // Choice of symbols is influenced by their appearance in different browsers
-          // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
-          // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
-          detailsShown: "▾",
-          detailsHidden: "▴",
-          menuShown: "▸",
-          menuHidden: "◂",
-          menuItemActive: "▸",
-          menuItemInactive: "▾",
-        },
-
-        elements:{
+        // 1) Fetch state.rawData
+        fetchRawDataFromTemplating() {
+          state.rawData = §DATA§;
+          // Data selection and normalization
+          state.nodeSizeDataSource = §NODE_SIZE_DATA_SOURCE§;
+          state.useNodeSizeNormalization = §USE_NODE_SIZE_NORMALIZATION§;
+          state.nodeSizeNormalizationMin = §NODE_SIZE_NORMALIZATION_MIN§;
+          state.nodeSizeNormalizationMax = §NODE_SIZE_NORMALIZATION_MAX§;
+          state.nodeLabelTextDataSource = §NODE_LABEL_DATA_SOURCE§;
+          state.edgeSizeDataSource = §EDGE_SIZE_DATA_SOURCE§;
+          state.useEdgeSizeNormalization = §USE_EDGE_SIZE_NORMALIZATION§;
+          state.edgeSizeNormalizationMin = §EDGE_SIZE_NORMALIZATION_MIN§;
+          state.edgeSizeNormalizationMax = §EDGE_SIZE_NORMALIZATION_MAX§;
+          state.edgeLabelTextDataSource = §EDGE_LABEL_DATA_SOURCE§;
           // Containers
-          mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
-          tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
-          leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
-          rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
-          graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
-          detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
-          detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
-          detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
-          // Data sources
-          dataHead: document.getElementById("§RANDOM_ID§-data-head"),
-          dataBody: document.getElementById("§RANDOM_ID§-data-body"),
-          graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
-          graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
-          nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
-          nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
-          nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
-          nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
-          nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
-          nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
-          nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
-          edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
-          edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
-          edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
-          edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
-          edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
-          edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
-          edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
-          // General
-          generalHead: document.getElementById("§RANDOM_ID§-general-head"),
-          generalBody: document.getElementById("§RANDOM_ID§-general-body"),
-          resetButton: document.getElementById("§RANDOM_ID§-reset"),
-          fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
-          svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
-          pngExportButton: document.getElementById("§RANDOM_ID§-png"),
-          jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+          state.graphContainerHeight = §GRAPH_HEIGHT§;
+          state.detailsContainerHeight = §DETAILS_HEIGHT§;
+          state.showDetails = §SHOW_DETAILS§,
+          state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
+          state.showMenu = §SHOW_MENU§,
+          state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+          state.useDarkMode = §USE_DARK_MODE§,
           // Nodes
-          nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
-          nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
-          nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
-          nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
-          nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
-          nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
-          nodeHoverNeighborhoodCheckbox: document.getElementById("§RANDOM_ID§-node-hover-neighborhood-checkbox"),
-          nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
-          nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
-          // Node images
-          nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
-          nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
-          nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
-          nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
-          nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
-          nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
-          // Node labels
-          nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
-          nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
-          nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
-          nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
-          nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
-          nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
-          nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
-          nodeLabelRotationText: document.getElementById("§RANDOM_ID§-node-label-rotation-text"),
-          nodeLabelRotationSlider: document.getElementById("§RANDOM_ID§-node-label-rotation-slider"),
+          state.showNodes = §SHOW_NODE§;
+          state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
+          state.nodeDragFix = §NODE_DRAG_FIX§;
+          state.nodeHoverNeighborhood = §NODE_HOVER_NEIGHBORHOOD§;
+          state.nodeHoverTooltip = §NODE_HOVER_TOOLTIP§;
+          state.showNodeImages = §SHOW_NODE_IMAGE§;
+          state.nodeImageSizeFactor = §NODE_IMAGE_SIZE_FACTOR§;
+          state.showNodeLabels = §SHOW_NODE_LABEL§;
+          state.showNodeLabelBorders = §SHOW_NODE_LABEL_BORDER§;
+          state.nodeLabelSizeFactor = §NODE_LABEL_SIZE_FACTOR§;
+          state.nodeLabelRotation = §NODE_LABEL_ROTATION§;
+          state.nodeLabelFont = §NODE_LABEL_FONT§;
           // Edges
-          edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
-          edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
-          edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
-          edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
-          edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
-          edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
-          edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
-          edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
-          // Edge labels
-          edgeLabelHead: document.getElementById("§RANDOM_ID§-edge-label-head"),
-          edgeLabelBody: document.getElementById("§RANDOM_ID§-edge-label-body"),
-          edgeLabelCheckbox: document.getElementById("§RANDOM_ID§-edge-label-checkbox"),
-          edgeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-edge-label-border-checkbox"),
-          edgeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-label-data-source-select"),
-          edgeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-edge-label-size-factor-text"),
-          edgeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-label-size-factor-slider"),
-          edgeLabelRotationText: document.getElementById("§RANDOM_ID§-edge-label-rotation-text"),
-          edgeLabelRotationSlider: document.getElementById("§RANDOM_ID§-edge-label-rotation-slider"),
+          state.showEdges = §SHOW_EDGE§;
+          state.edgeSizeFactor = §EDGE_SIZE_FACTOR§;
+          state.edgeCurvature = §EDGE_CURVATURE§;
+          state.edgeHoverTooltip = §EDGE_HOVER_TOOLTIP§,
+          state.showEdgeLabels = §SHOW_EDGE_LABEL§;
+          state.showEdgeLabelBorders = §SHOW_EDGE_LABEL_BORDER§;
+          state.edgeLabelSizeFactor = §EDGE_LABEL_SIZE_FACTOR§;
+          state.edgeLabelRotation = §EDGE_LABEL_ROTATION§;
+          state.edgeLabelFont = §EDGE_LABEL_FONT§;
           // Layout algorithm
-          layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
-          layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
-          simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
-          layoutAlgorithmSelection: document.getElementById("§RANDOM_ID§-layout-algorithm-select"),
-          centralGravitySlider: document.getElementById("§RANDOM_ID§-central-gravity-slider"),
-          centralGravityText: document.getElementById("§RANDOM_ID§-central-gravity-text"),
-          springLengthSlider: document.getElementById("§RANDOM_ID§-spring-length-slider"),
-          springLengthText: document.getElementById("§RANDOM_ID§-spring-length-text"),
-          springConstantSlider: document.getElementById("§RANDOM_ID§-spring-constant-slider"),
-          springConstantText: document.getElementById("§RANDOM_ID§-spring-constant-text"),
-          gravitationalConstantContainer: document.getElementById("§RANDOM_ID§-gravitational-constant-div"),
-          gravitationalConstantSlider: document.getElementById("§RANDOM_ID§-gravitational-constant-slider"),
-          gravitationalConstantText: document.getElementById("§RANDOM_ID§-gravitational-constant-text"),
-          avoidOverlapContainer: document.getElementById("§RANDOM_ID§-avoid-overlap-div"),
-          avoidOverlapSlider: document.getElementById("§RANDOM_ID§-avoid-overlap-slider"),
-          avoidOverlapText: document.getElementById("§RANDOM_ID§-avoid-overlap-text"),
+          state.layoutAlgorithmActive = §LAYOUT_ALGORITHM_ACTIVE§;
+          state.layoutAlgorithm = §LAYOUT_ALGORITHM§;
+          state.gravitationalConstant = §GRAVITATIONLAL_CONSTANT§;
+          state.centralGravity = §CENTRAL_GRAVITY§;
+          state.springLength = §SPRING_LENGTH§;
+          state.springConstant = §SPRING_CONSTANT§;
+          state.avoidOverlap = §AVOID_OVERLAP§;
+          // Other
+          state.initZoomFactor = §ZOOM_FACTOR§;
+          state.largeGraphThreshold = §LARGE_GRAPH_THRESHOLD§;
         },
 
-        composites:{
-          responsiveContainer:{
-            init(){
-              // Delete all contained items (relevant only for reset, not first creation)
-              ui.deleteChildElements(ui.elements.graphContainer);
-              ui.deleteChildElements(ui.elements.detailsBody);
-              // Menu
-              if(state.showMenu){
-                ui.composites.menu.show();
-              } else{
-                ui.composites.menu.hide();
+        // 2) Derive state.parsedData from state.givenData
+        rawDataParser: {
+          getBool(obj, prop, def) {
+            try {
+              const value = obj[prop];
+              if (value == "true" || value == "True") {
+                value = true;
+              } else if (value == "false" || value == "False") {
+                value = false;
               }
-              // Details
-              if(state.showDetails){
-                ui.composites.details.show(true);
-              } else{
-                ui.composites.details.hide(true);
+              if (value !== true && value !== false) {
+                throw "Invalid value. Not a bool.";
               }
-              // Divs
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-              ui.composites.responsiveContainer.getInnerWidths();
-            },
-
-            getInnerWidths(){
-              state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
-              state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
-            },
-
-            getInnerHeights(){
-              state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
-              if(state.showDetails){
-                state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-              }
-            },
-
-            setInnerHeights(){
-              ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
-              ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
-            },
-
-            setOuterHeights(){
-              ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
-            },
-
-            getSizes(){
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-            },
-
-            setSizes(){
-              ui.composites.responsiveContainer.setInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-            },
-
-            adaptToResize(){
-              ui.composites.responsiveContainer.getSizes();
-              ui.composites.responsiveContainer.setSizes();
-            },
-
-            adaptToFullscreen(){
-              ui.composites.responsiveContainer.getSizes();
-              if(document.fullscreenElement){
-                // On entering fullscreen, remember the current container heights
-                state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
-                state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
-                // and then adapt them to maximum height possible in full screen mode
-                function calculateFullscreenMaxGraphHeight(){
-                  let outerHeight = null;
-                  try{
-                    const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
-                      graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                      paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
-                      borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
-                      borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
-                      paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
-                    outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
-                    if(!isFinite(outerHeight) || outerHeight === null){
-                      throw "Invalid number";
-                    }
-                  } catch(e){
-                    // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
-                    outerHeight = 1 + 3 + 3 + 1;
-                  }
-                  let graphHeight = screen.height - outerHeight;
-                  if(state.showDetails){
-                    graphHeight -= ui.composites.details.calculateHeightDifference();
-                  }
-                  return graphHeight;
-                }
-                state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
-              } else{
-                // On leaving fullscreen, set container heights back to remembered values
-                state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
-                state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
-              }
-              ui.composites.responsiveContainer.setSizes();
-            },
-          },
-
-          menu:{
-            show(){
-              ui.elements.leftContainer.style.width = "80%";
-              ui.elements.rightContainer.style.width = "20%";
-              ui.elements.rightContainer.style.display = "block";
-            },
-
-            hide(){
-              ui.elements.leftContainer.style.width = "100%";
-              ui.elements.rightContainer.style.width = "0%";
-              ui.elements.rightContainer.style.display = "none";
-            },
-
-            toggle(){
-              // Update menu button
-              const div = ui.elements.menuToggleDiv;
-              state.showMenu = !state.showMenu;
-              if(state.showMenu){
-                div.innerText = ui.symbols.menuShown;
-                ui.composites.menu.show();
-              } else {
-                div.innerHTML = ui.symbols.menuHidden;
-                ui.composites.menu.hide();
-              }
-
-              // Update rest of UI
-              ui.composites.responsiveContainer.getInnerWidths();
-              ui.composites.responsiveContainer.getInnerHeights();
-              ui.composites.responsiveContainer.setOuterHeights();
-              ui.composites.graph.updateGraphDrawingArea();
-            },
-
-            setItem(keyElement, valElement, toActive){
-              const currentText = keyElement.innerHTML;
-              let sliceStart = 0;
-              if(currentText.startsWith(ui.symbols.menuItemActive)){
-                sliceStart = ui.symbols.menuItemActive.length;
-              } else if (currentText.startsWith(ui.symbols.menuItemInactive)){
-                sliceStart = ui.symbols.menuItemInactive.length;
-              }
-              if(toActive){
-                keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.classList.add("§RANDOM_ID§-active");
-                valElement.style.display = "block";
-              } else {
-                keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.classList.remove("§RANDOM_ID§-active");
-                valElement.style.display = "none";
-              }
-            },
-
-            toggleItem(keyElement, valElement){
-              const toActive = !(valElement.style.display !== "none");
-              ui.composites.menu.setItem(keyElement, valElement, toActive);
-            },
-          },
-
-          details:{
-            calculateHeightDifference(){
-              let outerHeight = null;
-              try{
-                const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
-                  detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
-                  border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
-                  margin = parseFloat(detailsContainerComputedStyle.marginTop),
-                  border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
-                outerHeight = border1 + margin + border2;
-                if(!isFinite(outerHeight) || outerHeight === null){
-                  throw "Invalid number";
-                }
-              } catch(e){
-                // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
-                outerHeight = 7.0;
-              }
-              return state.detailsContainerHeight + outerHeight
-            },
-
-            show(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "block";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight -= heightDiff;
-                if(state.graphContainerHeight < 70){
-                  state.graphContainerHeight = 70;
-                }
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            hide(init=false){
-              // Visibility
-              ui.elements.detailsContainer.style.display = "none";
-              if(!init){
-                // Height
-                const heightDiff = ui.composites.details.calculateHeightDifference();
-                state.graphContainerHeight += heightDiff;
-                // Update rest of UI
-                ui.composites.responsiveContainer.setSizes();
-                ui.composites.graph.updateGraphDrawingArea();
-              }
-            },
-
-            toggle(){
-              // Update details button
-              const toggleDiv = ui.elements.detailsToggleDiv;
-              state.showDetails = !state.showDetails;
-              if(state.showDetails){
-                toggleDiv.innerText = ui.symbols.detailsShown;
-                ui.composites.details.show();
-              } else {
-                toggleDiv.innerHTML = ui.symbols.detailsHidden;
-                ui.composites.details.hide();
-              }
-            },
-          },
-
-          download:{
-            png(filename){
-              ui.composites.download._rasterImage(filename, "png");
-            },
-
-            jpg(filename){
-              ui.composites.download._rasterImage(filename, "jpeg");
-            },
-
-            _rasterImage(filename, format){
-              const canvas = ui.elements.graphContainer.getElementsByTagName("canvas")[0],
-                mimeType = "image/" + format;
-              function finishedBlobCallback(blob){
-                ui.composites.download._blobToFileDownload(blob, filename);
-              }
-              try{
-                // Blob to overcome size limitations for data URLs (e.g. 4MB in Chrome)
-                canvas.toBlob(finishedBlobCallback, mimeType, 1.0);
-              } catch(e){
-                if(e.name === "SecurityError"){
-                  alert("Image creation failed. Some images within the nodes of the graph can " +
-                      "not be fetched from within JavaScript due to security settings of the " +
-                      "server that provides the images.");
-                } else{
-                  throw e;
-                }
-              }
-            },
-
-            _blobToFileDownload(blob, filename){
-              const url = URL.createObjectURL(blob),
-                a = document.createElement("a");
-              function handleClick(){
-                setTimeout(function(){
-                  // Long waiting time before removal for slow devices like mobile phones
-                  URL.revokeObjectURL(url);
-                  this.removeEventListener("click", handleClick);
-                }, 20000);
-              };
-              document.body.appendChild(a);
-              a.href = url;
-              a.download = filename;
-              a.addEventListener("click", handleClick, false);
-              a.click();
-              document.body.removeChild(a);
-            },
-          },
-
-          selection(element, optionList, valueList=undefined) {
-            while(element.hasChildNodes()){
-              element.removeChild(element.firstChild);
+              return value;
+            } catch (e) {
+              return def;
             }
-            for(let i=0; i<optionList.length; i++){
-              let text = optionList[i];
-              let value = text;
-              if(valueList){
-                value = valueList[i];
+            return def
+          },
+
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
               }
-              let opt = document.createElement("option");
-              opt.appendChild(document.createTextNode(text));
-              opt.value = value;
-              element.appendChild(opt);
+              return value;
+            } catch (e) {
+              return def;
+            }
+            return def;
+          },
+
+          getArrayLengthOrZero(array) {
+            try {
+              const value = parseInt(array.length);
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
+              }
+              return value;
+            } catch (e) {
+              return 0;
             }
           },
 
-          tooltip:{
-            show(xShift=null, yShift=null){
-              if(isFinite(xShift) && xShift !== null){
-                ui.elements.tooltipContainer.style.left =  parseInt(xShift) + "px";
+          getObjectLengthOrZero(obj) {
+            try {
+              const value = Object.keys(obj).length;
+              if (!((value + 1) > 0)) {
+                throw "Invalid value. Not a proper length.";
               }
-              if(isFinite(yShift) && yShift !== null){
-                ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
-              }
-              ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
-              ui.elements.tooltipContainer.style.visibility = "visible";
-              ui.elements.tooltipContainer.style.opacity = 1.0;
-            },
-
-            hide(){
-              ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
-              ui.elements.tooltipContainer.style.visibility = "hidden";
-              ui.elements.tooltipContainer.style.opacity = 0.0;
-            },
-          },
-
-          progressBar:{
-            create(){
-              // Main container
-              this.mainContainer = document.createElement("div");
-              this.mainContainer.id = "§RANDOM_ID§-progress-container";
-              this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
-              ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
-              // Text container
-              const numNodes = state.parsedData.nodes.length;
-              this.textContainer = document.createElement("div");
-              this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
-              this.textContainer.style.textAlign = "center";
-              // Bar container
-              this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
-              this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
-              this.innerBarContainer.style.width = "0%";
-              // Add them to DOM
-              this.outerBarContainer.appendChild(this.innerBarContainer);
-              this.mainContainer.appendChild(this.textContainer);
-              this.mainContainer.appendChild(this.outerBarContainer);
-              ui.elements.graphContainer.appendChild(this.mainContainer);
-            },
-
-            update(percentage){
-              this.innerBarContainer.style.width = percentage + "%";
-            },
-
-            remove(){
-              ui.elements.graphContainer.removeChild(this.mainContainer);
+              return value;
+            } catch (e) {
+              return 0;
             }
           },
 
-          graph:{
-            createGraph(){
-              // Remove existing elements
-              ui.deleteChildElements(ui.elements.graphContainer);
+          createUniqueEdgeId(sourceId, targetId, knownEdgeIds) {
+            let newEdgeIdBase = "(" + sourceId + ", " + targetId + ")",
+              newEdgeId = newEdgeIdBase,
+              multiEdgeCounter = 1;
+            for (let i = 1; knownEdgeIds.has(newEdgeId); i++) {
+              newEdgeId = newEdgeIdBase + "_" + String(i);
+              multiEdgeCounter += 1;
+            }
+            knownEdgeIds.add(newEdgeId);
+            return { "id": newEdgeId, "count": multiEdgeCounter }
+          },
+        },
 
-              // Create new elements
-              // I) Set graph options
-              // a) Nodes: https://visjs.github.io/vis-network/docs/network/nodes.html
-              const data = state.shownData,
-                visNodes = [];
-              let graphContainsFixedPositions = false;
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i];
-                let visNode = {
-                  id: node.id,
-                  shape: node.shape,
-                  borderWidth: node.border_size,
-                  color: {
-                    background: node.color,
-                    border: node.border_color,
-                  },
-                }
-                // - Node labels
-                if(state.showNodeLabels){
-                  if(typeof(node.label) !== "undefined"){
-                    visNode.label = node.label;
-                    visNode.font = {
-                      size: node.label_size,
-                      color: node.label_color,
-                      strokeWidth: (state.showNodeLabelBorders ? 1.2 : 0.0),
-                      strokeColor: data.general.background_color,
-                    }
-                  }
-                }
-                // - Nodes hidden/shown ("hidden" property hides entire graph, using size=0 instead)
-                if(state.showNodes || (typeof(node.image) !== "undefined" && state.showNodeImages)){
-                  visNode.size = node.size;
-                } else {
-                  visNode.size = 0.0;
-                }
-                // - Node images
-                if(typeof(node.image) !== "undefined"){
-                  if(state.showNodeImages){
-                    visNode.shape = "image";
-                    visNode.image = node.image;
-                    visNode.size = node.image_size;
-                    // prevent a visual change of nodes with images upon selection (not deactivatable)
-                    visNode.color.highlight = {
-                      background: visNode.color.background,
-                      border: visNode.color.border,
-                    };
-                    visNode.borderWidthSelected = visNode.borderWidth;
-                  }
-                }
-                // - Node positions
-                const x = node.fx,
-                  y = node.fy;
-                if((typeof(x) !== "undefined") || (typeof(y) !== "undefined")){
-                  graphContainsFixedPositions = true;
-                  visNode.fixed = {}
-                  if(typeof(x) !== "undefined"){
-                    visNode.x = x;
-                    visNode.fixed.x = true;
-                  }
-                  if(typeof(y) !== "undefined"){
-                    visNode.y = y;
-                    visNode.fixed.y = true;
-                  }
-                }
-                // - Node hover behavior 1: highlight neighborhood
-                visNode.color.hover = {
-                  background: visNode.color.background,
-                  border: visNode.color.background,
-                };
-                // - Node hover behavior 2: show tooltip
-                if(state.nodeHoverTooltip){
-                  if(typeof(node.hover) !== "undefined"){
-                    visNode.title = node.hover;
-                  }
-                }
-                // - Node click behavior: show details
-                if(typeof(node.click) !== "undefined" && node.click !== ""){
-                  visNode.click = node.click;
-                }
-                visNodes.push(visNode);
+        rawMetadataParser: {
+          getString(obj, prop, def) {
+            try {
+              const value = String(obj.metadata[prop]);
+              if (value === "undefined") {
+                throw "Invalid value. Not a proper string.";
               }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getShape(obj, prop, def) {
+            const givenShape = state.manager.rawMetadataParser.getString(obj, prop, def);
+            let visShape = def;
+            if (givenShape === "circle") {
+              visShape = "dot";
+            } else if (givenShape === "rectangle") {
+              visShape = "square";
+            } else if (givenShape === "hexagon") {
+              visShape = "hexagon";
+            }
+            return visShape;
+          },
+          getColor(obj, prop, def) {
+            function isBodyidColor(strColor) {
+              const sty = new Option().style;
+              sty.color = strColor;
+              return sty.color !== "";
+            }
+            try {
+              const value = obj.metadata[prop];
+              if (!isBodyidColor(value)) {
+                throw "Invalid value. Not a color."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null) {
+                throw "Invalid value. Not a finite number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFiniteNumberOrNull(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value)) {  // Note: isFinite(null) gives true
+                throw "Invalid value. Not a finite number or null."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          getFinitePositiveNumber(obj, prop, def) {
+            try {
+              const value = parseFloat(obj.metadata[prop]);
+              if (!isFinite(value) || value === null || value < 0.0) {
+                throw "Invalid value. Not a finite positive number."
+              }
+              return value;
+            } catch (e) {
+              return def;
+            }
+          },
+          collectOtherMetadata(sourceObject, targetObject, definedMetadata) {
+            if (typeof (sourceObject) !== "undefined" && typeof (sourceObject.metadata) !== "undefined") {
+              const properties = Object.keys(sourceObject.metadata);
+              for (let i = 0; i < properties.length; i++) {
+                const property = properties[i];
+                if (!definedMetadata.has(property)) {
+                  targetObject[property] = sourceObject.metadata[property];
+                }
+              }
+            }
+          },
+        },
 
-              // b) Edges: https://visjs.github.io/vis-network/docs/network/edges.html
-              const visEdges = [];
-              for(let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i];
-                const visEdge = {
-                  id: edge.id,
-                  from: edge.source.id,
-                  to: edge.target.id,
-                  color: edge.color,
-                  width: edge.size,
-                };
-                // - Edge labels
-                if(state.showEdgeLabels){
-                  if(typeof(edge.label) !== "undefined"){
-                    visEdge.label = edge.label;
-                    visEdge.font = {
-                      size: edge.label_size,
-                      color: edge.label_color,
-                      strokeWidth: (state.showEdgeLabelBorders ? 1.2 : 0.0),
-                      strokeColor: data.general.background_color,
-                    }
-                  }
-                }
-                // - Edges hidden/shown
-                if(!state.showEdges){
-                  visEdge.hidden = true;
-                }
-                // - Edge hover behavior
-                if(state.edgeHoverTooltip){
-                  if(typeof(edge.hover) !== "undefined") {
-                    visEdge.title = edge.hover;
-                  }
-                }
-                // - Edge click behavior
-                if(typeof(edge.click) !== "undefined" && edge.click !== ""){
-                  visEdge.click = edge.click;
-                }
-                visEdges.push(visEdge);
-              }
-              // c) Options: https://visjs.github.io/vis-network/docs/network/
-              const options = {};
-              // - Nodes
-              options.nodes = {};
-              options.nodes.chosen = false;
-              options.nodes.imagePadding = 1.5;
-              options.nodes.labelHighlightBold = false;
-              options.nodes.shapeProperties = {};
-              options.nodes.shapeProperties.useBorderWithImage = true;
-              // - Node label font family
-              if(state.nodeLabelFont !== null){
-                options.nodes.font = {
-                  "face": state.nodeLabelFont,
-                }
-              }
-              // - Edges
-              options.edges = {};
-              // - Edges hidden/shown
-              if(!state.showEdges){
-                options.edges.hidden = true;
-              }
-              // - Edge curvature
-              if(state.edgeCurvature === 0.0){
-                options.edges.smooth = false;
+        propertyClassifier: {
+          numeric: null,
+          nonNumeric: null,
+          init() {
+            this.numeric = new Set(),
+              this.nonNumeric = new Set();
+          },
+          isNumeric(d) {
+            return d === null || typeof (d) === "undefined" || String(parseFloat(d)) === String(d);
+          },
+          inspect(object, property) {
+            const value = object[property];
+            if (!this.nonNumeric.has(property)) {
+              if (this.isNumeric(value)) {
+                this.numeric.add(property);
               } else {
-                options.edges.smooth = ui.composites.graph.calculateEdgeCurvatureOptions();
+                this.nonNumeric.add(property);
+                this.numeric.delete(property);
               }
-              // - Edge arrows
-              if(data.general.directed){
-                options.edges.arrows = {};
-                options.edges.arrows.to = {};
-                options.edges.arrows.to.enabled = true;
-                if(data.general.arrow_size !== 0.0){
-                  options.edges.arrows.to.scaleFactor = data.general.arrow_size / 10.0;
-                }
-              }
-              // - Edge label font family
-              if(state.edgeLabelFont !== null){
-                options.edges.font = {
-                  "face": state.edgeLabelFont,
-                }
-              }
-              // - Drawing area
-              options.autoResize = false;
-              // - Interaction
-              options.interaction = {};
-              options.interaction.selectable = false;
-              options.interaction.selectConnectedEdges = false;
-              options.interaction.tooltipDelay = 0.0;
-              options.interaction.hover = state.nodeHoverNeighborhood;
-              options.interaction.hoverConnectedEdges = state.nodeHoverNeighborhood;
-              // - Layout algorithm
-              const numNodes = state.parsedData.nodes.length;
-              options.layout = {};
-              if(numNodes < 400){
-                options.layout.improvedLayout = true;
-              } else{
-                options.layout.improvedLayout = false;
-              }
-              options.physics = {};
-              options.physics.barnesHut = {"damping": 0.25};
-              options.physics.forceAtlas2Based = {"damping": 3.0};
-              options.physics.repulsion = {};
-              options.physics.hierarchicalRepulsion = {};
-              options.physics.stabilization = {};
-              options.physics.stabilization.enabled = false;
-              if(numNodes > state.largeGraphThreshold){
-                let numIterations = 800;
-                if(numNodes >= 25000){
-                  numIterations = 100;
-                } else if(numNodes >= 10000){
-                  numIterations = 300;
-                } else if(numNodes >= 5000){
-                  numIterations = 400;
-                } else if(numNodes >= 2000){
-                  numIterations = 500;
-                } else if(numNodes >= 1000){
-                  numIterations = 600;
-                }
-                options.physics.stabilization = {
-                  "enabled": true,
-                  "fit": true,
-                  "iterations": numIterations,
-                  "updateInterval": 1,
-                };
-              }
-              // II) Create graph
-              // - DataSet and Network: https://visjs.github.io/vis-network/docs/network
-              state.visOptions = options;
-              state.visData = {
-                nodes: new vis.DataSet(visNodes),
-                edges: new vis.DataSet(visEdges),
-              };
-              state.visGraph = new vis.Network(ui.elements.graphContainer, state.visData, state.visOptions);
-              // III) Set further graph options after its creation
-              // - Background: https://github.com/almende/vis/issues/2292
-              state.visGraph.on("beforeDrawing", function(ctx){
-                  ctx.save();
-                  ctx.setTransform(1, 0, 0, 1, 0, 0);
-                  ctx.fillStyle = data.general.background_color;
-                  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-                  ctx.restore();
-              })
-              // - Node positions: node update after graph creation seems to prevent a bug
-              if(graphContainsFixedPositions){
-                state.visData.nodes.update(visNodes);
-              }
-              // - Graph behavior
-              ui.composites.graph.setBehavior();
+            }
+          }
+        },
 
-              // Menu toggle button
-              if(state.showMenuToggleButton){
-                const menuDiv = document.createElement("div");
-                if(state.showMenu){
-                  menuDiv.innerText = ui.symbols.menuShown;
-                } else {
-                  menuDiv.innerText = ui.symbols.menuHidden;
-                }
-                menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
-                menuDiv.onclick = ui.composites.menu.toggle;
-                ui.elements.graphContainer.appendChild(menuDiv);
-                ui.elements.menuToggleDiv = menuDiv;
-              }
-              // Details toggle button
-              if(state.showDetailsToggleButton){
-                const detailsDiv = document.createElement("div");
-                if(state.showDetails){
-                  detailsDiv.innerText = ui.symbols.detailsShown;
-                } else {
-                  detailsDiv.innerText = ui.symbols.detailsHidden;
-                }
-                detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
-                detailsDiv.onclick = ui.composites.details.toggle;
-                ui.elements.graphContainer.appendChild(detailsDiv);
-                ui.elements.detailsToggleDiv = detailsDiv;
-              }
-            },
+        replaceStringVariables(givenString, givenItem, variables) {
+          let newString = givenString;
+          for (let i = 0; i < variables.length; i++) {
+            let variable = variables[i],
+              variableText = "$" + variable;
+            if (variable === "x") {
+              variable = "fx";
+            } else if (variable === "y") {
+              variable = "fy";
+            }
+            let insertedText = String(givenItem[variable]);
+            if (insertedText === "undefined") {
+              insertedText = "";
+            }
+            newString = newString.replace(variableText, insertedText);
+          }
+          return newString;
+        },
 
-            setBehavior(){
-              // - Progress bar: only if large graph, stops simulation to get initial static image
-              // https://visjs.github.io/vis-network/examples/network/exampleApplications/loadingBar.html
-              const numNodes = state.parsedData.nodes.length;
-              if(numNodes > state.largeGraphThreshold){
-                // Layout start
-                ui.composites.progressBar.create();
-                // Layout update
-                state.visGraph.on("stabilizationProgress", function(params){
-                  var progressPercentage = params.iterations / params.total * 100;
-                  ui.composites.progressBar.update(progressPercentage);
-                });
-                // Layout finished
-                state.visGraph.once("stabilizationIterationsDone", function(){
-                  setTimeout(function(){
-                    ui.composites.progressBar.remove();
-                    ui.composites.graph.simulationManager.stop();
-                  }, 60);
-                });
-              }
-              // - Node drag behavior: move node, fix its position or release it afterwards
-              state.visGraph.on("dragStart", function(params){
-                params.event = "[original event]";
-                const nodeId = this.getNodeAt(params.pointer.DOM);
-                if(nodeId){
-                  const visNode = state.visData.nodes.get(nodeId),
-                    position = state.visGraph.getPositions(nodeId);
-                  visNode.x = position.x;
-                  visNode.y = position.y;
-                  visNode.fixed = false;
-                  state.visData.nodes.update(visNode);
-                }
-              });
-              state.visGraph.on("dragEnd", function(params){
-                params.event = "[original event]";
-                const nodeId = this.getNodeAt(params.pointer.DOM);
-                if(nodeId){
-                  if(state.nodeDragFix){
-                    const visNode = state.visData.nodes.get(nodeId),
-                      position = state.visGraph.getPositions(nodeId);
-                    visNode.x = position.x;
-                    visNode.y = position.y;
-                    visNode.fixed = {"x": true, "y": true}
-                    state.visData.nodes.update(visNode);
-                  }
-                }
-              });
-              // - Node and edge hover behavior: already covered
-              // - Node and edge click behavior
-              // https://visjs.github.io/vis-network/examples/network/events/interactionEvents.html
-              function createNodeText(node){
-                let htmlText = "<div>Node: " + String(node.id) + "</div>";
-                if(typeof(node.click) !== "undefined" && node.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
-                }
-                return htmlText;
-              }
-              function createEdgeText(edge){
-                let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
-                if(typeof(edge.click) !== "undefined" && edge.click !== ""){
-                  htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
-                }
-                return htmlText;
-              }
-              state.visGraph.on("click", function(params){
-                params.event = "[original event]";
-                let htmlText = "";
-                const nodeId = this.getNodeAt(params.pointer.DOM);
-                if(nodeId){
-                  const node = state.visData.nodes.get(nodeId);
-                  if(node){
-                    htmlText = createNodeText(node);
-                  }
-                } else {
-                  const edgeId = this.getEdgeAt(params.pointer.DOM);
-                  if(edgeId){
-                    const edge = state.visData.edges.get(edgeId);
-                    if(edge){
-                      htmlText = createEdgeText(edge);
-                    }
-                  }
-                }
-                ui.elements.detailsBody.innerHTML = htmlText;
-              });
-              // - Simulation behavior
-              state.visGraph.on("startStabilizing", function(params){
-                // A manually stopped simulation restarts automatically by dragging a node or
-                // altering a dataset, immediately triggering this event. So if the simulation
-                // shall be inactive, any automatic restart can be turned off immediately here.
-                if(!state.layoutAlgorithmActive){
-                  state.visGraph.stopSimulation();
-                }
-              });
-              // Start (considers all simulation parameters)
-              ui.composites.graph.simulationManager.start();
-            },
-
-            // Graph
-            updateGraphDrawingArea(){
-              state.visGraph.setSize(state.graphContainerWidth, state.graphContainerHeight);
-              state.visGraph.redraw();
-            },
-
+        parseGeneral(givenData, parsedData) {
+          const generalDefaults = state.useDarkMode ? {
+            background_color: "#1f1f25",
+            arrow_color: "#7ddba3",
+            node_color: "#7ddba3",
+            node_border_color: "#f0f0f5",
+            node_label_color: "#f0f0f5",
+            edge_color: "#b5b8c5",
+            edge_label_color: "#f0f0f5",
+          } : {
+            background_color: "white",
+            arrow_color: "black",
+            node_color: "black",
+            node_border_color: "black",
+            node_label_color: "black",
+            edge_color: "black",
+            edge_label_color: "black",
+          };
+          parsedData.general = {
+            // General
+            directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
+            label: state.manager.rawDataParser.getString(givenData, "label", ""),
+            background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+            arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
+            arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
             // Nodes
-            updateNodes(){
-              const data = state.shownData,
-                newVisNodes = [];
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i],
-                  visNode = state.visData.nodes.get(node.id);
-                // Node shape
-                visNode.shape = node.shape;
-                // Node size
-                if(state.showNodes){
-                  visNode.size = node.size;
-                } else {
-                  visNode.size = 0.0;
+            node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
+            node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
+            node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
+            node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
+            node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
+            node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
+            node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
+            node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
+            node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
+            node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
+            node_image: state.manager.rawMetadataParser.getString(givenData, "node_image", ""),
+            node_x: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_x", null),
+            node_y: state.manager.rawMetadataParser.getFiniteNumberOrNull(givenData, "node_y", null),
+            contains_node_hover: false,
+            contains_node_click: false,
+            contains_node_image: false,
+            // Edges
+            edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
+            edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
+            edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
+            edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
+            edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
+            edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
+            edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
+            contains_edge_hover: false,
+            contains_edge_click: false,
+          };
+          if (!parsedData.general.directed) {
+            parsedData.general.arrow_size = 0.0;
+          }
+        },
+
+        parseNodes(givenData, parsedData) {
+          const numNodes = state.manager.rawDataParser.getObjectLengthOrZero(givenData.nodes),
+            nodeIdToObjectMap = new Map(),
+            nodeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "shape", "border_color", "border_size",
+                "label_color", "label_size", "hover", "click", "image", "x", "y"]),
+            nodeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "shape", "border_color", "border_size",
+              "label_color", "label_size", "image", "x", "y"];
+          state.manager.propertyClassifier.init();
+          try {
+            Object.entries(givenData.nodes);
+          }
+          catch (e) {
+            givenData.nodes = {};
+          }
+          for (const [givenNodeId, givenNode] of Object.entries(givenData.nodes)) {
+            const parsedNode = {};
+            // data: id, label
+            parsedNode.id = String(givenNodeId);
+            parsedNode.label = state.manager.rawDataParser.getString(givenNode, "label", "");
+            // defined metadata
+            parsedNode.color = state.manager.rawMetadataParser.getColor(givenNode, "color", parsedData.general.node_color);
+            parsedNode.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "opacity", parsedData.general.node_opacity);
+            parsedNode.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "size", parsedData.general.node_size);
+            parsedNode.shape = state.manager.rawMetadataParser.getShape(givenNode, "shape", parsedData.general.node_shape);
+            parsedNode.border_color = state.manager.rawMetadataParser.getColor(givenNode, "border_color", parsedData.general.node_border_color);
+            parsedNode.border_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "border_size", parsedData.general.node_border_size);
+            parsedNode.label_color = state.manager.rawMetadataParser.getColor(givenNode, "label_color", parsedData.general.node_label_color);
+            parsedNode.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenNode, "label_size", parsedData.general.node_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenNode, "hover", parsedData.general.node_hover);
+            const image = state.manager.rawMetadataParser.getString(givenNode, "image", parsedData.general.node_image);
+            if (image !== "") {
+              parsedNode.image = image;
+              parsedData.general.contains_node_image = true;
+            }
+            if (hover !== "") {
+              parsedNode.hover = hover;
+              parsedData.general.contains_node_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenNode, "click", parsedData.general.node_click);
+            if (click !== "") {
+              parsedNode.click = click;
+              parsedData.general.contains_node_click = true;
+            }
+            const x = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "x", parsedData.general.node_x);
+            const y = state.manager.rawMetadataParser.getFiniteNumberOrNull(givenNode, "y", parsedData.general.node_y);
+            if (x !== null) {
+              parsedNode.fx = x;
+            }
+            if (y !== null) {
+              parsedNode.fy = y;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenNode, parsedNode, nodeDefinedMetadata);
+            // feature classification
+            const parsedNodeProperties = Object.keys(parsedNode);
+            for (let i = 0; i < parsedNodeProperties.length; i++) {
+              const property = parsedNodeProperties[i],
+                value = parsedNode[property];
+              state.manager.propertyClassifier.inspect(parsedNode, property);
+            }
+            // variable replacements
+            if (parsedNode.hover) {
+              parsedNode.hover = state.manager.replaceStringVariables(parsedNode.hover, parsedNode, nodeReplacementVariables);
+            }
+            if (parsedNode.click) {
+              parsedNode.click = state.manager.replaceStringVariables(parsedNode.click, parsedNode, nodeReplacementVariables.concat(["hover"]));
+            }
+            // store the parsed node
+            parsedData.nodes.push(parsedNode);
+            // data structure for inserting node object references into edge data
+            nodeIdToObjectMap.set(parsedNode.id, parsedNode);
+          }
+          // Ensure numeric properties (except fx and fy) are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric).filter(name => name !== "fx" && name !== "fy"),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          for (let i = 0; i < numNodes; i++) {
+            const parsedNode = parsedData.nodes[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedNode[property]);
+              parsedNode[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
                 }
-                // Node images
-                if(state.showNodeImages){
-                  if(typeof(node.image) !== "undefined"){
-                    visNode.size = node.image_size;
-                    visNode.shape = "image";
-                    visNode.image = node.image;
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.node_properties = {
+            "node_size_data_sources": numericProperties,
+            "node_label_text_data_sources": nonNumericProperties.concat(numericProperties),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report empty graph
+          if (!(numNodes > 0)) {
+            console.log("Caution: Graph with 0 nodes. The provided data might be in the wrong format.");
+          }
+          return nodeIdToObjectMap;
+        },
+
+        parseEdges(givenData, parsedData, nodeIdToObjectMap) {
+          let numEdges = state.manager.rawDataParser.getArrayLengthOrZero(givenData.edges);
+          const knownEdgeIds = new Set(),
+            ignoredEdges = [],
+            edgeDefinedMetadata = new Set(
+              ["color", "opacity", "size", "label_color", "label_size", "hover", "click"]),
+            edgeReplacementVariables = [
+              "id", "label",
+              "color", "opacity", "size", "label_color", "label_size"];
+          state.manager.propertyClassifier.init();
+          for (let i = 0; i < numEdges; i++) {
+            const givenEdge = givenData.edges[i],
+              parsedEdge = {},
+              sourceId = String(givenEdge.source),
+              targetId = String(givenEdge.target);
+            // data: source, target, id, multi_edge_counter, label
+            try {
+              const sourceObj = nodeIdToObjectMap.get(sourceId);
+              const targetObj = nodeIdToObjectMap.get(targetId);
+              if (typeof (sourceObj) === "undefined" || typeof (targetObj) === "undefined") {
+                throw "Invalid node reference.";
+              }
+              parsedEdge.source = sourceObj;
+              parsedEdge.target = targetObj;
+            } catch (e) {
+              const ignoredEdge = {
+                index: i,
+                source: sourceId,
+                target: targetId,
+              }
+              ignoredEdges.push(ignoredEdge);
+              continue;
+            }
+            const result = state.manager.rawDataParser.createUniqueEdgeId(sourceId, targetId, knownEdgeIds);
+            parsedEdge.id = result.id;
+            parsedEdge.multi_edge_counter = result.count;
+            parsedEdge.label = state.manager.rawDataParser.getString(givenEdge, "label", "");
+            // defined metadata
+            parsedEdge.color = state.manager.rawMetadataParser.getColor(givenEdge, "color", parsedData.general.edge_color);
+            parsedEdge.opacity = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "opacity", parsedData.general.edge_opacity);
+            parsedEdge.size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "size", parsedData.general.edge_size);
+            parsedEdge.label_color = state.manager.rawMetadataParser.getColor(givenEdge, "label_color", parsedData.general.edge_label_color);
+            parsedEdge.label_size = state.manager.rawMetadataParser.getFinitePositiveNumber(givenEdge, "label_size", parsedData.general.edge_label_size);
+            const hover = state.manager.rawMetadataParser.getString(givenEdge, "hover", parsedData.general.edge_hover);
+            if (hover !== "") {
+              parsedEdge.hover = hover;
+              parsedData.general.contains_edge_hover = true;
+            }
+            const click = state.manager.rawMetadataParser.getString(givenEdge, "click", parsedData.general.edge_click);
+            if (click !== "") {
+              parsedEdge.click = click;
+              parsedData.general.contains_edge_click = true;
+            }
+            // other metadata
+            const otherMetadata = state.manager.rawMetadataParser.collectOtherMetadata(givenEdge, parsedEdge, edgeDefinedMetadata);
+            // feature classification
+            const parsedEdgeProperties = Object.keys(parsedEdge);
+            for (let i = 0; i < parsedEdgeProperties.length; i++) {
+              const property = parsedEdgeProperties[i],
+                value = parsedEdge[property];
+              state.manager.propertyClassifier.inspect(parsedEdge, property);
+            }
+            // variable replacements
+            if (parsedEdge.hover) {
+              parsedEdge.hover = state.manager.replaceStringVariables(parsedEdge.hover, parsedEdge, edgeReplacementVariables);
+            }
+            if (parsedEdge.click) {
+              parsedEdge.click = state.manager.replaceStringVariables(parsedEdge.click, parsedEdge, edgeReplacementVariables.concat(["hover"]));
+            }
+            // store it
+            parsedData.edges.push(parsedEdge);
+          }
+          // Ensure numeric properties are stored as numbers and remember their extrema
+          const numericProperties = Array.from(state.manager.propertyClassifier.numeric),
+            nonNumericProperties = Array.from(state.manager.propertyClassifier.nonNumeric),
+            minima = {},
+            maxima = {};
+          numEdges = state.manager.rawDataParser.getArrayLengthOrZero(parsedData.edges);
+          for (let i = 0; i < numEdges; i++) {
+            const parsedEdge = parsedData.edges[i];
+            for (let p = 0; p < numericProperties.length; p++) {
+              const property = numericProperties[p],
+                numericValue = parseFloat(parsedEdge[property]);
+              parsedEdge[property] = numericValue;
+              if (isFinite(numericValue)) {
+                if (typeof (minima[property]) === "undefined" || numericValue < minima[property]) {
+                  minima[property] = numericValue;
+                }
+                if (typeof (maxima[property]) === "undefined" || numericValue > maxima[property]) {
+                  maxima[property] = numericValue;
+                }
+              }
+            }
+          }
+          // Store feature classification and extrema
+          parsedData.general.edge_properties = {
+            "edge_size_data_sources": numericProperties.filter(item => item !== "multi_edge_counter"),
+            "edge_label_text_data_sources": nonNumericProperties.concat(numericProperties).filter(
+              item => item !== "source" && item !== "target" && item !== "multi_edge_counter"),
+            "minima": minima,
+            "maxima": maxima,
+          }
+          // Report invalid edges
+          if (ignoredEdges.length > 0) {
+            let message = undefined;
+            if (ignoredEdges.length == 1) {
+              message = "Caution: " + ignoredEdges.length + " edge was ignored because it " +
+                "refers to a node that is not part of the node list:\n";
+            } else {
+              message = "Caution: " + ignoredEdges.length + " edges were ignored because they " +
+                "refer to a node that is not part of the node list:\n";
+            }
+            for (let i = 0; i < ignoredEdges.length; i++) {
+              const ignoredEdge = ignoredEdges[i];
+              message += '- Edge with index ' + ignoredEdge.index;
+              message += ', source "' + ignoredEdge.source;
+              message += '", target "' + ignoredEdge.target + '"\n';
+              if (i == 9) {
+                message += '...';
+                break;
+              }
+            }
+            console.log(message);
+          }
+        },
+
+        parseChosenData(chosenGraphNumber) {
+          let givenData = state.rawData[chosenGraphNumber],
+            parsedData = {
+              general: {},
+              nodes: [],
+              edges: [],
+              adjacency: null,
+              incidence: null,
+            };
+          if (!givenData || givenData === null) {
+            givenData = [];
+          }
+          // a) General
+          state.manager.parseGeneral(givenData, parsedData);
+          // b) Nodes
+          const nodeIdToObjectMap = state.manager.parseNodes(givenData, parsedData);
+          // c) Edges
+          state.manager.parseEdges(givenData, parsedData, nodeIdToObjectMap);
+          // Update state
+          state.parsedData = parsedData;
+          state.currentGraphParts = {};
+          // Update UI: show or hide containers
+          ui.elements.graphContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          ui.elements.detailsContainer.style.display = ui.convert.boolToDisplayStyle(state.showDetails);
+          ui.elements.nodeImageMetaControl.style.display = ui.convert.boolToDisplayStyle(parsedData.general.contains_node_image);
+        },
+
+        // 3) Derive state.shownData from state.parsedData
+        createNodeToAdjacentNodesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(sourceNode, targetNode) {
+              let adjacentNodes = this.map.get(sourceNode);
+              if (adjacentNodes) {
+                adjacentNodes.add(targetNode);
+              } else {
+                adjacentNodes = new Set([targetNode]);
+                this.map.set(sourceNode, adjacentNodes);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        createNodeToIncidentEdgesMap() {
+          const dataStructure = {
+            map: new Map(),
+            add(node, edge) {
+              let incidentEdges = this.map.get(node);
+              if (incidentEdges) {
+                incidentEdges.add(edge);
+              } else {
+                incidentEdges = new Set([edge]);
+                this.map.set(node, incidentEdges);
+              }
+            },
+          }
+          return dataStructure;
+        },
+
+        hoverTextToHtml(text) {
+          // https://visjs.github.io/vis-network/examples/network/other/html-in-titles.html
+          const div = document.createElement("div");
+          div.innerHTML = text;
+          return div;
+        },
+
+        prepareShownData() {
+          const numNodes = state.parsedData.nodes.length,
+            numEdges = state.parsedData.edges.length;
+          state.shownData = {
+            "general": null,
+            "nodes": new Array(numNodes),
+            "edges": new Array(numEdges),
+          }
+          const nodeIdToObjectMap = new Map(),
+            nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          // a) General
+          state.shownData.general = {
+            "background_color": state.parsedData.general.background_color,
+            "arrow_size": state.parsedData.general.arrow_size,
+            "arrow_color": state.parsedData.general.arrow_color,
+            "directed": state.parsedData.general.directed,
+          };
+          // b) Nodes
+          for (let i = 0; i < numNodes; i++) {
+            state.shownData.nodes[i] = {};
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.id = parsedNode.id;
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+            shownNode.color = parsedNode.color;
+            shownNode.opacity = parsedNode.opacity;
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            shownNode.shape = parsedNode.shape;
+            shownNode.border_color = parsedNode.border_color;
+            shownNode.border_size = parsedNode.border_size;
+            shownNode.label_color = parsedNode.label_color;
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+            if (typeof (parsedNode.image) !== "undefined") {
+              shownNode.image = parsedNode.image;
+            }
+            if (typeof (parsedNode.hover) !== "undefined") {
+              shownNode.hover = state.manager.hoverTextToHtml(parsedNode.hover);
+            }
+            if (typeof (parsedNode.click) !== "undefined") {
+              shownNode.click = parsedNode.click;
+            }
+            if (typeof (parsedNode.fx) !== "undefined") {
+              shownNode.fx = parsedNode.fx;
+            }
+            if (typeof (parsedNode.fy) !== "undefined") {
+              shownNode.fy = parsedNode.fy;
+            }
+            nodeIdToObjectMap.set(shownNode.id, shownNode);
+            // Derived properties for performance improvement in updateNodePositions
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+            state.manager.calcSingleNodeBorderSizeDerivatives(shownNode);
+          }
+          // c) Edges
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer(),
+            nodeToAdjacentNodesMap = state.manager.createNodeToAdjacentNodesMap(),
+            nodeToIncidentEdgesMap = state.manager.createNodeToIncidentEdgesMap();
+          for (let i = 0; i < numEdges; i++) {
+            state.shownData.edges[i] = {};
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.source = nodeIdToObjectMap.get(parsedEdge.source.id);
+            shownEdge.target = nodeIdToObjectMap.get(parsedEdge.target.id);
+            shownEdge.id = parsedEdge.id;
+            shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
+            shownEdge.color = parsedEdge.color;
+            shownEdge.opacity = parsedEdge.opacity;
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+            shownEdge.label_color = parsedEdge.label_color;
+            shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
+            if (typeof (parsedEdge.hover) !== "undefined") {
+              shownEdge.hover = state.manager.hoverTextToHtml(parsedEdge.hover);
+            }
+            if (typeof (parsedEdge.click) !== "undefined") {
+              shownEdge.click = parsedEdge.click;
+            }
+            // Derived properties for performance improvement in updateEdgePositions
+            shownEdge.multiEdgeCurvatureFactor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+            // Data structure for highlighting adjacent nodes and incident edges to this node
+            nodeToAdjacentNodesMap.add(shownEdge.source, shownEdge.target);
+            nodeToAdjacentNodesMap.add(shownEdge.target, shownEdge.source);
+            nodeToIncidentEdgesMap.add(shownEdge.source, shownEdge);
+            nodeToIncidentEdgesMap.add(shownEdge.target, shownEdge);
+          }
+          state.shownData.adjacency = nodeToAdjacentNodesMap;
+          state.shownData.incidence = nodeToIncidentEdgesMap;
+        },
+
+        calcSingleNodeSize(parsedNode, nodeSizeNormalizer) {
+          const appearanceAdaptionFactor = 0.5;
+          let nodeSize = nodeSizeNormalizer(parsedNode[state.nodeSizeDataSource]);
+          if (!isFinite(nodeSize)) {
+            nodeSize = state.parsedData.general.node_size;
+          }
+          return nodeSize * state.nodeSizeFactor * appearanceAdaptionFactor;
+        },
+
+        calcSingleNodeSizeDerivatives(shownNode) {
+          shownNode.image_size = shownNode.size / 1.42 * state.nodeImageSizeFactor;
+        },
+
+        calcSingleNodeLabelText(parsedNode) {
+          return String(parsedNode[state.nodeLabelTextDataSource]);
+        },
+
+        calcSingleNodeLabelSize(parsedNode) {
+          return parsedNode.label_size * state.nodeLabelSizeFactor;
+        },
+
+        calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer) {
+          let edgeSize = edgeSizeNormalizer(parsedEdge[state.edgeSizeDataSource]);
+          if (!isFinite(edgeSize)) {
+            edgeSize = state.parsedData.general.edge_size;
+          }
+          return edgeSize * state.edgeSizeFactor;
+        },
+
+        calcSingleEdgeCurvatureFactor(parsedEdge) {
+          // Caution: Currently a single value is used for all edges instead of these here
+          const appearanceAdaptionFactor = 0.5;
+          return state.edgeCurvature * parsedEdge.multiEdgeCounter * appearanceAdaptionFactor;
+        },
+
+        calcSingleEdgeLabelText(parsedEdge) {
+          return String(parsedEdge[state.edgeLabelTextDataSource]);
+        },
+
+        calcSingleEdgeLabelSize(parsedEdge) {
+          return parsedEdge.label_size * state.edgeLabelSizeFactor;
+        },
+
+        calcSingleNodeBorderSizeDerivatives(shownNode) {
+          shownNode.border_size_half = shownNode.border_size / 2.0;
+        },
+
+        createNodeSizeNormalizer() {
+          let normalizer;
+          if (state.useNodeSizeNormalization) {
+            const dataMin = state.parsedData.general.node_properties.minima[state.nodeSizeDataSource],
+              dataMax = state.parsedData.general.node_properties.maxima[state.nodeSizeDataSource],
+              targetMin = state.nodeSizeNormalizationMin,
+              targetMax = state.nodeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor) || factor === null) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        createEdgeSizeNormalizer() {
+          let normalizer;
+          if (state.useEdgeSizeNormalization) {
+            const dataMin = state.parsedData.general.edge_properties.minima[state.edgeSizeDataSource],
+              dataMax = state.parsedData.general.edge_properties.maxima[state.edgeSizeDataSource],
+              targetMin = state.edgeSizeNormalizationMin,
+              targetMax = state.edgeSizeNormalizationMax,
+              dataDiff = dataMax - dataMin,
+              targetDiff = targetMax - targetMin;
+            let factor = targetDiff / dataDiff;
+            if (!isFinite(factor)) {
+              factor = 0.0;
+            }
+            normalizer = function (val) {
+              return (val - dataMin) * factor + targetMin;
+            }
+          } else {
+            normalizer = function (val) {
+              return val;
+            }
+          }
+          return normalizer;
+        },
+
+        updateNodeSizes() {
+          // Data
+          const nodeSizeNormalizer = state.manager.createNodeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.size = state.manager.calcSingleNodeSize(parsedNode, nodeSizeNormalizer);
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeSizes();
+        },
+
+        updateNodeLabelTexts() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label = state.manager.calcSingleNodeLabelText(parsedNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeLabels();
+        },
+
+        updateNodeLabelSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            shownNode.label_size = state.manager.calcSingleNodeLabelSize(parsedNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeLabels();
+        },
+
+        updateNodeImages() {
+          // Data
+          for (let i = 0; i < state.parsedData.nodes.length; i++) {
+            const parsedNode = state.parsedData.nodes[i],
+              shownNode = state.shownData.nodes[i];
+            state.manager.calcSingleNodeSizeDerivatives(shownNode);
+          }
+          // UI
+          ui.composites.graph.updateNodeImages();
+        },
+
+        updateEdgeSizes() {
+          // Data
+          const edgeSizeNormalizer = state.manager.createEdgeSizeNormalizer();
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.size = state.manager.calcSingleEdgeSize(parsedEdge, edgeSizeNormalizer);
+          }
+          // UI
+          ui.composites.graph.updateEdgeSizes();
+        },
+
+        updateEdgeCurvatures() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.multiEdgeCurvatureFactor = state.manager.calcSingleEdgeCurvatureFactor(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.updateEdgeCurvatures();
+        },
+
+        updateEdgeLabelTexts() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.label = state.manager.calcSingleEdgeLabelText(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.updateEdgeLabels();
+        },
+
+        updateEdgeLabelSizes() {
+          // Data
+          for (let i = 0; i < state.parsedData.edges.length; i++) {
+            const parsedEdge = state.parsedData.edges[i],
+              shownEdge = state.shownData.edges[i];
+            shownEdge.label_size = state.manager.calcSingleEdgeLabelSize(parsedEdge);
+          }
+          // UI
+          ui.composites.graph.updateEdgeLabels();
+        },
+      }
+    }
+
+    const ui = {
+      symbols: {
+        // Choice of symbols is influenced by their appearance in different browsers
+        // Alternatives: "▼", "▽", "▾" / "▲", "△", "▴" / "▶", "▷", "▸" / "◀", "◁", "◂"
+        // ▶ is rendered strangely on some mobile phone browsers, ▸ remains normal
+        detailsShown: "▾",
+        detailsHidden: "▴",
+        menuShown: "▸",
+        menuHidden: "◂",
+        menuItemActive: "▸",
+        menuItemInactive: "▾",
+      },
+
+      elements: {
+        // Containers
+        mainContainer: document.getElementById("§RANDOM_ID§-main-div"),
+        tooltipContainer: document.getElementById("§RANDOM_ID§-tooltip-div"),
+        leftContainer: document.getElementById("§RANDOM_ID§-left-div"),
+        rightContainer: document.getElementById("§RANDOM_ID§-right-div"),
+        graphContainer: document.getElementById("§RANDOM_ID§-graph-div"),
+        detailsContainer: document.getElementById("§RANDOM_ID§-details-div"),
+        detailsHead: document.getElementById("§RANDOM_ID§-details-head"),
+        detailsBody: document.getElementById("§RANDOM_ID§-details-body"),
+        // Data sources
+        dataHead: document.getElementById("§RANDOM_ID§-data-head"),
+        dataBody: document.getElementById("§RANDOM_ID§-data-body"),
+        graphSelectionContainer: document.getElementById("§RANDOM_ID§-graph-select-div"),
+        graphSelection: document.getElementById("§RANDOM_ID§-graph-select"),
+        nodeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-node-size-data-source-select"),
+        nodeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-node-size-normalization-checkbox"),
+        nodeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-node-size-norm-div"),
+        nodeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-node-size-normalization-min-text"),
+        nodeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-min-slider"),
+        nodeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-node-size-normalization-max-text"),
+        nodeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-node-size-normalization-max-slider"),
+        edgeSizeDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-size-data-source-select"),
+        edgeSizeNormalizationCheckbox: document.getElementById("§RANDOM_ID§-edge-size-normalization-checkbox"),
+        edgeSizeNormalizationContainer: document.getElementById("§RANDOM_ID§-edge-size-norm-div"),
+        edgeSizeNormalizationMinText: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-text"),
+        edgeSizeNormalizationMinSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-min-slider"),
+        edgeSizeNormalizationMaxText: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-text"),
+        edgeSizeNormalizationMaxSlider: document.getElementById("§RANDOM_ID§-edge-size-normalization-max-slider"),
+        // General
+        generalHead: document.getElementById("§RANDOM_ID§-general-head"),
+        generalBody: document.getElementById("§RANDOM_ID§-general-body"),
+        resetButton: document.getElementById("§RANDOM_ID§-reset"),
+        fullscreenButton: document.getElementById("§RANDOM_ID§-fullscreen-button"),
+        svgExportButton: document.getElementById("§RANDOM_ID§-svg"),
+        pngExportButton: document.getElementById("§RANDOM_ID§-png"),
+        jpgExportButton: document.getElementById("§RANDOM_ID§-jpg"),
+        // Nodes
+        nodeHead: document.getElementById("§RANDOM_ID§-node-head"),
+        nodeBody: document.getElementById("§RANDOM_ID§-node-body"),
+        nodeCheckbox: document.getElementById("§RANDOM_ID§-node-checkbox"),
+        nodeSizeFactorText: document.getElementById("§RANDOM_ID§-node-size-factor-text"),
+        nodeSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-size-factor-slider"),
+        nodeDragFixCheckbox: document.getElementById("§RANDOM_ID§-node-drag-fix-checkbox"),
+        nodeHoverNeighborhoodCheckbox: document.getElementById("§RANDOM_ID§-node-hover-neighborhood-checkbox"),
+        nodeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-node-hover-tooltip-checkbox"),
+        nodeReleaseButton: document.getElementById("§RANDOM_ID§-node-release-button"),
+        // Node images
+        nodeImageHead: document.getElementById("§RANDOM_ID§-node-image-head"),
+        nodeImageBody: document.getElementById("§RANDOM_ID§-node-image-body"),
+        nodeImageCheckbox: document.getElementById("§RANDOM_ID§-node-image-checkbox"),
+        nodeImageMetaControl: document.getElementById("§RANDOM_ID§-node-image-meta-control"),
+        nodeImageSizeFactorText: document.getElementById("§RANDOM_ID§-node-image-size-factor-text"),
+        nodeImageSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-image-size-factor-slider"),
+        // Node labels
+        nodeLabelHead: document.getElementById("§RANDOM_ID§-node-label-head"),
+        nodeLabelBody: document.getElementById("§RANDOM_ID§-node-label-body"),
+        nodeLabelCheckbox: document.getElementById("§RANDOM_ID§-node-label-checkbox"),
+        nodeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-node-label-border-checkbox"),
+        nodeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-node-label-data-source-select"),
+        nodeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-node-label-size-factor-text"),
+        nodeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-node-label-size-factor-slider"),
+        nodeLabelRotationText: document.getElementById("§RANDOM_ID§-node-label-rotation-text"),
+        nodeLabelRotationSlider: document.getElementById("§RANDOM_ID§-node-label-rotation-slider"),
+        // Edges
+        edgeHead: document.getElementById("§RANDOM_ID§-edge-head"),
+        edgeBody: document.getElementById("§RANDOM_ID§-edge-body"),
+        edgeCheckbox: document.getElementById("§RANDOM_ID§-edge-checkbox"),
+        edgeSizeFactorText: document.getElementById("§RANDOM_ID§-edge-size-factor-text"),
+        edgeSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-size-factor-slider"),
+        edgeCurvatureText: document.getElementById("§RANDOM_ID§-edge-curvature-text"),
+        edgeCurvatureSlider: document.getElementById("§RANDOM_ID§-edge-curvature-slider"),
+        edgeHoverTooltipCheckbox: document.getElementById("§RANDOM_ID§-edge-hover-tooltip-checkbox"),
+        // Edge labels
+        edgeLabelHead: document.getElementById("§RANDOM_ID§-edge-label-head"),
+        edgeLabelBody: document.getElementById("§RANDOM_ID§-edge-label-body"),
+        edgeLabelCheckbox: document.getElementById("§RANDOM_ID§-edge-label-checkbox"),
+        edgeLabelBorderCheckbox: document.getElementById("§RANDOM_ID§-edge-label-border-checkbox"),
+        edgeLabelTextDataSourceSelect: document.getElementById("§RANDOM_ID§-edge-label-data-source-select"),
+        edgeLabelSizeFactorText: document.getElementById("§RANDOM_ID§-edge-label-size-factor-text"),
+        edgeLabelSizeFactorSlider: document.getElementById("§RANDOM_ID§-edge-label-size-factor-slider"),
+        edgeLabelRotationText: document.getElementById("§RANDOM_ID§-edge-label-rotation-text"),
+        edgeLabelRotationSlider: document.getElementById("§RANDOM_ID§-edge-label-rotation-slider"),
+        // Layout algorithm
+        layoutAlgorithmHead: document.getElementById("§RANDOM_ID§-layout-algorithm-head"),
+        layoutAlgorithmBody: document.getElementById("§RANDOM_ID§-layout-algorithm-body"),
+        simulationCheckbox: document.getElementById("§RANDOM_ID§-simulation-active-checkbox"),
+        layoutAlgorithmSelection: document.getElementById("§RANDOM_ID§-layout-algorithm-select"),
+        centralGravitySlider: document.getElementById("§RANDOM_ID§-central-gravity-slider"),
+        centralGravityText: document.getElementById("§RANDOM_ID§-central-gravity-text"),
+        springLengthSlider: document.getElementById("§RANDOM_ID§-spring-length-slider"),
+        springLengthText: document.getElementById("§RANDOM_ID§-spring-length-text"),
+        springConstantSlider: document.getElementById("§RANDOM_ID§-spring-constant-slider"),
+        springConstantText: document.getElementById("§RANDOM_ID§-spring-constant-text"),
+        gravitationalConstantContainer: document.getElementById("§RANDOM_ID§-gravitational-constant-div"),
+        gravitationalConstantSlider: document.getElementById("§RANDOM_ID§-gravitational-constant-slider"),
+        gravitationalConstantText: document.getElementById("§RANDOM_ID§-gravitational-constant-text"),
+        avoidOverlapContainer: document.getElementById("§RANDOM_ID§-avoid-overlap-div"),
+        avoidOverlapSlider: document.getElementById("§RANDOM_ID§-avoid-overlap-slider"),
+        avoidOverlapText: document.getElementById("§RANDOM_ID§-avoid-overlap-text"),
+      },
+
+      composites: {
+        responsiveContainer: {
+          init() {
+            // Delete all contained items (relevant only for reset, not first creation)
+            ui.deleteChildElements(ui.elements.graphContainer);
+            ui.deleteChildElements(ui.elements.detailsBody);
+            // Menu
+            if (state.showMenu) {
+              ui.composites.menu.show();
+            } else {
+              ui.composites.menu.hide();
+            }
+            // Details
+            if (state.showDetails) {
+              ui.composites.details.show(true);
+            } else {
+              ui.composites.details.hide(true);
+            }
+            // Divs
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.responsiveContainer.getInnerWidths();
+          },
+
+          getInnerWidths() {
+            state.graphContainerWidth = parseInt(ui.elements.graphContainer.clientWidth);
+            state.detailsContainerWidth = parseInt(ui.elements.detailsContainer.clientWidth);
+          },
+
+          getInnerHeights() {
+            state.graphContainerHeight = parseInt(ui.elements.graphContainer.clientHeight);
+            if (state.showDetails) {
+              state.detailsContainerHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+            }
+          },
+
+          setInnerHeights() {
+            ui.elements.graphContainer.style.height = state.graphContainerHeight + "px";
+            ui.elements.detailsContainer.style.height = state.detailsContainerHeight + "px";
+          },
+
+          setOuterHeights() {
+            ui.elements.mainContainer.style.height = ui.elements.leftContainer.offsetHeight + "px";
+          },
+
+          getSizes() {
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+          },
+
+          setSizes() {
+            ui.composites.responsiveContainer.setInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+          },
+
+          adaptToResize() {
+            ui.composites.responsiveContainer.getSizes();
+            ui.composites.responsiveContainer.setSizes();
+          },
+
+          adaptToFullscreen() {
+            ui.composites.responsiveContainer.getSizes();
+            if (document.fullscreenElement) {
+              // On entering fullscreen, remember the current container heights
+              state.beforeFullscreenGraphContainerHeight = state.graphContainerHeight;
+              state.beforeFullscreenDetailsContainerHeight = state.detailsContainerHeight;
+              // and then adapt them to maximum height possible in full screen mode
+              function calculateFullscreenMaxGraphHeight() {
+                let outerHeight = null;
+                try {
+                  const mainDivComputedStyle = window.getComputedStyle(ui.elements.mainContainer),
+                    graphDivComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                    paddingTop = parseFloat(mainDivComputedStyle.paddingTop),
+                    borderTop = parseFloat(graphDivComputedStyle.borderTopWidth),
+                    borderBottom = parseFloat(graphDivComputedStyle.borderBottomWidth),
+                    paddingBottom = parseFloat(mainDivComputedStyle.paddingBottom);
+                  outerHeight = paddingTop + borderTop + borderBottom + paddingBottom;
+                  if (!isFinite(outerHeight) || outerHeight === null) {
+                    throw "Invalid number";
                   }
+                } catch (e) {
+                  // Hard coded fallback, depends on CSS of containers (1px borders, 6px padding)
+                  outerHeight = 1 + 3 + 3 + 1;
                 }
-                // Prevent node movements: Remove stored positions of nodes once fixed and now released
-                if(visNode.fixed === false){
-                  delete visNode.x;
-                  delete visNode.y;
+                let graphHeight = screen.height - outerHeight;
+                if (state.showDetails) {
+                  graphHeight -= ui.composites.details.calculateHeightDifference();
                 }
-                newVisNodes.push(visNode);
+                return graphHeight;
               }
-              state.visData.nodes.update(newVisNodes);
-            },
+              state.graphContainerHeight = calculateFullscreenMaxGraphHeight();
+            } else {
+              // On leaving fullscreen, set container heights back to remembered values
+              state.graphContainerHeight = state.beforeFullscreenGraphContainerHeight;
+              state.detailsContainerHeight = state.beforeFullscreenDetailsContainerHeight;
+            }
+            ui.composites.responsiveContainer.setSizes();
+          },
+        },
 
-            preventNodeJump(visNode){
-              if(visNode.fixed === false){
-                delete visNode.x;
-                delete visNode.y;
+        menu: {
+          show() {
+            ui.elements.leftContainer.style.width = "80%";
+            ui.elements.rightContainer.style.width = "20%";
+            ui.elements.rightContainer.style.display = "block";
+          },
+
+          hide() {
+            ui.elements.leftContainer.style.width = "100%";
+            ui.elements.rightContainer.style.width = "0%";
+            ui.elements.rightContainer.style.display = "none";
+          },
+
+          toggle() {
+            // Update menu button
+            const div = ui.elements.menuToggleDiv;
+            state.showMenu = !state.showMenu;
+            if (state.showMenu) {
+              div.innerText = ui.symbols.menuShown;
+              ui.composites.menu.show();
+            } else {
+              div.innerHTML = ui.symbols.menuHidden;
+              ui.composites.menu.hide();
+            }
+
+            // Update rest of UI
+            ui.composites.responsiveContainer.getInnerWidths();
+            ui.composites.responsiveContainer.getInnerHeights();
+            ui.composites.responsiveContainer.setOuterHeights();
+            ui.composites.graph.updateGraphDrawingArea();
+          },
+
+          setItem(keyElement, valElement, toActive) {
+            const currentText = keyElement.innerHTML;
+            let sliceStart = 0;
+            if (currentText.startsWith(ui.symbols.menuItemActive)) {
+              sliceStart = ui.symbols.menuItemActive.length;
+            } else if (currentText.startsWith(ui.symbols.menuItemInactive)) {
+              sliceStart = ui.symbols.menuItemInactive.length;
+            }
+            if (toActive) {
+              keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
+              keyElement.classList.add("§RANDOM_ID§-active");
+              valElement.style.display = "block";
+            } else {
+              keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
+              keyElement.classList.remove("§RANDOM_ID§-active");
+              valElement.style.display = "none";
+            }
+          },
+
+          toggleItem(keyElement, valElement) {
+            const toActive = !(valElement.style.display !== "none");
+            ui.composites.menu.setItem(keyElement, valElement, toActive);
+          },
+        },
+
+        details: {
+          calculateHeightDifference() {
+            let outerHeight = null;
+            try {
+              const graphContainerComputedStyle = window.getComputedStyle(ui.elements.graphContainer),
+                detailsContainerComputedStyle = window.getComputedStyle(ui.elements.detailsContainer),
+                border1 = parseFloat(graphContainerComputedStyle.borderBottomWidth),
+                margin = parseFloat(detailsContainerComputedStyle.marginTop),
+                border2 = parseFloat(detailsContainerComputedStyle.borderTopWidth);
+              outerHeight = border1 + margin + border2;
+              if (!isFinite(outerHeight) || outerHeight === null) {
+                throw "Invalid number";
               }
-            },
+            } catch (e) {
+              // Hard coded fallback, depends on CSS of containers (1px borders, 5px margin)
+              outerHeight = 7.0;
+            }
+            return state.detailsContainerHeight + outerHeight
+          },
 
-            updateNodeVisibilities(){
-              ui.composites.graph.updateNodes();
-            },
-
-            updateNodeSizes(){
-              const data = state.shownData,
-                newVisNodes = [];
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i],
-                  visNode = state.visData.nodes.get(node.id);
-                visNode.size = node.size;
-                if(state.showNodeImages && typeof(node.image) !== "undefined"){
-                  visNode.size = node.image_size;
-                }
-                ui.composites.graph.preventNodeJump(visNode);
-                newVisNodes.push(visNode);
+          show(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "block";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight -= heightDiff;
+              if (state.graphContainerHeight < 70) {
+                state.graphContainerHeight = 70;
               }
-              state.visData.nodes.update(newVisNodes);
-            },
+              // Update rest of UI
+              ui.composites.responsiveContainer.setSizes();
+              ui.composites.graph.updateGraphDrawingArea();
+            }
+          },
 
-            updateNodeHoverNeighborhoodBehavior(){
-              state.visOptions.interaction.hover = state.nodeHoverNeighborhood;
-              state.visOptions.interaction.hoverConnectedEdges = state.nodeHoverNeighborhood;
-              state.visGraph.setOptions(state.visOptions);
-            },
+          hide(init = false) {
+            // Visibility
+            ui.elements.detailsContainer.style.display = "none";
+            if (!init) {
+              // Height
+              const heightDiff = ui.composites.details.calculateHeightDifference();
+              state.graphContainerHeight += heightDiff;
+              // Update rest of UI
+              ui.composites.responsiveContainer.setSizes();
+              ui.composites.graph.updateGraphDrawingArea();
+            }
+          },
 
-            updateNodeHoverTooltipBehavior(){
-              const data = state.shownData,
-                newVisNodes = [];
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i],
-                  visNode = state.visData.nodes.get(node.id);
-                if(typeof(node.hover) !== "undefined"){
-                  visNode.title = state.nodeHoverTooltip ? node.hover : null;
-                }
-                newVisNodes.push(visNode);
+          toggle() {
+            // Update details button
+            const toggleDiv = ui.elements.detailsToggleDiv;
+            state.showDetails = !state.showDetails;
+            if (state.showDetails) {
+              toggleDiv.innerText = ui.symbols.detailsShown;
+              ui.composites.details.show();
+            } else {
+              toggleDiv.innerHTML = ui.symbols.detailsHidden;
+              ui.composites.details.hide();
+            }
+          },
+        },
+
+        download: {
+          png(filename) {
+            ui.composites.download._rasterImage(filename, "png");
+          },
+
+          jpg(filename) {
+            ui.composites.download._rasterImage(filename, "jpeg");
+          },
+
+          _rasterImage(filename, format) {
+            const canvas = ui.elements.graphContainer.getElementsByTagName("canvas")[0],
+              mimeType = "image/" + format;
+            function finishedBlobCallback(blob) {
+              ui.composites.download._blobToFileDownload(blob, filename);
+            }
+            try {
+              // Blob to overcome size limitations for data URLs (e.g. 4MB in Chrome)
+              canvas.toBlob(finishedBlobCallback, mimeType, 1.0);
+            } catch (e) {
+              if (e.name === "SecurityError") {
+                alert("Image creation failed. Some images within the nodes of the graph can " +
+                  "not be fetched from within JavaScript due to security settings of the " +
+                  "server that provides the images.");
+              } else {
+                throw e;
               }
-              state.visData.nodes.update(newVisNodes);
-            },
+            }
+          },
 
-            // Node images
-            updateNodeImages(){
-              const data = state.shownData,
-                newVisNodes = [];
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i],
-                  visNode = state.visData.nodes.get(node.id);
-                visNode.shape = node.shape;
-                if(state.showNodes){
-                  visNode.size = node.size;
-                } else {
-                  visNode.size = 0.0;
-                }
-                if(state.showNodeImages){
-                  if(typeof(node.image) !== "undefined"){
-                    visNode.size = node.image_size;
-                    visNode.shape = "image";
-                    visNode.image = node.image;
-                  }
-                }
-                ui.composites.graph.preventNodeJump(visNode);
-                newVisNodes.push(visNode);
+          _blobToFileDownload(blob, filename) {
+            const url = URL.createObjectURL(blob),
+              a = document.createElement("a");
+            function handleClick() {
+              setTimeout(function () {
+                // Long waiting time before removal for slow devices like mobile phones
+                URL.revokeObjectURL(url);
+                this.removeEventListener("click", handleClick);
+              }, 20000);
+            };
+            document.body.appendChild(a);
+            a.href = url;
+            a.download = filename;
+            a.addEventListener("click", handleClick, false);
+            a.click();
+            document.body.removeChild(a);
+          },
+        },
+
+        selection(element, optionList, valueList = undefined) {
+          while (element.hasChildNodes()) {
+            element.removeChild(element.firstChild);
+          }
+          for (let i = 0; i < optionList.length; i++) {
+            let text = optionList[i];
+            let value = text;
+            if (valueList) {
+              value = valueList[i];
+            }
+            let opt = document.createElement("option");
+            opt.appendChild(document.createTextNode(text));
+            opt.value = value;
+            element.appendChild(opt);
+          }
+        },
+
+        tooltip: {
+          show(xShift = null, yShift = null) {
+            if (isFinite(xShift) && xShift !== null) {
+              ui.elements.tooltipContainer.style.left = parseInt(xShift) + "px";
+            }
+            if (isFinite(yShift) && yShift !== null) {
+              ui.elements.tooltipContainer.style.top = parseInt(yShift) + "px";
+            }
+            ui.elements.tooltipContainer.style.transition = "visibility 0s, opacity 0.1s";
+            ui.elements.tooltipContainer.style.visibility = "visible";
+            ui.elements.tooltipContainer.style.opacity = 1.0;
+          },
+
+          hide() {
+            ui.elements.tooltipContainer.style.transition = "visibility 0.3s, opacity 0.3s ease-in";
+            ui.elements.tooltipContainer.style.visibility = "hidden";
+            ui.elements.tooltipContainer.style.opacity = 0.0;
+          },
+        },
+
+        progressBar: {
+          create() {
+            // Main container
+            this.mainContainer = document.createElement("div");
+            this.mainContainer.id = "§RANDOM_ID§-progress-container";
+            this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
+            ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
+            // Text container
+            const numNodes = state.parsedData.nodes.length;
+            this.textContainer = document.createElement("div");
+            this.textContainer.innerText = "Large graph with " + numNodes + " nodes. Calculating an initial layout before visualizing it.";
+            this.textContainer.style.textAlign = "center";
+            // Bar container
+            this.outerBarContainer = document.createElement("div");
+            this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
+            this.innerBarContainer = document.createElement("div");
+            this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
+            this.innerBarContainer.style.width = "0%";
+            // Add them to DOM
+            this.outerBarContainer.appendChild(this.innerBarContainer);
+            this.mainContainer.appendChild(this.textContainer);
+            this.mainContainer.appendChild(this.outerBarContainer);
+            ui.elements.graphContainer.appendChild(this.mainContainer);
+          },
+
+          update(percentage) {
+            this.innerBarContainer.style.width = percentage + "%";
+          },
+
+          remove() {
+            ui.elements.graphContainer.removeChild(this.mainContainer);
+          }
+        },
+
+        graph: {
+          createGraph() {
+            // Remove existing elements
+            ui.deleteChildElements(ui.elements.graphContainer);
+
+            // Create new elements
+            // I) Set graph options
+            // a) Nodes: https://visjs.github.io/vis-network/docs/network/nodes.html
+            const data = state.shownData,
+              visNodes = [];
+            let graphContainsFixedPositions = false;
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i];
+              let visNode = {
+                id: node.id,
+                shape: node.shape,
+                borderWidth: node.border_size,
+                color: {
+                  background: node.color,
+                  border: node.border_color,
+                },
               }
-              state.visData.nodes.update(newVisNodes);
-            },
-
-            // Node labels
-            updateNodeLabels(){
-              // Vis data sets: https://visjs.github.io/vis-data/data/dataset.html
-              const data = state.shownData,
-                newVisNodes = [];
-              for(let i=0; i<data.nodes.length; i++){
-                const node = data.nodes[i];
-                const visNode = state.visData.nodes.get(node.id);
-                if(state.showNodeLabels){
+              // - Node labels
+              if (state.showNodeLabels) {
+                if (typeof (node.label) !== "undefined") {
                   visNode.label = node.label;
                   visNode.font = {
                     size: node.label_size,
@@ -2791,108 +2275,75 @@
                     strokeWidth: (state.showNodeLabelBorders ? 1.2 : 0.0),
                     strokeColor: data.general.background_color,
                   }
-                } else{
-                  visNode.label = undefined;
                 }
-                ui.composites.graph.preventNodeJump(visNode);
-                newVisNodes.push(visNode);
               }
-              state.visData.nodes.update(newVisNodes);
-            },
-
-            // Edges
-            calculateEdgeCurvatureOptions(){
-              const appearanceAdaptionFactor = 0.5,
-                options = {
-                "type": state.edgeCurvature > 0.0 ? "curvedCW" : "curvedCCW",
-                "roundness": Math.abs(state.edgeCurvature) * appearanceAdaptionFactor,
-              };
-              return options
-            },
-
-            updateEdgeVisibility(){
-              const data = state.shownData,
-                newVisEdges = [];
-              for(let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i],
-                  visEdge = state.visData.edges.get(edge.id);
-                visEdge.hidden = !state.showEdges;
-                newVisEdges.push(visEdge);
-              }
-              state.visData.edges.update(newVisEdges);
-            },
-
-            updateEdgeSizes(){
-              const data = state.shownData,
-                newVisEdges = [];
-              for (let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i],
-                  newVisEdge = state.visData.edges.get(edge.id);
-                newVisEdge.width = edge.size;
-                newVisEdges.push(newVisEdge);
-              }
-              state.visData.edges.update(newVisEdges);
-            },
-
-            updateEdgeCurvatures(){
-              if(state.edgeCurvature === 0.0){
-                state.visOptions.edges.smooth = false;
+              // - Nodes hidden/shown ("hidden" property hides entire graph, using size=0 instead)
+              if (state.showNodes || (typeof (node.image) !== "undefined" && state.showNodeImages)) {
+                visNode.size = node.size;
               } else {
-                state.visOptions.edges.smooth = ui.composites.graph.calculateEdgeCurvatureOptions();
+                visNode.size = 0.0;
               }
-              state.visGraph.setOptions(state.visOptions);
-            },
-
-            updateEdgeHoverTooltipBehavior(){
-              /* Correct code, but there is a bug that renders null values as empty div (instead of ignoring them)
-              const data = state.shownData,
-                newVisEdges = [];
-              for(let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i],
-                  visEdge = state.visData.edges.get(edge.id);
-                if(typeof(edge.hover) !== "undefined"){
-                  visEdge.title = state.edgeHoverTooltip ? edge.hover : null;
-                }
-                newVisEdges.push(visEdge);
-              }
-              state.visData.edges.update(newVisEdges);
-              */
-              // Workaround code
-              function cloneObject(obj){
-                return Object.assign({}, obj);
-              }
-              const data = state.shownData,
-                newVisEdges = [];
-              for(let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i],
-                  visEdge = state.visData.edges.get(edge.id);
-                if(typeof(edge.hover) !== "undefined"){
-                  if(state.edgeHoverTooltip){
-                    visEdge.title = edge.hover;
-                    newVisEdges.push(visEdge);
-                  } else{
-                    // edges.update can only add properties, not delete them, hence use of clone/remove/add
-                    clonedEdge = cloneObject(visEdge);
-                    delete clonedEdge.title;
-                    state.visData.edges.remove(edge.id);
-                    state.visData.edges.add(clonedEdge);
-                  }
+              // - Node images
+              if (typeof (node.image) !== "undefined") {
+                if (state.showNodeImages) {
+                  visNode.shape = "image";
+                  visNode.image = node.image;
+                  visNode.size = node.image_size;
+                  // prevent a visual change of nodes with images upon selection (not deactivatable)
+                  visNode.color.highlight = {
+                    background: visNode.color.background,
+                    border: visNode.color.border,
+                  };
+                  visNode.borderWidthSelected = visNode.borderWidth;
                 }
               }
-              if(state.edgeHoverTooltip){
-                state.visData.edges.update(newVisEdges);
+              // - Node positions
+              const x = node.fx,
+                y = node.fy;
+              if ((typeof (x) !== "undefined") || (typeof (y) !== "undefined")) {
+                graphContainsFixedPositions = true;
+                visNode.fixed = {}
+                if (typeof (x) !== "undefined") {
+                  visNode.x = x;
+                  visNode.fixed.x = true;
+                }
+                if (typeof (y) !== "undefined") {
+                  visNode.y = y;
+                  visNode.fixed.y = true;
+                }
               }
-            },
+              // - Node hover behavior 1: highlight neighborhood
+              visNode.color.hover = {
+                background: visNode.color.background,
+                border: visNode.color.background,
+              };
+              // - Node hover behavior 2: show tooltip
+              if (state.nodeHoverTooltip) {
+                if (typeof (node.hover) !== "undefined") {
+                  visNode.title = node.hover;
+                }
+              }
+              // - Node click behavior: show details
+              if (typeof (node.click) !== "undefined" && node.click !== "") {
+                visNode.click = node.click;
+              }
+              visNodes.push(visNode);
+            }
 
-            // Edge labels
-            updateEdgeLabels(){
-              const data = state.shownData,
-                newVisEdges = [],
-                noLabel = " ";  // undefined, null, "" or deleting label property does not work
-              for(let i=0; i<data.edges.length; i++){
-                const edge = data.edges[i],
-                  visEdge = state.visData.edges.get(edge.id);
-                if(state.showEdgeLabels){
+            // b) Edges: https://visjs.github.io/vis-network/docs/network/edges.html
+            const visEdges = [];
+            for (let i = 0; i < data.edges.length; i++) {
+              const edge = data.edges[i];
+              const visEdge = {
+                id: edge.id,
+                from: edge.source.id,
+                to: edge.target.id,
+                color: edge.color,
+                width: edge.size,
+              };
+              // - Edge labels
+              if (state.showEdgeLabels) {
+                if (typeof (edge.label) !== "undefined") {
                   visEdge.label = edge.label;
                   visEdge.font = {
                     size: edge.label_size,
@@ -2900,620 +2351,1110 @@
                     strokeWidth: (state.showEdgeLabelBorders ? 1.2 : 0.0),
                     strokeColor: data.general.background_color,
                   }
-                } else {
-                  visEdge.label = noLabel;
                 }
-                newVisEdges.push(visEdge);
               }
-              state.visData.edges.update(newVisEdges);
-            },
+              // - Edges hidden/shown
+              if (!state.showEdges) {
+                visEdge.hidden = true;
+              }
+              // - Edge hover behavior
+              if (state.edgeHoverTooltip) {
+                if (typeof (edge.hover) !== "undefined") {
+                  visEdge.title = edge.hover;
+                }
+              }
+              // - Edge click behavior
+              if (typeof (edge.click) !== "undefined" && edge.click !== "") {
+                visEdge.click = edge.click;
+              }
+              visEdges.push(visEdge);
+            }
+            // c) Options: https://visjs.github.io/vis-network/docs/network/
+            const options = {};
+            // - Nodes
+            options.nodes = {};
+            options.nodes.chosen = false;
+            options.nodes.imagePadding = 1.5;
+            options.nodes.labelHighlightBold = false;
+            options.nodes.shapeProperties = {};
+            options.nodes.shapeProperties.useBorderWithImage = true;
+            // - Node label font family
+            if (state.nodeLabelFont !== null) {
+              options.nodes.font = {
+                "face": state.nodeLabelFont,
+              }
+            }
+            // - Edges
+            options.edges = {};
+            // - Edges hidden/shown
+            if (!state.showEdges) {
+              options.edges.hidden = true;
+            }
+            // - Edge curvature
+            if (state.edgeCurvature === 0.0) {
+              options.edges.smooth = false;
+            } else {
+              options.edges.smooth = ui.composites.graph.calculateEdgeCurvatureOptions();
+            }
+            // - Edge arrows
+            if (data.general.directed) {
+              options.edges.arrows = {};
+              options.edges.arrows.to = {};
+              options.edges.arrows.to.enabled = true;
+              if (data.general.arrow_size !== 0.0) {
+                options.edges.arrows.to.scaleFactor = data.general.arrow_size / 10.0;
+              }
+            }
+            // - Edge label font family
+            if (state.edgeLabelFont !== null) {
+              options.edges.font = {
+                "face": state.edgeLabelFont,
+              }
+            }
+            // - Drawing area
+            options.autoResize = false;
+            // - Interaction
+            options.interaction = {};
+            options.interaction.selectable = false;
+            options.interaction.selectConnectedEdges = false;
+            options.interaction.tooltipDelay = 0.0;
+            options.interaction.hover = state.nodeHoverNeighborhood;
+            options.interaction.hoverConnectedEdges = state.nodeHoverNeighborhood;
+            // - Layout algorithm
+            const numNodes = state.parsedData.nodes.length;
+            options.layout = {};
+            if (numNodes < 400) {
+              options.layout.improvedLayout = true;
+            } else {
+              options.layout.improvedLayout = false;
+            }
+            options.physics = {};
+            options.physics.barnesHut = { "damping": 0.25 };
+            options.physics.forceAtlas2Based = { "damping": 3.0 };
+            options.physics.repulsion = {};
+            options.physics.hierarchicalRepulsion = {};
+            options.physics.stabilization = {};
+            options.physics.stabilization.enabled = false;
+            if (numNodes > state.largeGraphThreshold) {
+              let numIterations = 800;
+              if (numNodes >= 25000) {
+                numIterations = 100;
+              } else if (numNodes >= 10000) {
+                numIterations = 300;
+              } else if (numNodes >= 5000) {
+                numIterations = 400;
+              } else if (numNodes >= 2000) {
+                numIterations = 500;
+              } else if (numNodes >= 1000) {
+                numIterations = 600;
+              }
+              options.physics.stabilization = {
+                "enabled": true,
+                "fit": true,
+                "iterations": numIterations,
+                "updateInterval": 1,
+              };
+            }
+            // II) Create graph
+            // - DataSet and Network: https://visjs.github.io/vis-network/docs/network
+            state.visOptions = options;
+            state.visData = {
+              nodes: new vis.DataSet(visNodes),
+              edges: new vis.DataSet(visEdges),
+            };
+            state.visGraph = new vis.Network(ui.elements.graphContainer, state.visData, state.visOptions);
+            // III) Set further graph options after its creation
+            // - Background: https://github.com/almende/vis/issues/2292
+            state.visGraph.on("beforeDrawing", function (ctx) {
+              ctx.save();
+              ctx.setTransform(1, 0, 0, 1, 0, 0);
+              ctx.fillStyle = data.general.background_color;
+              ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+              ctx.restore();
+            })
+            // - Node positions: node update after graph creation seems to prevent a bug
+            if (graphContainsFixedPositions) {
+              state.visData.nodes.update(visNodes);
+            }
+            // - Graph behavior
+            ui.composites.graph.setBehavior();
 
-            // Layout algorithm
-            simulationManager:{
-              start(){
-                state.visGraph.startSimulation();
-                this.setAlgorithm();
-                this.setSpringLength();
-                this.setSpringConstant();
-                this.setCentralGravity();
-                this.setGravitationalConstant();
-                this.setAvoidOverlap();
-              },
-              stop(){
+            // Menu toggle button
+            if (state.showMenuToggleButton) {
+              const menuDiv = document.createElement("div");
+              if (state.showMenu) {
+                menuDiv.innerText = ui.symbols.menuShown;
+              } else {
+                menuDiv.innerText = ui.symbols.menuHidden;
+              }
+              menuDiv.id = "§RANDOM_ID§-menu-toggle-button";
+              menuDiv.onclick = ui.composites.menu.toggle;
+              ui.elements.graphContainer.appendChild(menuDiv);
+              ui.elements.menuToggleDiv = menuDiv;
+            }
+            // Details toggle button
+            if (state.showDetailsToggleButton) {
+              const detailsDiv = document.createElement("div");
+              if (state.showDetails) {
+                detailsDiv.innerText = ui.symbols.detailsShown;
+              } else {
+                detailsDiv.innerText = ui.symbols.detailsHidden;
+              }
+              detailsDiv.id = "§RANDOM_ID§-details-toggle-button";
+              detailsDiv.onclick = ui.composites.details.toggle;
+              ui.elements.graphContainer.appendChild(detailsDiv);
+              ui.elements.detailsToggleDiv = detailsDiv;
+            }
+          },
+
+          setBehavior() {
+            // - Progress bar: only if large graph, stops simulation to get initial static image
+            // https://visjs.github.io/vis-network/examples/network/exampleApplications/loadingBar.html
+            const numNodes = state.parsedData.nodes.length;
+            if (numNodes > state.largeGraphThreshold) {
+              // Layout start
+              ui.composites.progressBar.create();
+              // Layout update
+              state.visGraph.on("stabilizationProgress", function (params) {
+                var progressPercentage = params.iterations / params.total * 100;
+                ui.composites.progressBar.update(progressPercentage);
+              });
+              // Layout finished
+              state.visGraph.once("stabilizationIterationsDone", function () {
+                setTimeout(function () {
+                  ui.composites.progressBar.remove();
+                  ui.composites.graph.simulationManager.stop();
+                }, 60);
+              });
+            }
+            // - Node drag behavior: move node, fix its position or release it afterwards
+            state.visGraph.on("dragStart", function (params) {
+              params.event = "[original event]";
+              const nodeId = this.getNodeAt(params.pointer.DOM);
+              if (nodeId) {
+                const visNode = state.visData.nodes.get(nodeId),
+                  position = state.visGraph.getPositions(nodeId);
+                visNode.x = position.x;
+                visNode.y = position.y;
+                visNode.fixed = false;
+                state.visData.nodes.update(visNode);
+              }
+            });
+            state.visGraph.on("dragEnd", function (params) {
+              params.event = "[original event]";
+              const nodeId = this.getNodeAt(params.pointer.DOM);
+              if (nodeId) {
+                if (state.nodeDragFix) {
+                  const visNode = state.visData.nodes.get(nodeId),
+                    position = state.visGraph.getPositions(nodeId);
+                  visNode.x = position.x;
+                  visNode.y = position.y;
+                  visNode.fixed = { "x": true, "y": true }
+                  state.visData.nodes.update(visNode);
+                }
+              }
+            });
+            // - Node and edge hover behavior: already covered
+            // - Node and edge click behavior
+            // https://visjs.github.io/vis-network/examples/network/events/interactionEvents.html
+            function createNodeText(node) {
+              let htmlText = "<div>Node: " + String(node.id) + "</div>";
+              if (typeof (node.click) !== "undefined" && node.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + node.click + '</div>';
+              }
+              return htmlText;
+            }
+            function createEdgeText(edge) {
+              let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
+              if (typeof (edge.click) !== "undefined" && edge.click !== "") {
+                htmlText += '<div id="§RANDOM_ID§-details-user-provided">' + edge.click + '</div>';
+              }
+              return htmlText;
+            }
+            state.visGraph.on("click", function (params) {
+              params.event = "[original event]";
+              let htmlText = "";
+              const nodeId = this.getNodeAt(params.pointer.DOM);
+              if (nodeId) {
+                const node = state.visData.nodes.get(nodeId);
+                if (node) {
+                  htmlText = createNodeText(node);
+                }
+              } else {
+                const edgeId = this.getEdgeAt(params.pointer.DOM);
+                if (edgeId) {
+                  const edge = state.visData.edges.get(edgeId);
+                  if (edge) {
+                    htmlText = createEdgeText(edge);
+                  }
+                }
+              }
+              ui.elements.detailsBody.innerHTML = htmlText;
+            });
+            // - Simulation behavior
+            state.visGraph.on("startStabilizing", function (params) {
+              // A manually stopped simulation restarts automatically by dragging a node or
+              // altering a dataset, immediately triggering this event. So if the simulation
+              // shall be inactive, any automatic restart can be turned off immediately here.
+              if (!state.layoutAlgorithmActive) {
                 state.visGraph.stopSimulation();
-              },
-              setActivity(on){
-                if(on){
-                  this.start();
-                } else{
-                  this.stop();
-                }
-              },
-              setAlgorithm(){
-                const name = state.layoutAlgorithm;
-                state.visOptions.physics.solver = name;
-                state.visGraph.setOptions(state.visOptions);
-                if(name === "repulsion"){
-                  ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(false);
-                  ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(false);
-                } else if(name === "hierarchicalRepulsion"){
-                  ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(true);
-                  ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(false);
-                } else {
-                  ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(true);
-                  ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(true);
-                }
-              },
-              releaseFixedNodes(){
-                const data = state.shownData,
-                  newVisNodes = [];
-                for(let i=0; i<data.nodes.length; i++){
-                  const node = data.nodes[i],
-                    visNode = state.visData.nodes.get(node.id);
-                  ui.composites.graph.preventNodeJump(visNode);
-                  visNode.fixed = false;
-                  // Note: Deletion of x, y and fixed may work too, but .update does not delete props
-                  newVisNodes.push(visNode);
-                }
-                state.visData.nodes.update(newVisNodes);
-              },
-              setSpringLength(){
-                state.visOptions.physics.barnesHut.springLength = state.springLength;
-                state.visOptions.physics.forceAtlas2Based.springLength = state.springLength;
-                state.visOptions.physics.repulsion.springLength = state.springLength;
-                state.visOptions.physics.hierarchicalRepulsion.springLength = state.springLength;
-                state.visGraph.setOptions(state.visOptions);
-              },
-              setSpringConstant(){
-                state.visOptions.physics.barnesHut.springConstant = state.springConstant / 10.0;
-                state.visOptions.physics.forceAtlas2Based.springConstant = state.springConstant;
-                state.visOptions.physics.repulsion.springConstant = state.springConstant;
-                state.visOptions.physics.hierarchicalRepulsion.springConstant = state.springConstant;
-                state.visGraph.setOptions(state.visOptions);
-              },
-              setCentralGravity(){
-                state.visOptions.physics.barnesHut.centralGravity = state.centralGravity;
-                state.visOptions.physics.forceAtlas2Based.centralGravity = state.centralGravity / 100.0;
-                state.visOptions.physics.repulsion.centralGravity = state.centralGravity;
-                state.visOptions.physics.hierarchicalRepulsion.centralGravity = state.centralGravity;
-                state.visGraph.setOptions(state.visOptions);
-              },
-              setGravitationalConstant(){
-                state.visOptions.physics.barnesHut.gravitationalConstant = state.gravitationalConstant;
-                state.visOptions.physics.forceAtlas2Based.gravitationalConstant = state.gravitationalConstant / 10.0;
-                // Not a parameter in repulsion and hierarchicalRepulsion
-                state.visGraph.setOptions(state.visOptions);
-              },
-              setAvoidOverlap(){
-                state.visOptions.physics.barnesHut.avoidOverlap = state.avoidOverlap;
-                state.visOptions.physics.forceAtlas2Based.avoidOverlap = state.avoidOverlap;
-                // Not a parameter in repulsion and hierarchicalRepulsion
-                state.visGraph.setOptions(state.visOptions);
-              },
-            }
-          },
-        },
-
-        init(){
-          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
-          // Containers
-          ui.composites.responsiveContainer.init();
-          // Graph selection (only visible if multiple graphs in data)
-          if(state.rawData.length > 1){
-            ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
-            const optionList = [],
-              valueList = [];
-            let label;
-            for(let i=0; i<state.rawData.length; i++){
-              const graph = state.rawData[i];
-              try{
-                label = String(graph.label);
-                if(label === "undefined" || label === ""){
-                  throw "Invalid label";
-                }
-              } catch(e){
-                label = "Unnamed graph";
               }
-              const name = String(i+1) + ": " + label;
-              optionList.push(name);
-              valueList.push(String(i));
-            }
-            ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
-          }
-          // General (menu item)
-          ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
-          // Data selection (menu item)
-          ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
-          // - Node size
-          ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
-          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-          ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-          ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-          // - Edge size
-          ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
-          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-          ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-          ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+            });
+            // Start (considers all simulation parameters)
+            ui.composites.graph.simulationManager.start();
+          },
+
+          // Graph
+          updateGraphDrawingArea() {
+            state.visGraph.setSize(state.graphContainerWidth, state.graphContainerHeight);
+            state.visGraph.redraw();
+          },
+
           // Nodes
-          ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
-          ui.elements.nodeCheckbox.checked = state.showNodes;
-          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
-          ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
-          ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
-          ui.elements.nodeHoverNeighborhoodCheckbox.checked = state.nodeHoverNeighborhood;
-          ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
+          updateNodes() {
+            const data = state.shownData,
+              newVisNodes = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i],
+                visNode = state.visData.nodes.get(node.id);
+              // Node shape
+              visNode.shape = node.shape;
+              // Node size
+              if (state.showNodes) {
+                visNode.size = node.size;
+              } else {
+                visNode.size = 0.0;
+              }
+              // Node images
+              if (state.showNodeImages) {
+                if (typeof (node.image) !== "undefined") {
+                  visNode.size = node.image_size;
+                  visNode.shape = "image";
+                  visNode.image = node.image;
+                }
+              }
+              // Prevent node movements: Remove stored positions of nodes once fixed and now released
+              if (visNode.fixed === false) {
+                delete visNode.x;
+                delete visNode.y;
+              }
+              newVisNodes.push(visNode);
+            }
+            state.visData.nodes.update(newVisNodes);
+          },
+
+          preventNodeJump(visNode) {
+            if (visNode.fixed === false) {
+              delete visNode.x;
+              delete visNode.y;
+            }
+          },
+
+          updateNodeVisibilities() {
+            ui.composites.graph.updateNodes();
+          },
+
+          updateNodeSizes() {
+            const data = state.shownData,
+              newVisNodes = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i],
+                visNode = state.visData.nodes.get(node.id);
+              visNode.size = node.size;
+              if (state.showNodeImages && typeof (node.image) !== "undefined") {
+                visNode.size = node.image_size;
+              }
+              ui.composites.graph.preventNodeJump(visNode);
+              newVisNodes.push(visNode);
+            }
+            state.visData.nodes.update(newVisNodes);
+          },
+
+          updateNodeHoverNeighborhoodBehavior() {
+            state.visOptions.interaction.hover = state.nodeHoverNeighborhood;
+            state.visOptions.interaction.hoverConnectedEdges = state.nodeHoverNeighborhood;
+            state.visGraph.setOptions(state.visOptions);
+          },
+
+          updateNodeHoverTooltipBehavior() {
+            const data = state.shownData,
+              newVisNodes = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i],
+                visNode = state.visData.nodes.get(node.id);
+              if (typeof (node.hover) !== "undefined") {
+                visNode.title = state.nodeHoverTooltip ? node.hover : null;
+              }
+              newVisNodes.push(visNode);
+            }
+            state.visData.nodes.update(newVisNodes);
+          },
+
           // Node images
-          ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
-          ui.elements.nodeImageMetaControl.style.display = false;
-          ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
-          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
-          ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
+          updateNodeImages() {
+            const data = state.shownData,
+              newVisNodes = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i],
+                visNode = state.visData.nodes.get(node.id);
+              visNode.shape = node.shape;
+              if (state.showNodes) {
+                visNode.size = node.size;
+              } else {
+                visNode.size = 0.0;
+              }
+              if (state.showNodeImages) {
+                if (typeof (node.image) !== "undefined") {
+                  visNode.size = node.image_size;
+                  visNode.shape = "image";
+                  visNode.image = node.image;
+                }
+              }
+              ui.composites.graph.preventNodeJump(visNode);
+              newVisNodes.push(visNode);
+            }
+            state.visData.nodes.update(newVisNodes);
+          },
+
           // Node labels
-          ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
-          ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
-          ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
-          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
-          ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
-          ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(state.nodeLabelRotation);
-          ui.elements.nodeLabelRotationSlider.value = state.nodeLabelRotation;
+          updateNodeLabels() {
+            // Vis data sets: https://visjs.github.io/vis-data/data/dataset.html
+            const data = state.shownData,
+              newVisNodes = [];
+            for (let i = 0; i < data.nodes.length; i++) {
+              const node = data.nodes[i];
+              const visNode = state.visData.nodes.get(node.id);
+              if (state.showNodeLabels) {
+                visNode.label = node.label;
+                visNode.font = {
+                  size: node.label_size,
+                  color: node.label_color,
+                  strokeWidth: (state.showNodeLabelBorders ? 1.2 : 0.0),
+                  strokeColor: data.general.background_color,
+                }
+              } else {
+                visNode.label = undefined;
+              }
+              ui.composites.graph.preventNodeJump(visNode);
+              newVisNodes.push(visNode);
+            }
+            state.visData.nodes.update(newVisNodes);
+          },
+
           // Edges
-          ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
-          ui.elements.edgeCheckbox.checked = state.showEdges;
-          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
-          ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
-          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
-          ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
-          ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
+          calculateEdgeCurvatureOptions() {
+            const appearanceAdaptionFactor = 0.5,
+              options = {
+                "type": state.edgeCurvature > 0.0 ? "curvedCW" : "curvedCCW",
+                "roundness": Math.abs(state.edgeCurvature) * appearanceAdaptionFactor,
+              };
+            return options
+          },
+
+          updateEdgeVisibility() {
+            const data = state.shownData,
+              newVisEdges = [];
+            for (let i = 0; i < data.edges.length; i++) {
+              const edge = data.edges[i],
+                visEdge = state.visData.edges.get(edge.id);
+              visEdge.hidden = !state.showEdges;
+              newVisEdges.push(visEdge);
+            }
+            state.visData.edges.update(newVisEdges);
+          },
+
+          updateEdgeSizes() {
+            const data = state.shownData,
+              newVisEdges = [];
+            for (let i = 0; i < data.edges.length; i++) {
+              const edge = data.edges[i],
+                newVisEdge = state.visData.edges.get(edge.id);
+              newVisEdge.width = edge.size;
+              newVisEdges.push(newVisEdge);
+            }
+            state.visData.edges.update(newVisEdges);
+          },
+
+          updateEdgeCurvatures() {
+            if (state.edgeCurvature === 0.0) {
+              state.visOptions.edges.smooth = false;
+            } else {
+              state.visOptions.edges.smooth = ui.composites.graph.calculateEdgeCurvatureOptions();
+            }
+            state.visGraph.setOptions(state.visOptions);
+          },
+
+          updateEdgeHoverTooltipBehavior() {
+            /* Correct code, but there is a bug that renders null values as empty div (instead of ignoring them)
+            const data = state.shownData,
+              newVisEdges = [];
+            for(let i=0; i<data.edges.length; i++){
+              const edge = data.edges[i],
+                visEdge = state.visData.edges.get(edge.id);
+              if(typeof(edge.hover) !== "undefined"){
+                visEdge.title = state.edgeHoverTooltip ? edge.hover : null;
+              }
+              newVisEdges.push(visEdge);
+            }
+            state.visData.edges.update(newVisEdges);
+            */
+            // Workaround code
+            function cloneObject(obj) {
+              return Object.assign({}, obj);
+            }
+            const data = state.shownData,
+              newVisEdges = [];
+            for (let i = 0; i < data.edges.length; i++) {
+              const edge = data.edges[i],
+                visEdge = state.visData.edges.get(edge.id);
+              if (typeof (edge.hover) !== "undefined") {
+                if (state.edgeHoverTooltip) {
+                  visEdge.title = edge.hover;
+                  newVisEdges.push(visEdge);
+                } else {
+                  // edges.update can only add properties, not delete them, hence use of clone/remove/add
+                  clonedEdge = cloneObject(visEdge);
+                  delete clonedEdge.title;
+                  state.visData.edges.remove(edge.id);
+                  state.visData.edges.add(clonedEdge);
+                }
+              }
+            }
+            if (state.edgeHoverTooltip) {
+              state.visData.edges.update(newVisEdges);
+            }
+          },
+
           // Edge labels
-          ui.composites.menu.setItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody, false);
-          ui.elements.edgeLabelCheckbox.checked = state.showEdgeLabels;
-          ui.elements.edgeLabelBorderCheckbox.checked = state.showEdgeLabelBorders;
-          ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeLabelSizeFactor);
-          ui.elements.edgeLabelSizeFactorSlider.value = state.edgeLabelSizeFactor;
-          ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(state.edgeLabelRotation);
-          ui.elements.edgeLabelRotationSlider.value = state.edgeLabelRotation;
+          updateEdgeLabels() {
+            const data = state.shownData,
+              newVisEdges = [],
+              noLabel = " ";  // undefined, null, "" or deleting label property does not work
+            for (let i = 0; i < data.edges.length; i++) {
+              const edge = data.edges[i],
+                visEdge = state.visData.edges.get(edge.id);
+              if (state.showEdgeLabels) {
+                visEdge.label = edge.label;
+                visEdge.font = {
+                  size: edge.label_size,
+                  color: edge.label_color,
+                  strokeWidth: (state.showEdgeLabelBorders ? 1.2 : 0.0),
+                  strokeColor: data.general.background_color,
+                }
+              } else {
+                visEdge.label = noLabel;
+              }
+              newVisEdges.push(visEdge);
+            }
+            state.visData.edges.update(newVisEdges);
+          },
+
           // Layout algorithm
-          ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
-          ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
-          ui.elements.layoutAlgorithmSelection.value = state.layoutAlgorithm;
-          ui.elements.centralGravitySlider.value = state.centralGravity;
-          ui.elements.centralGravityText.innerHTML = ui.convert.numberToText(state.centralGravity);
-          ui.elements.springLengthSlider.value = state.springLength;
-          ui.elements.springLengthText.innerHTML = ui.convert.numberToText(state.springLength);
-          ui.elements.springConstantSlider.value = state.springConstant;
-          ui.elements.springConstantText.innerHTML = ui.convert.numberToText(state.springConstant);
-          ui.elements.gravitationalConstantSlider.value = state.gravitationalConstant;
-          ui.elements.gravitationalConstantText.innerHTML = ui.convert.numberToText(state.gravitationalConstant);
-          ui.elements.avoidOverlapSlider.value = state.avoidOverlap;
-          ui.elements.avoidOverlapText.innerHTML = ui.convert.numberToText(state.avoidOverlap);
-
-          ui.initSelectionValues();
-        },
-
-        initSelectionValues(){
-          function setSelectionOptionsAndValue(element, options, value, values=null){
-            if(values === null){
-              values = options;
-            }
-            if(!values.includes(value)){
-              value = values[0];
-            }
-            ui.composites.selection(element, options, values);
-            element.value = value;
+          simulationManager: {
+            start() {
+              state.visGraph.startSimulation();
+              this.setAlgorithm();
+              this.setSpringLength();
+              this.setSpringConstant();
+              this.setCentralGravity();
+              this.setGravitationalConstant();
+              this.setAvoidOverlap();
+            },
+            stop() {
+              state.visGraph.stopSimulation();
+            },
+            setActivity(on) {
+              if (on) {
+                this.start();
+              } else {
+                this.stop();
+              }
+            },
+            setAlgorithm() {
+              const name = state.layoutAlgorithm;
+              state.visOptions.physics.solver = name;
+              state.visGraph.setOptions(state.visOptions);
+              if (name === "repulsion") {
+                ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(false);
+                ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(false);
+              } else if (name === "hierarchicalRepulsion") {
+                ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(true);
+                ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(false);
+              } else {
+                ui.elements.avoidOverlapContainer.style.opacity = ui.convert.boolToOpacity(true);
+                ui.elements.gravitationalConstantContainer.style.opacity = ui.convert.boolToOpacity(true);
+              }
+            },
+            releaseFixedNodes() {
+              const data = state.shownData,
+                newVisNodes = [];
+              for (let i = 0; i < data.nodes.length; i++) {
+                const node = data.nodes[i],
+                  visNode = state.visData.nodes.get(node.id);
+                ui.composites.graph.preventNodeJump(visNode);
+                visNode.fixed = false;
+                // Note: Deletion of x, y and fixed may work too, but .update does not delete props
+                newVisNodes.push(visNode);
+              }
+              state.visData.nodes.update(newVisNodes);
+            },
+            setSpringLength() {
+              state.visOptions.physics.barnesHut.springLength = state.springLength;
+              state.visOptions.physics.forceAtlas2Based.springLength = state.springLength;
+              state.visOptions.physics.repulsion.springLength = state.springLength;
+              state.visOptions.physics.hierarchicalRepulsion.springLength = state.springLength;
+              state.visGraph.setOptions(state.visOptions);
+            },
+            setSpringConstant() {
+              state.visOptions.physics.barnesHut.springConstant = state.springConstant / 10.0;
+              state.visOptions.physics.forceAtlas2Based.springConstant = state.springConstant;
+              state.visOptions.physics.repulsion.springConstant = state.springConstant;
+              state.visOptions.physics.hierarchicalRepulsion.springConstant = state.springConstant;
+              state.visGraph.setOptions(state.visOptions);
+            },
+            setCentralGravity() {
+              state.visOptions.physics.barnesHut.centralGravity = state.centralGravity;
+              state.visOptions.physics.forceAtlas2Based.centralGravity = state.centralGravity / 100.0;
+              state.visOptions.physics.repulsion.centralGravity = state.centralGravity;
+              state.visOptions.physics.hierarchicalRepulsion.centralGravity = state.centralGravity;
+              state.visGraph.setOptions(state.visOptions);
+            },
+            setGravitationalConstant() {
+              state.visOptions.physics.barnesHut.gravitationalConstant = state.gravitationalConstant;
+              state.visOptions.physics.forceAtlas2Based.gravitationalConstant = state.gravitationalConstant / 10.0;
+              // Not a parameter in repulsion and hierarchicalRepulsion
+              state.visGraph.setOptions(state.visOptions);
+            },
+            setAvoidOverlap() {
+              state.visOptions.physics.barnesHut.avoidOverlap = state.avoidOverlap;
+              state.visOptions.physics.forceAtlas2Based.avoidOverlap = state.avoidOverlap;
+              // Not a parameter in repulsion and hierarchicalRepulsion
+              state.visGraph.setOptions(state.visOptions);
+            },
           }
-          // Node label text data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeLabelTextDataSourceSelect,
-            state.parsedData.general.node_properties.node_label_text_data_sources,
-            state.nodeLabelTextDataSource,
-          );
-          // Edge label text data source
-          setSelectionOptionsAndValue(
-            ui.elements.edgeLabelTextDataSourceSelect,
-            state.parsedData.general.edge_properties.edge_label_text_data_sources,
-            state.edgeLabelTextDataSource,
-          );
-          // Node size data source
-          setSelectionOptionsAndValue(
-            ui.elements.nodeSizeDataSourceSelect,
-            state.parsedData.general.node_properties.node_size_data_sources,
-            state.nodeSizeDataSource,
-          );
-          // Edge size data source
-          setSelectionOptionsAndValue(
-            ui.elements.edgeSizeDataSourceSelect,
-            state.parsedData.general.edge_properties.edge_size_data_sources,
-            state.edgeSizeDataSource,
-          );
-          // Layout algorithm
-          setSelectionOptionsAndValue(
-            ui.elements.layoutAlgorithmSelection,
-            ["Barnes-Hut", "Force Atlas 2", "Repulsion", "Hierarchical repulsion"],
-            state.layoutAlgorithm,
-            ["barnesHut", "forceAtlas2Based", "repulsion", "hierarchicalRepulsion"],
-          );
         },
+      },
 
-        deleteChildElements(element){
-          while(element.firstChild){
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management
-            // As of 2019, it is not possible to explicitly or programmatically trigger
-            // garbage collection in JavaScript.
-            element.removeChild(element.firstChild);
+      init() {
+        ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
+        // Containers
+        ui.composites.responsiveContainer.init();
+        // Graph selection (only visible if multiple graphs in data)
+        if (state.rawData.length > 1) {
+          ui.elements.graphSelectionContainer.style.display = ui.convert.boolToDisplayStyle(true);
+          const optionList = [],
+            valueList = [];
+          let label;
+          for (let i = 0; i < state.rawData.length; i++) {
+            const graph = state.rawData[i];
+            try {
+              label = String(graph.label);
+              if (label === "undefined" || label === "") {
+                throw "Invalid label";
+              }
+            } catch (e) {
+              label = "Unnamed graph";
+            }
+            const name = String(i + 1) + ": " + label;
+            optionList.push(name);
+            valueList.push(String(i));
           }
+          ui.composites.selection(ui.elements.graphSelection, optionList, valueList);
+        }
+        // General (menu item)
+        ui.composites.menu.setItem(ui.elements.generalHead, ui.elements.generalBody, true);
+        // Data selection (menu item)
+        ui.composites.menu.setItem(ui.elements.dataHead, ui.elements.dataBody, false);
+        // - Node size
+        ui.elements.nodeSizeNormalizationCheckbox.checked = state.useNodeSizeNormalization;
+        ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+        ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+        ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+        ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
+        ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+        // - Edge size
+        ui.elements.edgeSizeNormalizationCheckbox.checked = state.useEdgeSizeNormalization;
+        ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+        ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+        ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+        ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+        ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+        // Nodes
+        ui.composites.menu.setItem(ui.elements.nodeHead, ui.elements.nodeBody, false);
+        ui.elements.nodeCheckbox.checked = state.showNodes;
+        ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeSizeFactor);
+        ui.elements.nodeSizeFactorSlider.value = state.nodeSizeFactor;
+        ui.elements.nodeDragFixCheckbox.checked = state.nodeDragFix;
+        ui.elements.nodeHoverNeighborhoodCheckbox.checked = state.nodeHoverNeighborhood;
+        ui.elements.nodeHoverTooltipCheckbox.checked = state.nodeHoverTooltip;
+        // Node images
+        ui.composites.menu.setItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody, false);
+        ui.elements.nodeImageMetaControl.style.display = false;
+        ui.elements.nodeImageCheckbox.checked = state.showNodeImages;
+        ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeImageSizeFactor);
+        ui.elements.nodeImageSizeFactorSlider.value = state.nodeImageSizeFactor;
+        // Node labels
+        ui.composites.menu.setItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody, false);
+        ui.elements.nodeLabelCheckbox.checked = state.showNodeLabels;
+        ui.elements.nodeLabelBorderCheckbox.checked = state.showNodeLabelBorders;
+        ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.nodeLabelSizeFactor);
+        ui.elements.nodeLabelSizeFactorSlider.value = state.nodeLabelSizeFactor;
+        ui.elements.nodeLabelRotationText.innerHTML = ui.convert.numberToText(state.nodeLabelRotation);
+        ui.elements.nodeLabelRotationSlider.value = state.nodeLabelRotation;
+        // Edges
+        ui.composites.menu.setItem(ui.elements.edgeHead, ui.elements.edgeBody, false);
+        ui.elements.edgeCheckbox.checked = state.showEdges;
+        ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeSizeFactor);
+        ui.elements.edgeSizeFactorSlider.value = state.edgeSizeFactor;
+        ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(state.edgeCurvature);
+        ui.elements.edgeCurvatureSlider.value = state.edgeCurvature;
+        ui.elements.edgeHoverTooltipCheckbox.checked = state.edgeHoverTooltip;
+        // Edge labels
+        ui.composites.menu.setItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody, false);
+        ui.elements.edgeLabelCheckbox.checked = state.showEdgeLabels;
+        ui.elements.edgeLabelBorderCheckbox.checked = state.showEdgeLabelBorders;
+        ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(state.edgeLabelSizeFactor);
+        ui.elements.edgeLabelSizeFactorSlider.value = state.edgeLabelSizeFactor;
+        ui.elements.edgeLabelRotationText.innerHTML = ui.convert.numberToText(state.edgeLabelRotation);
+        ui.elements.edgeLabelRotationSlider.value = state.edgeLabelRotation;
+        // Layout algorithm
+        ui.composites.menu.setItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody, false);
+        ui.elements.simulationCheckbox.checked = state.layoutAlgorithmActive;
+        ui.elements.layoutAlgorithmSelection.value = state.layoutAlgorithm;
+        ui.elements.centralGravitySlider.value = state.centralGravity;
+        ui.elements.centralGravityText.innerHTML = ui.convert.numberToText(state.centralGravity);
+        ui.elements.springLengthSlider.value = state.springLength;
+        ui.elements.springLengthText.innerHTML = ui.convert.numberToText(state.springLength);
+        ui.elements.springConstantSlider.value = state.springConstant;
+        ui.elements.springConstantText.innerHTML = ui.convert.numberToText(state.springConstant);
+        ui.elements.gravitationalConstantSlider.value = state.gravitationalConstant;
+        ui.elements.gravitationalConstantText.innerHTML = ui.convert.numberToText(state.gravitationalConstant);
+        ui.elements.avoidOverlapSlider.value = state.avoidOverlap;
+        ui.elements.avoidOverlapText.innerHTML = ui.convert.numberToText(state.avoidOverlap);
+
+        ui.initSelectionValues();
+      },
+
+      initSelectionValues() {
+        function setSelectionOptionsAndValue(element, options, value, values = null) {
+          if (values === null) {
+            values = options;
+          }
+          if (!values.includes(value)) {
+            value = values[0];
+          }
+          ui.composites.selection(element, options, values);
+          element.value = value;
+        }
+        // Node label text data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeLabelTextDataSourceSelect,
+          state.parsedData.general.node_properties.node_label_text_data_sources,
+          state.nodeLabelTextDataSource,
+        );
+        // Edge label text data source
+        setSelectionOptionsAndValue(
+          ui.elements.edgeLabelTextDataSourceSelect,
+          state.parsedData.general.edge_properties.edge_label_text_data_sources,
+          state.edgeLabelTextDataSource,
+        );
+        // Node size data source
+        setSelectionOptionsAndValue(
+          ui.elements.nodeSizeDataSourceSelect,
+          state.parsedData.general.node_properties.node_size_data_sources,
+          state.nodeSizeDataSource,
+        );
+        // Edge size data source
+        setSelectionOptionsAndValue(
+          ui.elements.edgeSizeDataSourceSelect,
+          state.parsedData.general.edge_properties.edge_size_data_sources,
+          state.edgeSizeDataSource,
+        );
+        // Layout algorithm
+        setSelectionOptionsAndValue(
+          ui.elements.layoutAlgorithmSelection,
+          ["Barnes-Hut", "Force Atlas 2", "Repulsion", "Hierarchical repulsion"],
+          state.layoutAlgorithm,
+          ["barnesHut", "forceAtlas2Based", "repulsion", "hierarchicalRepulsion"],
+        );
+      },
+
+      deleteChildElements(element) {
+        while (element.firstChild) {
+          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management
+          // As of 2019, it is not possible to explicitly or programmatically trigger
+          // garbage collection in JavaScript.
+          element.removeChild(element.firstChild);
+        }
+      },
+
+      convert: {
+        numberToText(number, numDigits = 2) {
+          return String(Number(number).toFixed(numDigits));
         },
 
-        convert:{
-          numberToText(number, numDigits=2) {
-            return String(Number(number).toFixed(numDigits));
-          },
-
-          boolToDisplayStyle(isVisible){
-            if(isVisible){
-              return "block";
-            }
-            return "none";
-          },
-
-          boolToOpacity(isActive){
-            if(isActive){
-              return 1.0;
-            }
-            return 0.25;
-          },
-
-          boolToTooltipDelay(isActive){
-            if(isActive){
-              return 0;
-            }
-            return 100000000;
-          },
+        boolToDisplayStyle(isVisible) {
+          if (isVisible) {
+            return "block";
+          }
+          return "none";
         },
 
-        setBehavior(){
-          // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
-          window.onresize = function(){
+        boolToOpacity(isActive) {
+          if (isActive) {
+            return 1.0;
+          }
+          return 0.25;
+        },
+
+        boolToTooltipDelay(isActive) {
+          if (isActive) {
+            return 0;
+          }
+          return 100000000;
+        },
+      },
+
+      setBehavior() {
+        // Window resize (includes ctrl+wheel zoom, landscape/portrait orientation on phones)
+        window.onresize = function () {
+          ui.composites.responsiveContainer.adaptToResize();
+          ui.composites.graph.updateGraphDrawingArea();
+        }
+        // Container resize
+        ui.elements.graphContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
+          if (currentHeight != state.graphContainerHeight) {
             ui.composites.responsiveContainer.adaptToResize();
             ui.composites.graph.updateGraphDrawingArea();
           }
-          // Container resize
-          ui.elements.graphContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.graphContainer.clientHeight);
-            if(currentHeight != state.graphContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
-          };
-          ui.elements.detailsContainer.onmouseup = function(){
-            const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
-            if(currentHeight != state.detailsContainerHeight){
-              ui.composites.responsiveContainer.adaptToResize();
-            }
-          };
-          // Tooltip
-          ui.elements.tooltipContainer.onmouseover = function(){
-            ui.composites.tooltip.show();
+        };
+        ui.elements.detailsContainer.onmouseup = function () {
+          const currentHeight = parseInt(ui.elements.detailsContainer.clientHeight);
+          if (currentHeight != state.detailsContainerHeight) {
+            ui.composites.responsiveContainer.adaptToResize();
           }
-          ui.elements.tooltipContainer.onmouseout = function(){
-            ui.composites.tooltip.hide();
+        };
+        // Tooltip
+        ui.elements.tooltipContainer.onmouseover = function () {
+          ui.composites.tooltip.show();
+        }
+        ui.elements.tooltipContainer.onmouseout = function () {
+          ui.composites.tooltip.hide();
+        }
+        // General menu
+        ui.elements.generalHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
+        };
+        ui.elements.resetButton.onclick = function () {
+          app.restart();
+        };
+        ui.elements.fullscreenButton.onclick = function () {
+          if (document.fullscreenElement) {
+            document.exitFullscreen();
+          } else {
+            ui.elements.mainContainer.requestFullscreen()
+              .catch(function (err) {
+                alert("Error attempting to enable full-screen mode: " + err.message);
+              });
           }
-          // General menu
-          ui.elements.generalHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.generalHead, ui.elements.generalBody);
-          };
-          ui.elements.resetButton.onclick = function(){
-            app.restart();
-          };
-          ui.elements.fullscreenButton.onclick = function(){
-            if(document.fullscreenElement){
-              document.exitFullscreen();
-            } else{
-              ui.elements.mainContainer.requestFullscreen()
-                .catch(function(err){
-                  alert("Error attempting to enable full-screen mode: " + err.message);
-                });
-            }
-          };
-          ui.elements.mainContainer.onfullscreenchange = function(){
-            if(document.fullscreenElement){
-              ui.elements.fullscreenButton.innerText = "Exit full screen";
-            } else{
-              ui.elements.fullscreenButton.innerText = "Enter full screen";
-            }
-            // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
-            setTimeout(function(){
-              ui.composites.responsiveContainer.adaptToFullscreen();
-              ui.composites.graph.updateGraphDrawingArea();
-            }, 250);
-          };
-          ui.elements.pngExportButton.onclick = function(){
-            ui.composites.download.png("graph.png");
-          };
-          ui.elements.jpgExportButton.onclick = function(){
-            ui.composites.download.jpg("graph.jpg");
-          };
-          // Data menu
-          ui.elements.dataHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
-          };
-          // - Graph selection
-          ui.elements.graphSelection.onchange = function(){
-            const chosenGraphIndex = parseInt(this.value);
-            state.manager.parseChosenData(chosenGraphIndex);
-            state.manager.prepareShownData();
-            ui.initSelectionValues();
-            ui.composites.graph.createGraph();
-          };
-          // - Node label text
-          ui.elements.nodeLabelTextDataSourceSelect.onchange = function(){
-            state.nodeLabelTextDataSource = this.value;
-            state.manager.updateNodeLabelTexts();
-          };
-          // - Edge label text
-          ui.elements.edgeLabelTextDataSourceSelect.onchange = function(){
-            state.edgeLabelTextDataSource = this.value;
-            state.manager.updateEdgeLabelTexts();
-          };
-          // - Node size
-          ui.elements.nodeSizeDataSourceSelect.onchange = function(){
-            state.nodeSizeDataSource = this.value;
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationCheckbox.onchange = function(){
-            state.useNodeSizeNormalization = this.checked;
-            ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMinSlider.onchange = function(){
-            state.nodeSizeNormalizationMin = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax){
-              state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
-            }
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeNormalizationMaxSlider.onchange = function(){
-            state.nodeSizeNormalizationMax = parseFloat(this.value);
-            if(state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin){
-              state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
-              ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
-              ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
-            }
-            state.manager.updateNodeSizes();
-          };
-          // - Edge size
-          ui.elements.edgeSizeDataSourceSelect.onchange = function(){
-            state.edgeSizeDataSource = this.value;
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationCheckbox.onchange = function(){
-            state.useEdgeSizeNormalization = this.checked;
-            ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMinSlider.onchange = function(){
-            state.edgeSizeNormalizationMin = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax){
-              state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.oninput = function(){
-            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeNormalizationMaxSlider.onchange = function(){
-            state.edgeSizeNormalizationMax = parseFloat(this.value);
-            if(state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin){
-              state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
-              ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
-              ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
-            }
-            state.manager.updateEdgeSizes();
-          };
-          // Nodes menu
-          ui.elements.nodeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
-          };
-          ui.elements.nodeCheckbox.onchange = function(){
-            state.showNodes = this.checked;
-            ui.composites.graph.updateNodeVisibilities();
-          };
-          ui.elements.nodeSizeFactorSlider.oninput = function(){
-            ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeSizeFactorSlider.onchange = function(){
-            state.nodeSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeSizes();
-          };
-          ui.elements.nodeDragFixCheckbox.onchange = function(){
-            state.nodeDragFix = this.checked;
-          };
-          ui.elements.nodeHoverNeighborhoodCheckbox.onchange = function(){
-            state.nodeHoverNeighborhood = this.checked;
-            ui.composites.graph.updateNodeHoverNeighborhoodBehavior();
-          };
-          ui.elements.nodeHoverTooltipCheckbox.onchange = function(){
-            state.nodeHoverTooltip = this.checked;
-            ui.composites.graph.updateNodeHoverTooltipBehavior();
-          };
-          ui.elements.nodeReleaseButton.onclick = function(){
-            ui.composites.graph.simulationManager.releaseFixedNodes();
-          };
-          // Node images menu
-          ui.elements.nodeImageHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
-          };
-          ui.elements.nodeImageCheckbox.onchange = function(){
-            state.showNodeImages = this.checked;
-            state.manager.updateNodeImages();
-          };
-          ui.elements.nodeImageSizeFactorSlider.oninput = function(){
-            ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeImageSizeFactorSlider.onchange = function(){
-            state.nodeImageSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeImages();
-          };
-          // Node labels menu
-          ui.elements.nodeLabelHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
-          };
-          ui.elements.nodeLabelCheckbox.onchange = function(){
-            state.showNodeLabels = this.checked;
-            ui.composites.graph.updateNodeLabels();
-          };
-          ui.elements.nodeLabelBorderCheckbox.onchange = function(){
-            state.showNodeLabelBorders = this.checked;
-            ui.composites.graph.updateNodeLabels();
-          };
-          ui.elements.nodeLabelSizeFactorSlider.oninput = function(){
-            ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.nodeLabelSizeFactorSlider.onchange = function(){
-            state.nodeLabelSizeFactor = parseFloat(this.value);
-            state.manager.updateNodeLabelSizes();
-          };
-          // Edges menu
-          ui.elements.edgeHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
-          };
-          ui.elements.edgeCheckbox.onchange = function(){
-            state.showEdges = this.checked;
-            ui.composites.graph.updateEdgeVisibility();
-          };
-          ui.elements.edgeSizeFactorSlider.oninput = function(){
-            ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeSizeFactorSlider.onchange = function(){
-            state.edgeSizeFactor = parseFloat(this.value);
-            state.manager.updateEdgeSizes();
-          };
-          ui.elements.edgeCurvatureSlider.oninput = function(){
-            ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeCurvatureSlider.onchange = function(){
-            state.edgeCurvature = parseFloat(this.value);
-            state.manager.updateEdgeCurvatures();
-          };
-          ui.elements.edgeHoverTooltipCheckbox.onchange = function(){
-            state.edgeHoverTooltip = this.checked;
-            ui.composites.graph.updateEdgeHoverTooltipBehavior();
-          };
-          // Edge labels menu
-          ui.elements.edgeLabelHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody);
-          };
-          ui.elements.edgeLabelCheckbox.onchange = function(){
-            state.showEdgeLabels = this.checked;
-            ui.composites.graph.updateEdgeLabels();
-          };
-          ui.elements.edgeLabelBorderCheckbox.onchange = function(){
-            state.showEdgeLabelBorders = this.checked;
-            ui.composites.graph.updateEdgeLabels();
-          };
-          ui.elements.edgeLabelSizeFactorSlider.oninput = function(){
-            ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.edgeLabelSizeFactorSlider.onchange = function(){
-            state.edgeLabelSizeFactor = parseFloat(this.value);
-            state.manager.updateEdgeLabelSizes();
-          };
-          // Layout algorithm menu
-          ui.elements.layoutAlgorithmHead.onclick = function(){
-            ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
-          };
-          ui.elements.simulationCheckbox.onchange = function(){
-            state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
-            ui.composites.graph.simulationManager.setActivity(state.layoutAlgorithmActive);
-          };
-          ui.elements.layoutAlgorithmSelection.onchange = function(){
-            state.layoutAlgorithm = this.value;
-            ui.composites.graph.simulationManager.setAlgorithm();
-          };
-          ui.elements.centralGravitySlider.oninput = function(){
-            ui.elements.centralGravityText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.centralGravitySlider.onchange = function(){
-            state.centralGravity = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setCentralGravity();
-          };
-          ui.elements.springLengthSlider.oninput = function(){
-            ui.elements.springLengthText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.springLengthSlider.onchange = function(){
-            state.springLength = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setSpringLength();
-          };
-          ui.elements.springConstantSlider.oninput = function(){
-            ui.elements.springConstantText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.springConstantSlider.onchange = function(){
-            state.springConstant = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setSpringConstant();
-          };
-          ui.elements.gravitationalConstantSlider.oninput = function(){
-            ui.elements.gravitationalConstantText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.gravitationalConstantSlider.onchange = function(){
-            state.gravitationalConstant = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setGravitationalConstant();
-          };
-          ui.elements.avoidOverlapSlider.oninput = function(){
-            ui.elements.avoidOverlapText.innerHTML = ui.convert.numberToText(this.value);
-          };
-          ui.elements.avoidOverlapSlider.onchange = function(){
-            state.avoidOverlap = parseFloat(this.value);
-            ui.composites.graph.simulationManager.setAvoidOverlap();
-          };
-        },
-      }
-
-      const app = {
-        start(){
-          state.manager.fetchRawDataFromTemplating();
-          state.manager.parseChosenData(0);
+        };
+        ui.elements.mainContainer.onfullscreenchange = function () {
+          if (document.fullscreenElement) {
+            ui.elements.fullscreenButton.innerText = "Exit full screen";
+          } else {
+            ui.elements.fullscreenButton.innerText = "Enter full screen";
+          }
+          // Wait for browser to switch to fullscreen and resize divs, then adapt to new sizes
+          setTimeout(function () {
+            ui.composites.responsiveContainer.adaptToFullscreen();
+            ui.composites.graph.updateGraphDrawingArea();
+          }, 250);
+        };
+        ui.elements.pngExportButton.onclick = function () {
+          ui.composites.download.png("graph.png");
+        };
+        ui.elements.jpgExportButton.onclick = function () {
+          ui.composites.download.jpg("graph.jpg");
+        };
+        // Data menu
+        ui.elements.dataHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.dataHead, ui.elements.dataBody);
+        };
+        // - Graph selection
+        ui.elements.graphSelection.onchange = function () {
+          const chosenGraphIndex = parseInt(this.value);
+          state.manager.parseChosenData(chosenGraphIndex);
           state.manager.prepareShownData();
-          ui.init();
-          // Wait a bit to finish UI rendering, then start potentially slow layout computation
-          setTimeout(function(){
-            ui.composites.graph.createGraph();
-            ui.setBehavior();
-          }, 400);
-          // Reduce risk of getting stuck with a wrong drawing area size
-          function checkIfSizeUpdateRequired(){
-            if(ui.elements.graphContainer.clientWidth != state.graphContainerWidth){
-              ui.composites.responsiveContainer.adaptToResize();
-              ui.composites.graph.updateGraphDrawingArea();
-            }
+          ui.initSelectionValues();
+          ui.composites.graph.createGraph();
+        };
+        // - Node label text
+        ui.elements.nodeLabelTextDataSourceSelect.onchange = function () {
+          state.nodeLabelTextDataSource = this.value;
+          state.manager.updateNodeLabelTexts();
+        };
+        // - Edge label text
+        ui.elements.edgeLabelTextDataSourceSelect.onchange = function () {
+          state.edgeLabelTextDataSource = this.value;
+          state.manager.updateEdgeLabelTexts();
+        };
+        // - Node size
+        ui.elements.nodeSizeDataSourceSelect.onchange = function () {
+          state.nodeSizeDataSource = this.value;
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationCheckbox.onchange = function () {
+          state.useNodeSizeNormalization = this.checked;
+          ui.elements.nodeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useNodeSizeNormalization);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMinSlider.onchange = function () {
+          state.nodeSizeNormalizationMin = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMin > state.nodeSizeNormalizationMax) {
+            state.nodeSizeNormalizationMax = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMaxSlider.value = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMax);
           }
-          [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function(delay){
-            setTimeout(checkIfSizeUpdateRequired, delay*1000);
-          })
-        },
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.nodeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeNormalizationMaxSlider.onchange = function () {
+          state.nodeSizeNormalizationMax = parseFloat(this.value);
+          if (state.nodeSizeNormalizationMax < state.nodeSizeNormalizationMin) {
+            state.nodeSizeNormalizationMin = state.nodeSizeNormalizationMax;
+            ui.elements.nodeSizeNormalizationMinSlider.value = state.nodeSizeNormalizationMin;
+            ui.elements.nodeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.nodeSizeNormalizationMin);
+          }
+          state.manager.updateNodeSizes();
+        };
+        // - Edge size
+        ui.elements.edgeSizeDataSourceSelect.onchange = function () {
+          state.edgeSizeDataSource = this.value;
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationCheckbox.onchange = function () {
+          state.useEdgeSizeNormalization = this.checked;
+          ui.elements.edgeSizeNormalizationContainer.style.display = ui.convert.boolToDisplayStyle(state.useEdgeSizeNormalization);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMinSlider.onchange = function () {
+          state.edgeSizeNormalizationMin = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMin > state.edgeSizeNormalizationMax) {
+            state.edgeSizeNormalizationMax = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMaxSlider.value = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMax);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.oninput = function () {
+          ui.elements.edgeSizeNormalizationMaxText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeNormalizationMaxSlider.onchange = function () {
+          state.edgeSizeNormalizationMax = parseFloat(this.value);
+          if (state.edgeSizeNormalizationMax < state.edgeSizeNormalizationMin) {
+            state.edgeSizeNormalizationMin = state.edgeSizeNormalizationMax;
+            ui.elements.edgeSizeNormalizationMinSlider.value = state.edgeSizeNormalizationMin;
+            ui.elements.edgeSizeNormalizationMinText.innerHTML = ui.convert.numberToText(state.edgeSizeNormalizationMin);
+          }
+          state.manager.updateEdgeSizes();
+        };
+        // Nodes menu
+        ui.elements.nodeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeHead, ui.elements.nodeBody);
+        };
+        ui.elements.nodeCheckbox.onchange = function () {
+          state.showNodes = this.checked;
+          ui.composites.graph.updateNodeVisibilities();
+        };
+        ui.elements.nodeSizeFactorSlider.oninput = function () {
+          ui.elements.nodeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeSizeFactorSlider.onchange = function () {
+          state.nodeSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeSizes();
+        };
+        ui.elements.nodeDragFixCheckbox.onchange = function () {
+          state.nodeDragFix = this.checked;
+        };
+        ui.elements.nodeHoverNeighborhoodCheckbox.onchange = function () {
+          state.nodeHoverNeighborhood = this.checked;
+          ui.composites.graph.updateNodeHoverNeighborhoodBehavior();
+        };
+        ui.elements.nodeHoverTooltipCheckbox.onchange = function () {
+          state.nodeHoverTooltip = this.checked;
+          ui.composites.graph.updateNodeHoverTooltipBehavior();
+        };
+        ui.elements.nodeReleaseButton.onclick = function () {
+          ui.composites.graph.simulationManager.releaseFixedNodes();
+        };
+        // Node images menu
+        ui.elements.nodeImageHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeImageHead, ui.elements.nodeImageBody);
+        };
+        ui.elements.nodeImageCheckbox.onchange = function () {
+          state.showNodeImages = this.checked;
+          state.manager.updateNodeImages();
+        };
+        ui.elements.nodeImageSizeFactorSlider.oninput = function () {
+          ui.elements.nodeImageSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeImageSizeFactorSlider.onchange = function () {
+          state.nodeImageSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeImages();
+        };
+        // Node labels menu
+        ui.elements.nodeLabelHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.nodeLabelHead, ui.elements.nodeLabelBody);
+        };
+        ui.elements.nodeLabelCheckbox.onchange = function () {
+          state.showNodeLabels = this.checked;
+          ui.composites.graph.updateNodeLabels();
+        };
+        ui.elements.nodeLabelBorderCheckbox.onchange = function () {
+          state.showNodeLabelBorders = this.checked;
+          ui.composites.graph.updateNodeLabels();
+        };
+        ui.elements.nodeLabelSizeFactorSlider.oninput = function () {
+          ui.elements.nodeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.nodeLabelSizeFactorSlider.onchange = function () {
+          state.nodeLabelSizeFactor = parseFloat(this.value);
+          state.manager.updateNodeLabelSizes();
+        };
+        // Edges menu
+        ui.elements.edgeHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.edgeHead, ui.elements.edgeBody);
+        };
+        ui.elements.edgeCheckbox.onchange = function () {
+          state.showEdges = this.checked;
+          ui.composites.graph.updateEdgeVisibility();
+        };
+        ui.elements.edgeSizeFactorSlider.oninput = function () {
+          ui.elements.edgeSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeSizeFactorSlider.onchange = function () {
+          state.edgeSizeFactor = parseFloat(this.value);
+          state.manager.updateEdgeSizes();
+        };
+        ui.elements.edgeCurvatureSlider.oninput = function () {
+          ui.elements.edgeCurvatureText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeCurvatureSlider.onchange = function () {
+          state.edgeCurvature = parseFloat(this.value);
+          state.manager.updateEdgeCurvatures();
+        };
+        ui.elements.edgeHoverTooltipCheckbox.onchange = function () {
+          state.edgeHoverTooltip = this.checked;
+          ui.composites.graph.updateEdgeHoverTooltipBehavior();
+        };
+        // Edge labels menu
+        ui.elements.edgeLabelHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.edgeLabelHead, ui.elements.edgeLabelBody);
+        };
+        ui.elements.edgeLabelCheckbox.onchange = function () {
+          state.showEdgeLabels = this.checked;
+          ui.composites.graph.updateEdgeLabels();
+        };
+        ui.elements.edgeLabelBorderCheckbox.onchange = function () {
+          state.showEdgeLabelBorders = this.checked;
+          ui.composites.graph.updateEdgeLabels();
+        };
+        ui.elements.edgeLabelSizeFactorSlider.oninput = function () {
+          ui.elements.edgeLabelSizeFactorText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.edgeLabelSizeFactorSlider.onchange = function () {
+          state.edgeLabelSizeFactor = parseFloat(this.value);
+          state.manager.updateEdgeLabelSizes();
+        };
+        // Layout algorithm menu
+        ui.elements.layoutAlgorithmHead.onclick = function () {
+          ui.composites.menu.toggleItem(ui.elements.layoutAlgorithmHead, ui.elements.layoutAlgorithmBody);
+        };
+        ui.elements.simulationCheckbox.onchange = function () {
+          state.layoutAlgorithmActive = !state.layoutAlgorithmActive;
+          ui.composites.graph.simulationManager.setActivity(state.layoutAlgorithmActive);
+        };
+        ui.elements.layoutAlgorithmSelection.onchange = function () {
+          state.layoutAlgorithm = this.value;
+          ui.composites.graph.simulationManager.setAlgorithm();
+        };
+        ui.elements.centralGravitySlider.oninput = function () {
+          ui.elements.centralGravityText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.centralGravitySlider.onchange = function () {
+          state.centralGravity = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setCentralGravity();
+        };
+        ui.elements.springLengthSlider.oninput = function () {
+          ui.elements.springLengthText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.springLengthSlider.onchange = function () {
+          state.springLength = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setSpringLength();
+        };
+        ui.elements.springConstantSlider.oninput = function () {
+          ui.elements.springConstantText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.springConstantSlider.onchange = function () {
+          state.springConstant = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setSpringConstant();
+        };
+        ui.elements.gravitationalConstantSlider.oninput = function () {
+          ui.elements.gravitationalConstantText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.gravitationalConstantSlider.onchange = function () {
+          state.gravitationalConstant = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setGravitationalConstant();
+        };
+        ui.elements.avoidOverlapSlider.oninput = function () {
+          ui.elements.avoidOverlapText.innerHTML = ui.convert.numberToText(this.value);
+        };
+        ui.elements.avoidOverlapSlider.onchange = function () {
+          state.avoidOverlap = parseFloat(this.value);
+          ui.composites.graph.simulationManager.setAvoidOverlap();
+        };
+      },
+    }
 
-        restart(){
-          app.start();
-        },
-      }
+    const app = {
+      start() {
+        state.manager.fetchRawDataFromTemplating();
+        state.manager.parseChosenData(0);
+        state.manager.prepareShownData();
+        ui.init();
+        // Wait a bit to finish UI rendering, then start potentially slow layout computation
+        setTimeout(function () {
+          ui.composites.graph.createGraph();
+          ui.setBehavior();
+        }, 400);
+        // Reduce risk of getting stuck with a wrong drawing area size
+        function checkIfSizeUpdateRequired() {
+          if (ui.elements.graphContainer.clientWidth != state.graphContainerWidth) {
+            ui.composites.responsiveContainer.adaptToResize();
+            ui.composites.graph.updateGraphDrawingArea();
+          }
+        }
+        [1, 2, 5, 8, 12, 15, 20, 25, 30, 35, 40, 45, 50, 60, 90].forEach(function (delay) {
+          setTimeout(checkIfSizeUpdateRequired, delay * 1000);
+        })
+      },
 
-      // Start website dynamics
-      app.start();
-    });
-  </script>
+      restart() {
+        app.start();
+      },
+    }
+
+    // Start website dynamics
+    app.start();
+  });
+</script>
 §SUFFIX§

--- a/gravis/_internal/plotting/templates/vis.html
+++ b/gravis/_internal/plotting/templates/vis.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -137,14 +182,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +204,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +215,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +230,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +241,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +250,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +286,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +300,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +316,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +326,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +342,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -309,32 +368,6 @@
     #§RANDOM_ID§-details-user-provided ul {
       list-style-position: inside;
       padding-left: 6px;
-    }
-
-    /* Unavailable in vis.js and therefore hidden */
-    #§RANDOM_ID§-svg,
-    #§RANDOM_ID§-node-label-rotation,
-    #§RANDOM_ID§-edge-label-rotation {
-      display: none;
-    }
-    /* Specific to vis.js */
-    div.vis-tooltip {
-      position: absolute;
-      visibility: hidden;
-      pointer-events: none;
-      z-index: 5;
-      max-width: 40%;
-      white-space: pre-wrap;
-      word-break: break-word;
-      font-size: 10px;
-      padding: 5px;
-      color: black;
-      background-color: white;
-      -moz-border-radius: 3px;
-      -webkit-border-radius: 3px;
-      border-radius: 3px;
-      border: 0.5px solid black;
-      box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
     }
   </style>
 
@@ -942,6 +975,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1177,21 +1211,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1202,10 +1253,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2052,17 +2103,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2235,15 +2280,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -2953,6 +2993,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/vis.html
+++ b/gravis/_internal/plotting/templates/vis.html
@@ -5,7 +5,44 @@
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
-      background-color: white;
+      background-color: var(--§RANDOM_ID§-background-color);
+      color: var(--§RANDOM_ID§-text-color);
+      --§RANDOM_ID§-background-color: #ffffff;
+      --§RANDOM_ID§-text-color: #222222;
+      --§RANDOM_ID§-text-color-subtle: #666666;
+      --§RANDOM_ID§-accent-color: #006429;
+      --§RANDOM_ID§-surface-color: #f5f5f5;
+      --§RANDOM_ID§-surface-color-muted: #f2f2f2;
+      --§RANDOM_ID§-surface-color-strong: #dddddd;
+      --§RANDOM_ID§-surface-color-overlay: #ffffff;
+      --§RANDOM_ID§-border-color: #cccccc;
+      --§RANDOM_ID§-border-color-strong: #bbbbbb;
+      --§RANDOM_ID§-border-color-hover: #999999;
+      --§RANDOM_ID§-tooltip-background: #ffffff;
+      --§RANDOM_ID§-tooltip-text: #111111;
+      --§RANDOM_ID§-details-separator: #333333;
+      --§RANDOM_ID§-progress-border: #000000;
+      --§RANDOM_ID§-progress-fill: #000000;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+    }
+    #§RANDOM_ID§-main-div.§RANDOM_ID§-dark {
+      --§RANDOM_ID§-background-color: #1f1f25;
+      --§RANDOM_ID§-text-color: #f0f0f5;
+      --§RANDOM_ID§-text-color-subtle: #b5b8c5;
+      --§RANDOM_ID§-accent-color: #7ddba3;
+      --§RANDOM_ID§-surface-color: #2d303c;
+      --§RANDOM_ID§-surface-color-muted: #343746;
+      --§RANDOM_ID§-surface-color-strong: #3d4050;
+      --§RANDOM_ID§-surface-color-overlay: #282a36;
+      --§RANDOM_ID§-border-color: #43465a;
+      --§RANDOM_ID§-border-color-strong: #50546a;
+      --§RANDOM_ID§-border-color-hover: #5e637c;
+      --§RANDOM_ID§-tooltip-background: #2f3241;
+      --§RANDOM_ID§-tooltip-text: #f0f2ff;
+      --§RANDOM_ID§-details-separator: #5e637c;
+      --§RANDOM_ID§-progress-border: #f0f2ff;
+      --§RANDOM_ID§-progress-fill: #7ddba3;
+      --§RANDOM_ID§-select-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMi42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+');
     }
     #§RANDOM_ID§-left-div {
       float: left;
@@ -34,23 +71,25 @@
       overflow: hidden;
       resize: vertical;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       border-radius: 4px;
       box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
       display: none;
       line-height: normal;
       box-sizing: content-box;
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
     }
     #§RANDOM_ID§-details-head {
       user-select: none;
@@ -58,7 +97,7 @@
       padding-top: 4px !important;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: gray;
+      color: var(--§RANDOM_ID§-text-color-subtle);
       line-height: normal;
       box-sizing: content-box;
     }
@@ -75,7 +114,7 @@
     .§RANDOM_ID§-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       cursor: pointer;
       padding-left: 5px;
       padding-right: 0px;
@@ -83,10 +122,16 @@
       padding-bottom: 5px;
       margin-bottom: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
+    }
+    .§RANDOM_ID§-menu-item-head.§RANDOM_ID§-active {
+      background-color: var(--§RANDOM_ID§-surface-color);
+      border-color: var(--§RANDOM_ID§-border-color-hover);
+      box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     }
     .§RANDOM_ID§-menu-item-body {
       margin-left: 5px;
@@ -98,7 +143,7 @@
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
-      color: #006429;
+      color: var(--§RANDOM_ID§-accent-color);
       cursor: default;
       margin-bottom: 2px;
       line-height: normal;
@@ -118,6 +163,7 @@
       align-items: center;
       margin-top: 1px;
       margin-bottom: 1px;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-label {
       all: initial;
@@ -125,6 +171,7 @@
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
       cursor: pointer;
+      color: var(--§RANDOM_ID§-text-color);
     }
     .§RANDOM_ID§-slider {
       width: 100%;
@@ -137,14 +184,14 @@
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: left;
       margin-top: 2px;
     }
     .§RANDOM_ID§-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
+      color: var(--§RANDOM_ID§-text-color);
       float: right;
     }
     .§RANDOM_ID§-checkbox {
@@ -159,8 +206,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f5f5f5;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color);
       width: 100%;
       padding-top: 4px !important;
       padding-bottom: 4px !important;
@@ -170,13 +217,13 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
 
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyOTIuNCIgaGVpZ2h0PSIyOTIuNCI+PHBhdGggZmlsbD0iIzAwMDAwMCIgZD0iTSAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2IDI5Mi4zOTk5OSw2NC41NzI2NTQgMTQ2LjE5OTk3LDIzMy42Mjg0NyAtNS4yMDY0NjJlLTYsNjQuNTcyNjU2Ii8+PC9zdmc+Cg==');
+      background-image: var(--§RANDOM_ID§-select-arrow);
       background-repeat: no-repeat;
       background-position: right 4px top 50%;
       background-size: 6px;
@@ -185,7 +232,7 @@
       /* Dirty hack to remove dotted border on focus */
       .§RANDOM_ID§-select {
         color: transparent !important;
-        text-shadow: 0 0 0 black !important;
+        text-shadow: 0 0 0 var(--§RANDOM_ID§-text-color) !important;
       }
     }
     .§RANDOM_ID§-select:after {
@@ -196,8 +243,8 @@
       outline: none;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
-      color: black;
-      background-color: #f2f2f2;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-muted);
       padding-top: 4px !important;
       padding-bottom: 4px !important;
       padding-left: 10px;
@@ -205,15 +252,15 @@
       margin-top: 2px;
       margin-bottom: 2px;
       border-radius: 4px;
-      border: 1.2px solid #bbb;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-strong);
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
     .§RANDOM_ID§-button:hover {
-      border: 1.2px solid #999;
-      background-color: #f2f2f2;
+      border: 1.2px solid var(--§RANDOM_ID§-border-color-hover);
+      background-color: var(--§RANDOM_ID§-surface-color);
     }
     .§RANDOM_ID§-button:active {
-      background-color: #ddd;
+      background-color: var(--§RANDOM_ID§-surface-color-strong);
     }
     .§RANDOM_ID§-button::-moz-focus-inner {
       border: 0;
@@ -241,10 +288,10 @@
       padding: 5px;
       white-space: pre-wrap;
       word-break: break-word;
-      color: black;
-      background-color: white;
+      color: var(--§RANDOM_ID§-tooltip-text);
+      background-color: var(--§RANDOM_ID§-tooltip-background);
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--§RANDOM_ID§-border-color);
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
       box-sizing: content-box;
@@ -255,7 +302,8 @@
       z-index: 42000;
       cursor: pointer;
       position: absolute;
-      background-color: white;
+      color: var(--§RANDOM_ID§-text-color);
+      background-color: var(--§RANDOM_ID§-surface-color-overlay);
       border-radius: 4px;
       box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
       line-height: normal;
@@ -270,8 +318,8 @@
       padding-bottom: 12px;
       border-top: 0px;
       border-right: 0px;
-      border-bottom: 1px solid #ccc;
-      border-left: 1px solid #ccc;
+      border-bottom: 1px solid var(--§RANDOM_ID§-border-color);
+      border-left: 1px solid var(--§RANDOM_ID§-border-color);
     }
     #§RANDOM_ID§-details-toggle-button {
       bottom: 0;
@@ -280,8 +328,8 @@
       padding-right: 19px;
       padding-top: 0.5px;
       padding-bottom: 2px;
-      border-top: 1px solid #ccc;
-      border-right: 1px solid #ccc;
+      border-top: 1px solid var(--§RANDOM_ID§-border-color);
+      border-right: 1px solid var(--§RANDOM_ID§-border-color);
       border-bottom: 0px;
       border-left: 0px;
     }
@@ -296,11 +344,24 @@
       box-shadow: none;
     }
 
+    .§RANDOM_ID§-progress-bar-outer {
+      border: 1px solid var(--§RANDOM_ID§-progress-border);
+      border-radius: 4px;
+      margin-top: 1ex;
+      padding: 1px;
+    }
+    .§RANDOM_ID§-progress-bar-inner {
+      background-color: var(--§RANDOM_ID§-progress-fill);
+      width: 0%;
+      height: 8px;
+      border-radius: 3px;
+    }
+
     /* Details */
     #§RANDOM_ID§-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
-      border-top: 0.5px dashed black;
+      border-top: 0.5px dashed var(--§RANDOM_ID§-details-separator);
       line-height: normal;
       box-sizing: content-box;
       white-space: pre-wrap;
@@ -309,32 +370,6 @@
     #§RANDOM_ID§-details-user-provided ul {
       list-style-position: inside;
       padding-left: 6px;
-    }
-
-    /* Unavailable in vis.js and therefore hidden */
-    #§RANDOM_ID§-svg,
-    #§RANDOM_ID§-node-label-rotation,
-    #§RANDOM_ID§-edge-label-rotation {
-      display: none;
-    }
-    /* Specific to vis.js */
-    div.vis-tooltip {
-      position: absolute;
-      visibility: hidden;
-      pointer-events: none;
-      z-index: 5;
-      max-width: 40%;
-      white-space: pre-wrap;
-      word-break: break-word;
-      font-size: 10px;
-      padding: 5px;
-      color: black;
-      background-color: white;
-      -moz-border-radius: 3px;
-      -webkit-border-radius: 3px;
-      border-radius: 3px;
-      border: 0.5px solid black;
-      box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
     }
   </style>
 
@@ -942,6 +977,7 @@
             state.showDetailsToggleButton = §SHOW_DETAILS_TOGGLE_BUTTON§,
             state.showMenu = §SHOW_MENU§,
             state.showMenuToggleButton = §SHOW_MENU_TOGGLE_BUTTON§,
+            state.useDarkMode = §USE_DARK_MODE§,
             // Nodes
             state.showNodes = §SHOW_NODE§;
             state.nodeSizeFactor = §NODE_SIZE_FACTOR§;
@@ -1177,21 +1213,38 @@
           },
 
           parseGeneral(givenData, parsedData){
+            const generalDefaults = state.useDarkMode ? {
+              background_color: "#1f1f25",
+              arrow_color: "#7ddba3",
+              node_color: "#7ddba3",
+              node_border_color: "#f0f0f5",
+              node_label_color: "#f0f0f5",
+              edge_color: "#b5b8c5",
+              edge_label_color: "#f0f0f5",
+            } : {
+              background_color: "white",
+              arrow_color: "black",
+              node_color: "black",
+              node_border_color: "black",
+              node_label_color: "black",
+              edge_color: "black",
+              edge_label_color: "black",
+            };
             parsedData.general = {
               // General
               directed: state.manager.rawDataParser.getBool(givenData, "directed", true),
               label: state.manager.rawDataParser.getString(givenData, "label", ""),
-              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", "white"),
-              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", "black"),
+              background_color: state.manager.rawMetadataParser.getColor(givenData, "background_color", generalDefaults.background_color),
+              arrow_color: state.manager.rawMetadataParser.getColor(givenData, "arrow_color", generalDefaults.arrow_color),
               arrow_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "arrow_size", 10.0),
               // Nodes
-              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", "black"),
+              node_color: state.manager.rawMetadataParser.getColor(givenData, "node_color", generalDefaults.node_color),
               node_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_opacity", 1.0),
               node_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_size", 10.0),
               node_shape: state.manager.rawMetadataParser.getString(givenData, "node_shape", "circle"),
-              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", "black"),
+              node_border_color: state.manager.rawMetadataParser.getColor(givenData, "node_border_color", generalDefaults.node_border_color),
               node_border_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_border_size", 0.0),
-              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", "black"),
+              node_label_color: state.manager.rawMetadataParser.getColor(givenData, "node_label_color", generalDefaults.node_label_color),
               node_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "node_label_size", 12.0),
               node_hover: state.manager.rawMetadataParser.getString(givenData, "node_hover", ""),
               node_click: state.manager.rawMetadataParser.getString(givenData, "node_click", ""),
@@ -1202,10 +1255,10 @@
               contains_node_click: false,
               contains_node_image: false,
               // Edges
-              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", "black"),
+              edge_color: state.manager.rawMetadataParser.getColor(givenData, "edge_color", generalDefaults.edge_color),
               edge_opacity: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_opacity", 1.0),
               edge_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_size", 1.0),
-              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", "black"),
+              edge_label_color: state.manager.rawMetadataParser.getColor(givenData, "edge_label_color", generalDefaults.edge_label_color),
               edge_label_size: state.manager.rawMetadataParser.getFinitePositiveNumber(givenData, "edge_label_size", 8.0),
               edge_hover: state.manager.rawMetadataParser.getString(givenData, "edge_hover", ""),
               edge_click: state.manager.rawMetadataParser.getString(givenData, "edge_click", ""),
@@ -2052,17 +2105,11 @@
               }
               if(toActive){
                 keyElement.innerHTML = ui.symbols.menuItemActive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "#f5f5f5";
-                keyElement.style.color = "black";
-                keyElement.style.borderColor = "#999";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.35)";
+                keyElement.classList.add("§RANDOM_ID§-active");
                 valElement.style.display = "block";
               } else {
                 keyElement.innerHTML = ui.symbols.menuItemInactive + currentText.slice(sliceStart);
-                keyElement.style.backgroundColor = "white";
-                keyElement.style.color = "#222";
-                keyElement.style.borderColor = "#ccc";
-                keyElement.style.boxShadow = "0px 0px 3px rgba(0, 0, 0, 0.2)";
+                keyElement.classList.remove("§RANDOM_ID§-active");
                 valElement.style.display = "none";
               }
             },
@@ -2235,15 +2282,10 @@
               this.textContainer.style.textAlign = "center";
               // Bar container
               this.outerBarContainer = document.createElement("div");
-              this.outerBarContainer.style.border = "1px solid black";
-              this.outerBarContainer.style.borderRadius = "4px";
-              this.outerBarContainer.style.marginTop = "1ex";
-              this.outerBarContainer.style.padding = "1px";
+              this.outerBarContainer.className = "§RANDOM_ID§-progress-bar-outer";
               this.innerBarContainer = document.createElement("div");
-              this.innerBarContainer.style.backgroundColor = "black";
+              this.innerBarContainer.className = "§RANDOM_ID§-progress-bar-inner";
               this.innerBarContainer.style.width = "0%";
-              this.innerBarContainer.style.height = "8px";
-              this.innerBarContainer.style.borderRadius = "3px";
               // Add them to DOM
               this.outerBarContainer.appendChild(this.innerBarContainer);
               this.mainContainer.appendChild(this.textContainer);
@@ -2953,6 +2995,7 @@
         },
 
         init(){
+          ui.elements.mainContainer.classList.toggle("§RANDOM_ID§-dark", state.useDarkMode);
           // Containers
           ui.composites.responsiveContainer.init();
           // Graph selection (only visible if multiple graphs in data)

--- a/gravis/_internal/plotting/templates/vis.html
+++ b/gravis/_internal/plotting/templates/vis.html
@@ -413,8 +413,8 @@
 
   #legend {
     position: absolute;
-    top: 10px;
-    left: 10px;
+    top: 20px;
+    left: 20px;
     z-index: 1000;
   }
 </style>

--- a/gravis/_internal/plotting/three.py
+++ b/gravis/_internal/plotting/three.py
@@ -34,7 +34,7 @@ def three(data,
           use_y_positioning_force=False, y_positioning_force_strength=0.2,
           use_z_positioning_force=False, z_positioning_force_strength=0.2,
           use_centering_force=True,
-          use_dark_mode=False):
+          use_dark_mode=False, legend_code=""):
     """Create an interactive graph visualization with HTML/CSS/JS based on 3d-force-graph.js.
 
     The library 3d-force-graph.js uses three.js to create a 3d visualization in WebGL,
@@ -241,6 +241,8 @@ def three(data,
         if all nodes are fixed and then a single one is released by dragging it.
     use_dark_mode : bool
         If True, the interface is rendered with a dark theme instead of the default light theme.
+    legend_code : str
+        Custom HTML code for the legend section of the visualization.
 
     Returns
     -------
@@ -311,6 +313,8 @@ def three(data,
     _ca(z_positioning_force_strength, 'z_positioning_force_strength', (int, float))
     _ca(use_centering_force, 'use_centering_force', bool)
     _ca(use_dark_mode, 'use_dark_mode', bool)
+    _ca(legend_code, 'legend_code', str)
+
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -327,6 +331,7 @@ def three(data,
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
         'USE_DARK_MODE': _ts.to_json(use_dark_mode),
+        'LEGEND-CODE': legend_code,
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/gravis/_internal/plotting/three.py
+++ b/gravis/_internal/plotting/three.py
@@ -33,7 +33,8 @@ def three(data,
           use_x_positioning_force=False, x_positioning_force_strength=0.2,
           use_y_positioning_force=False, y_positioning_force_strength=0.2,
           use_z_positioning_force=False, z_positioning_force_strength=0.2,
-          use_centering_force=True):
+          use_centering_force=True,
+          use_dark_mode=False):
     """Create an interactive graph visualization with HTML/CSS/JS based on 3d-force-graph.js.
 
     The library 3d-force-graph.js uses three.js to create a 3d visualization in WebGL,
@@ -238,6 +239,8 @@ def three(data,
         This force attracts each node towards the center of the coordinate system at (0, 0, 0)
         to keep the graph in the display area. It may lead to unexpected repulsion effects
         if all nodes are fixed and then a single one is released by dragging it.
+    use_dark_mode : bool
+        If True, the interface is rendered with a dark theme instead of the default light theme.
 
     Returns
     -------
@@ -255,6 +258,7 @@ def three(data,
     _ca(show_details_toggle_button, 'show_details_toggle_button', bool)
     _ca(show_menu, 'show_menu', bool)
     _ca(show_menu_toggle_button, 'show_menu_toggle_button', bool)
+    _ca(use_dark_mode, 'use_dark_mode', bool)
     _ca(show_node, 'show_node', bool)
     _ca(node_size_factor, 'node_size_factor', (int, float))
     _ca(node_size_data_source, 'node_size_data_source', str)
@@ -306,6 +310,7 @@ def three(data,
     _ca(use_z_positioning_force, 'use_z_positioning_force', bool)
     _ca(z_positioning_force_strength, 'z_positioning_force_strength', (int, float))
     _ca(use_centering_force, 'use_centering_force', bool)
+    _ca(use_dark_mode, 'use_dark_mode', bool)
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -321,6 +326,7 @@ def three(data,
         'SHOW_DETAILS_TOGGLE_BUTTON': _ts.to_json(show_details_toggle_button),
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
+        'USE_DARK_MODE': _ts.to_json(use_dark_mode),
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/gravis/_internal/plotting/vis.py
+++ b/gravis/_internal/plotting/vis.py
@@ -27,7 +27,7 @@ def vis(data,
         layout_algorithm_active=True, layout_algorithm='barnesHut',
         gravitational_constant=-2000.0, central_gravity=0.1, spring_length=70.0,
         spring_constant=0.1, avoid_overlap=0.0,
-        use_dark_mode=False):
+        use_dark_mode=False, legend_code=""):
     """Create an interactive graph visualization with HTML/CSS/JS based on vis.js.
 
     Note
@@ -192,6 +192,8 @@ def vis(data,
         "hierarchicalRepulsion".
     use_dark_mode : bool
         If True, the interface is rendered with a dark theme instead of the default light theme.
+    legend_code : str
+        Custom HTML code for the legend section of the visualization.
 
     Returns
     -------
@@ -252,6 +254,7 @@ def vis(data,
     _ca(spring_constant, 'spring_constant', (int, float))
     _ca(avoid_overlap, 'avoid_overlap', (int, float))
     _ca(use_dark_mode, 'use_dark_mode', bool)
+    _ca(legend_code, 'legend_code', str)
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -267,6 +270,7 @@ def vis(data,
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
         'USE_DARK_MODE': _ts.to_json(use_dark_mode),
+        'LEGEND-CODE': legend_code,
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/gravis/_internal/plotting/vis.py
+++ b/gravis/_internal/plotting/vis.py
@@ -26,7 +26,8 @@ def vis(data,
         zoom_factor=0.75, large_graph_threshold=500,
         layout_algorithm_active=True, layout_algorithm='barnesHut',
         gravitational_constant=-2000.0, central_gravity=0.1, spring_length=70.0,
-        spring_constant=0.1, avoid_overlap=0.0):
+        spring_constant=0.1, avoid_overlap=0.0,
+        use_dark_mode=False):
     """Create an interactive graph visualization with HTML/CSS/JS based on vis.js.
 
     Note
@@ -189,6 +190,8 @@ def vis(data,
         if they come too close together.
         Only active if layout_algorithm is "barnesHut", "forceAtlas2Based" or
         "hierarchicalRepulsion".
+    use_dark_mode : bool
+        If True, the interface is rendered with a dark theme instead of the default light theme.
 
     Returns
     -------
@@ -248,6 +251,7 @@ def vis(data,
     _ca(spring_length, 'spring_length', (int, float))
     _ca(spring_constant, 'spring_constant', (int, float))
     _ca(avoid_overlap, 'avoid_overlap', (int, float))
+    _ca(use_dark_mode, 'use_dark_mode', bool)
     data = _internal.normalize_graph_data(data)
 
     # Transformation
@@ -262,6 +266,7 @@ def vis(data,
         'SHOW_DETAILS_TOGGLE_BUTTON': _ts.to_json(show_details_toggle_button),
         'SHOW_MENU': _ts.to_json(show_menu),
         'SHOW_MENU_TOGGLE_BUTTON': _ts.to_json(show_menu_toggle_button),
+        'USE_DARK_MODE': _ts.to_json(use_dark_mode),
 
         'SHOW_NODE': _ts.to_json(show_node),
         'NODE_SIZE_FACTOR': _ts.to_json(node_size_factor),

--- a/tests/test_plotting_options.py
+++ b/tests/test_plotting_options.py
@@ -175,6 +175,7 @@ def test_plotting_with_each_keyword_argument(my_outdir):
         details_height=40,
         show_details=True,
         show_menu=False,
+        use_dark_mode=True,
         show_node=False,
         node_size_factor=2.0,
         node_size_data_source='label_size',


### PR DESCRIPTION
This PR adds support for dark mode in visualizations by introducing a new keyword argument `use_dark_mode: bool`. When set to True, the background, text and edge colors adapt to dark-themed environments.